### PR TITLE
ci: disable automatic Benchmark CI runs

### DIFF
--- a/.github/workflows/benchmark_ci.yml
+++ b/.github/workflows/benchmark_ci.yml
@@ -1,7 +1,5 @@
 name: Benchmark CI
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- stop Benchmark CI from auto-running on pushes to `main`
- keep `workflow_dispatch` so it can still be run manually if needed

## Why
The benchmark workflow is not currently useful enough to justify the runner cost and noise.