### PR TITLE
fix(core): use package imports and add import check

### DIFF
--- a/.github/workflows/core_import_check.yml
+++ b/.github/workflows/core_import_check.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  perception-node:
     runs-on: X64
     steps:
       - name: Checkout code
@@ -20,18 +20,102 @@ jobs:
         run: git lfs checkout
 
       - name: Pull CI image
-        run: docker pull uniflexai/tinynav:342ca22d
+        run: docker pull uniflexai/tinynav:latest
 
-      - name: Check core module imports
+      - name: Check perception_node imports
         run: |
           docker run --rm -i \
             --entrypoint "" \
             -v "$GITHUB_WORKSPACE:/tinynav" \
             -w /tinynav \
-            uniflexai/tinynav:342ca22d \
+            uniflexai/tinynav:latest \
             bash -lc '
               set -eo pipefail
               source /opt/ros/humble/setup.bash
-              python -m py_compile tinynav/core/perception_node.py tinynav/core/map_node.py tinynav/core/build_map_node.py tinynav/core/planning_node.py
+              python -m py_compile tinynav/core/perception_node.py
               python -c "import tinynav.core.perception_node"
+            '
+
+  map-node:
+    runs-on: X64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Perform Git LFS checkout
+        run: git lfs checkout
+
+      - name: Pull CI image
+        run: docker pull uniflexai/tinynav:latest
+
+      - name: Check map_node imports
+        run: |
+          docker run --rm -i \
+            --entrypoint "" \
+            -v "$GITHUB_WORKSPACE:/tinynav" \
+            -w /tinynav \
+            uniflexai/tinynav:latest \
+            bash -lc '
+              set -eo pipefail
+              source /opt/ros/humble/setup.bash
+              python -m py_compile tinynav/core/map_node.py
+              python -c "import tinynav.core.map_node"
+            '
+
+  build-map-node:
+    runs-on: X64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Perform Git LFS checkout
+        run: git lfs checkout
+
+      - name: Pull CI image
+        run: docker pull uniflexai/tinynav:latest
+
+      - name: Check build_map_node imports
+        run: |
+          docker run --rm -i \
+            --entrypoint "" \
+            -v "$GITHUB_WORKSPACE:/tinynav" \
+            -w /tinynav \
+            uniflexai/tinynav:latest \
+            bash -lc '
+              set -eo pipefail
+              source /opt/ros/humble/setup.bash
+              python -m py_compile tinynav/core/build_map_node.py
+              python -c "import tinynav.core.build_map_node"
+            '
+
+  planning-node:
+    runs-on: X64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Perform Git LFS checkout
+        run: git lfs checkout
+
+      - name: Pull CI image
+        run: docker pull uniflexai/tinynav:latest
+
+      - name: Check planning_node imports
+        run: |
+          docker run --rm -i \
+            --entrypoint "" \
+            -v "$GITHUB_WORKSPACE:/tinynav" \
+            -w /tinynav \
+            uniflexai/tinynav:latest \
+            bash -lc '
+              set -eo pipefail
+              source /opt/ros/humble/setup.bash
+              python -m py_compile tinynav/core/planning_node.py
+              python -c "import tinynav.core.planning_node"
             '

--- a/.github/workflows/core_import_check.yml
+++ b/.github/workflows/core_import_check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: X64
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,7 +34,6 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/perception_node.py
               python -c "import tinynav.core.perception_node"
-              chmod -R 777 /tinynav
             '
 
       - name: Check map_node imports
@@ -49,7 +48,6 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/map_node.py
               python -c "import tinynav.core.map_node"
-              chmod -R 777 /tinynav
             '
 
       - name: Check build_map_node imports
@@ -64,7 +62,6 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/build_map_node.py
               python -c "import tinynav.core.build_map_node"
-              chmod -R 777 /tinynav
             '
 
       - name: Check planning_node imports
@@ -79,5 +76,4 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/planning_node.py
               python -c "import tinynav.core.planning_node"
-              chmod -R 777 /tinynav
             '

--- a/.github/workflows/core_import_check.yml
+++ b/.github/workflows/core_import_check.yml
@@ -1,0 +1,37 @@
+name: Core Import Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: X64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Perform Git LFS checkout
+        run: git lfs checkout
+
+      - name: Pull CI image
+        run: docker pull uniflexai/tinynav:342ca22d
+
+      - name: Check core module imports
+        run: |
+          docker run --rm -i \
+            --entrypoint "" \
+            -v "$GITHUB_WORKSPACE:/tinynav" \
+            -w /tinynav \
+            uniflexai/tinynav:342ca22d \
+            bash -lc '
+              set -eo pipefail
+              source /opt/ros/humble/setup.bash
+              python -m py_compile tinynav/core/perception_node.py tinynav/core/map_node.py tinynav/core/build_map_node.py tinynav/core/planning_node.py
+              python -c "import tinynav.core.perception_node"
+            '

--- a/.github/workflows/core_import_check.yml
+++ b/.github/workflows/core_import_check.yml
@@ -32,6 +32,7 @@ jobs:
             bash -lc '
               set -eo pipefail
               source /opt/ros/humble/setup.bash
+              uv sync --python /opt/venv/bin/python --extra unitree
               python -m py_compile tinynav/core/perception_node.py
               python -c "import tinynav.core.perception_node"
             '
@@ -46,6 +47,7 @@ jobs:
             bash -lc '
               set -eo pipefail
               source /opt/ros/humble/setup.bash
+              uv sync --python /opt/venv/bin/python --extra unitree
               python -m py_compile tinynav/core/map_node.py
               python -c "import tinynav.core.map_node"
             '
@@ -60,6 +62,7 @@ jobs:
             bash -lc '
               set -eo pipefail
               source /opt/ros/humble/setup.bash
+              uv sync --python /opt/venv/bin/python --extra unitree
               python -m py_compile tinynav/core/build_map_node.py
               python -c "import tinynav.core.build_map_node"
             '
@@ -74,6 +77,7 @@ jobs:
             bash -lc '
               set -eo pipefail
               source /opt/ros/humble/setup.bash
+              uv sync --python /opt/venv/bin/python --extra unitree
               python -m py_compile tinynav/core/planning_node.py
               python -c "import tinynav.core.planning_node"
             '

--- a/.github/workflows/core_import_check.yml
+++ b/.github/workflows/core_import_check.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  perception-node:
+  build:
     runs-on: X64
     steps:
       - name: Checkout code
@@ -36,20 +36,6 @@ jobs:
               python -c "import tinynav.core.perception_node"
             '
 
-  map-node:
-    runs-on: X64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Perform Git LFS checkout
-        run: git lfs checkout
-
-      - name: Pull CI image
-        run: docker pull uniflexai/tinynav:latest
-
       - name: Check map_node imports
         run: |
           docker run --rm -i \
@@ -64,20 +50,6 @@ jobs:
               python -c "import tinynav.core.map_node"
             '
 
-  build-map-node:
-    runs-on: X64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Perform Git LFS checkout
-        run: git lfs checkout
-
-      - name: Pull CI image
-        run: docker pull uniflexai/tinynav:latest
-
       - name: Check build_map_node imports
         run: |
           docker run --rm -i \
@@ -91,20 +63,6 @@ jobs:
               python -m py_compile tinynav/core/build_map_node.py
               python -c "import tinynav.core.build_map_node"
             '
-
-  planning-node:
-    runs-on: X64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Perform Git LFS checkout
-        run: git lfs checkout
-
-      - name: Pull CI image
-        run: docker pull uniflexai/tinynav:latest
 
       - name: Check planning_node imports
         run: |

--- a/.github/workflows/core_import_check.yml
+++ b/.github/workflows/core_import_check.yml
@@ -34,6 +34,7 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/perception_node.py
               python -c "import tinynav.core.perception_node"
+              chmod -R 777 /tinynav
             '
 
       - name: Check map_node imports
@@ -48,6 +49,7 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/map_node.py
               python -c "import tinynav.core.map_node"
+              chmod -R 777 /tinynav
             '
 
       - name: Check build_map_node imports
@@ -62,6 +64,7 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/build_map_node.py
               python -c "import tinynav.core.build_map_node"
+              chmod -R 777 /tinynav
             '
 
       - name: Check planning_node imports
@@ -76,4 +79,5 @@ jobs:
               source /opt/ros/humble/setup.bash
               python -m py_compile tinynav/core/planning_node.py
               python -c "import tinynav.core.planning_node"
+              chmod -R 777 /tinynav
             '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pybind11",
     "huggingface_hub",
     "einops",
+    "async-lru",
     "tyro",
     "reportlab>=4.4.3",
     "tabulate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "matplotlib",
     "opencv-python",
     "codetiming",
-    "numba",
+    "numba==0.61.2",
     "fufpy",
     "pygame",
     "cuda_python==12.6.0; platform_machine == 'aarch64'",

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -10,7 +10,7 @@ from sensor_msgs.msg import PointCloud2
 from std_msgs.msg import Header
 from visualization_msgs.msg import Marker, MarkerArray
 from std_msgs.msg import ColorRGBA
-from math_utils import matrix_to_quat, msg2np, estimate_pose, tf2np, depth_to_cloud
+from tinynav.core.math_utils import matrix_to_quat, msg2np, estimate_pose, tf2np, depth_to_cloud
 from sensor_msgs.msg import Image, CameraInfo, CompressedImage
 from message_filters import Subscriber, ApproximateTimeSynchronizer
 from cv_bridge import CvBridge
@@ -21,8 +21,8 @@ import argparse
 import sys
 
 from tinynav.tinynav_cpp_bind import pose_graph_solve
-from models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
-from planning_node import run_raycasting_loopy
+from tinynav.core.models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
+from tinynav.core.planning_node import run_raycasting_loopy
 import logging
 import asyncio
 import shelve

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -9,7 +9,7 @@ import sys
 import json
 
 import heapq
-from math_utils import matrix_to_quat, msg2np, np2msg, estimate_pose, np2tf, se3_inv
+from tinynav.core.math_utils import matrix_to_quat, msg2np, np2msg, estimate_pose, np2tf, se3_inv
 from sensor_msgs.msg import Image, CameraInfo
 from message_filters import TimeSynchronizer, Subscriber
 from cv_bridge import CvBridge
@@ -18,14 +18,14 @@ from codetiming import Timer
 import argparse
 
 from tinynav.tinynav_cpp_bind import pose_graph_solve
-from models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
+from tinynav.core.models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
 import logging
 import asyncio
 from tf2_ros import TransformBroadcaster
-from build_map_node import TinyNavDB
-from build_map_node import find_loop, solve_pose_graph
+from tinynav.core.build_map_node import TinyNavDB
+from tinynav.core.build_map_node import find_loop, solve_pose_graph
 import einops
-from build_map_node import OdomPoseRecorder
+from tinynav.core.build_map_node import OdomPoseRecorder
 logger = logging.getLogger(__name__)
 
 

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -8,14 +8,14 @@ import numpy as np
 import rclpy
 from codetiming import Timer
 from cv_bridge import CvBridge
-from models_trt import LightGlueTRT, SuperPointTRT, StereoEngineTRT
+from tinynav.core.models_trt import LightGlueTRT, SuperPointTRT, StereoEngineTRT
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from sensor_msgs.msg import Image, Imu, CameraInfo
 from std_msgs.msg import Float32MultiArray
 from rclpy.qos import QoSProfile, ReliabilityPolicy
-from math_utils import rot_from_two_vector, np2msg, np2tf, estimate_pose, se3_inv
-from math_utils import uf_init, uf_union, uf_all_sets_list
+from tinynav.core.math_utils import rot_from_two_vector, np2msg, np2tf, estimate_pose, se3_inv
+from tinynav.core.math_utils import uf_init, uf_union, uf_all_sets_list
 from tf2_ros import TransformBroadcaster
 import asyncio
 import gtsam

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -15,7 +15,7 @@ import sensor_msgs_py.point_cloud2 as pc2
 from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
-from math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
+from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
 
 
 @dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -3895,6 +3895,7 @@ name = "tinynav"
 version = "0.1.3"
 source = { editable = "." }
 dependencies = [
+    { name = "async-lru" },
     { name = "codetiming" },
     { name = "cuda-python", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.6.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
@@ -3937,6 +3938,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "async-lru" },
     { name = "codetiming" },
     { name = "cuda-python", marker = "platform_machine == 'aarch64'", specifier = "==12.6.0" },
     { name = "cuda-python", marker = "platform_machine == 'x86_64'", specifier = "==12.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1766,14 +1766,15 @@ wheels = [
 
 [[package]]
 name = "llvmlite"
-version = "0.47.0"
+version = "0.44.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/6a/95a3d3610d5c75293d5dbbb2a76480d5d4eeba641557b69fe90af6c5b84e/llvmlite-0.44.0.tar.gz", hash = "sha256:07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4", size = 171880, upload-time = "2025-01-20T11:14:41.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/f5/a1bde3aa8c43524b0acaf3f72fb3d80a32dd29dbb42d7dc434f84584cdcc/llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17", size = 37232772, upload-time = "2026-03-31T18:28:12.198Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/fb/76d88fc05ee1f9c1a6efe39eb493c4a727e5d1690412469017cd23bcb776/llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7", size = 56275179, upload-time = "2026-03-31T18:28:15.725Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/08/29da7f36217abd56a0c389ef9a18bea47960826e691ced1a36c92c6ce93c/llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063", size = 55128632, upload-time = "2026-03-31T18:28:19.946Z" },
-    { url = "https://files.pythonhosted.org/packages/df/f8/5e12e9ed447d65f04acf6fcf2d79cded2355640b5131a46cee4c99a5949d/llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea", size = 38138402, upload-time = "2026-03-31T18:28:23.327Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/d4863ddfd8ab5f6e70f4504cf8cc37f4e986ec6910f4ef8502bb7d3c1c71/llvmlite-0.44.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:9fbadbfba8422123bab5535b293da1cf72f9f478a65645ecd73e781f962ca614", size = 28132306, upload-time = "2025-01-20T11:12:18.634Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d9/6e8943e1515d2f1003e8278819ec03e4e653e2eeb71e4d00de6cfe59424e/llvmlite-0.44.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cccf8eb28f24840f2689fb1a45f9c0f7e582dd24e088dcf96e424834af11f791", size = 26201096, upload-time = "2025-01-20T11:12:24.544Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/46/8ffbc114def88cc698906bf5acab54ca9fdf9214fe04aed0e71731fb3688/llvmlite-0.44.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7202b678cdf904823c764ee0fe2dfe38a76981f4c1e51715b4cb5abb6cf1d9e8", size = 42361859, upload-time = "2025-01-20T11:12:31.839Z" },
+    { url = "https://files.pythonhosted.org/packages/30/1c/9366b29ab050a726af13ebaae8d0dff00c3c58562261c79c635ad4f5eb71/llvmlite-0.44.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40526fb5e313d7b96bda4cbb2c85cd5374e04d80732dd36a282d72a560bb6408", size = 41184199, upload-time = "2025-01-20T11:12:40.049Z" },
+    { url = "https://files.pythonhosted.org/packages/69/07/35e7c594b021ecb1938540f5bce543ddd8713cff97f71d81f021221edc1b/llvmlite-0.44.0-cp310-cp310-win_amd64.whl", hash = "sha256:41e3839150db4330e1b2716c0be3b5c4672525b4c9005e17c7597f835f351ce2", size = 30332381, upload-time = "2025-01-20T11:12:47.054Z" },
 ]
 
 [[package]]
@@ -2285,18 +2286,19 @@ wheels = [
 
 [[package]]
 name = "numba"
-version = "0.65.0"
+version = "0.61.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131, upload-time = "2026-04-01T03:52:01.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615, upload-time = "2025-04-09T02:58:07.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/9b/e8453d93d5cb3f53cc956f135024be09d52f4f99643acaf8fdca090a8f3c/numba-0.65.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:dff9fd5fbc9a35c517359c5823ea705d9b65f01fb46e42e35a2eabe5a52c2e96", size = 2680537, upload-time = "2026-04-01T03:51:17.325Z" },
-    { url = "https://files.pythonhosted.org/packages/07/95/d6a2f0625e1092624228301eea11cdaff21ddcaf917ef3d631846a38b2f4/numba-0.65.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4c894c94afa5ffd627c7e3b693df10cb0d905bd5eb06de3dfc31775140cf4f89", size = 3739444, upload-time = "2026-04-01T03:51:19.629Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ed/fe518c97af035e4ec670c2edc3f0ff7a518cbed2f0b5053124d7c979bd8a/numba-0.65.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7325b1aab88f0339057288ee32f39dc660e14f93872a6fda14fa6eb9f95b047", size = 3446390, upload-time = "2026-04-01T03:51:21.55Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/06/5010939854249c290c6217e3fb7404914f4ed953f9923e340c3e166bcaf0/numba-0.65.0-cp310-cp310-win_amd64.whl", hash = "sha256:71e72e9ca2f619df4768f9c3962bfec60191a5a26fe2b6a8c6a07532b6146169", size = 2747200, upload-time = "2026-04-01T03:51:23.674Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ca/f470be59552ccbf9531d2d383b67ae0b9b524d435fb4a0d229fef135116e/numba-0.61.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:cf9f9fc00d6eca0c23fc840817ce9f439b9f03c8f03d6246c0e7f0cb15b7162a", size = 2775663, upload-time = "2025-04-09T02:57:34.143Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/13/3bdf52609c80d460a3b4acfb9fdb3817e392875c0d6270cf3fd9546f138b/numba-0.61.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ea0247617edcb5dd61f6106a56255baab031acc4257bddaeddb3a1003b4ca3fd", size = 2778344, upload-time = "2025-04-09T02:57:36.609Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7d/bfb2805bcfbd479f04f835241ecf28519f6e3609912e3a985aed45e21370/numba-0.61.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae8c7a522c26215d5f62ebec436e3d341f7f590079245a2f1008dfd498cc1642", size = 3824054, upload-time = "2025-04-09T02:57:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/27/797b2004745c92955470c73c82f0e300cf033c791f45bdecb4b33b12bdea/numba-0.61.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bd1e74609855aa43661edffca37346e4e8462f6903889917e9f41db40907daa2", size = 3518531, upload-time = "2025-04-09T02:57:39.709Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c6/c2fb11e50482cb310afae87a997707f6c7d8a48967b9696271347441f650/numba-0.61.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae45830b129c6137294093b269ef0a22998ccc27bf7cf096ab8dcf7bca8946f9", size = 2831612, upload-time = "2025-04-09T02:57:41.559Z" },
 ]
 
 [[package]]
@@ -3950,7 +3952,7 @@ requires-dist = [
     { name = "matplotlib" },
     { name = "nerfstudio", marker = "extra == '3dgs'", git = "https://github.com/junlinp/nerfstudio.git?rev=d69136d198beea473aaa148cbd5114d01c2f847e" },
     { name = "newrawpy", marker = "extra == '3dgs'", specifier = "<=1.0.0b0" },
-    { name = "numba" },
+    { name = "numba", specifier = "==0.61.2" },
     { name = "numpy", specifier = "==1.26.1" },
     { name = "opencv-python" },
     { name = "plyfile" },


### PR DESCRIPTION
## Summary
- switch core modules from bare local imports to package imports under `tinynav.core`
- add a `Core Import Check` workflow to catch syntax and import regressions early
- validate the main core modules with `py_compile` and `import tinynav.core.perception_node` inside the pinned CI image

## Why
This prevents `perception_node.py` and related core scripts from silently depending on cwd/PYTHONPATH quirks and lets CI catch import breakages directly.