### PR TITLE
chore(mapping): remove debug print

### DIFF
--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -693,7 +693,6 @@ class BuildMapNode(Node):
         np.save(f"{self.map_save_path}/poses.npy", self.pose_graph_used_pose, allow_pickle = True)
         np.save(f"{self.map_save_path}/intrinsics.npy", self.K)
         np.save(f"{self.map_save_path}/baseline.npy", self.baseline)
-        print(f"T_rgb_to_infra1: {self.T_rgb_to_infra1}")
         np.save(f"{self.map_save_path}/T_rgb_to_infra1.npy", self.T_rgb_to_infra1, allow_pickle = True)
         np.save(f"{self.map_save_path}/rgb_camera_intrinsics.npy", self.rgb_camera_K, allow_pickle = True)
         np.save(f"{self.map_save_path}/edges.npy", list(self.edges), allow_pickle = True)

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -342,7 +342,6 @@ class BagPlayer(Node):
 
         self.start_timestamp_ns = None
         self.end_timestamp_ns = None
-        self.current_timestamp_ns = None
 
         topic_infos = self._reader.get_all_topics_and_types()
         if len(topic_infos) == 0:
@@ -353,8 +352,6 @@ class BagPlayer(Node):
             storage_id,
             serialization_format,
         )
-        if self.end_timestamp_ns <= self.start_timestamp_ns:
-            raise ValueError(f"Invalid bag timestamp range: start={self.start_timestamp_ns}, end={self.end_timestamp_ns}")
 
         # topic -> (publisher, msg_type)
         self._topic_publishers = {}
@@ -403,10 +400,7 @@ class BagPlayer(Node):
         self._mapping_percent_pub.publish(msg)
 
     def _publish_percent_from_timestamp(self, timestamp_ns: int) -> None:
-        if self.end_timestamp_ns <= self.start_timestamp_ns:
-            raise ValueError(f"Invalid bag timestamp range: start={self.start_timestamp_ns}, end={self.end_timestamp_ns}")
         percent = 100.0 * (timestamp_ns - self.start_timestamp_ns) / (self.end_timestamp_ns - self.start_timestamp_ns)
-        percent = max(0.0, min(100.0, percent))
         self._publish_percent(percent)
 
     def play_next(self) -> bool:
@@ -418,8 +412,7 @@ class BagPlayer(Node):
             return False
 
         topic, serialized_msg, timestamp_ns = self._reader.read_next()
-        self.current_timestamp_ns = int(timestamp_ns)
-        self._publish_percent_from_timestamp(self.current_timestamp_ns)
+        self._publish_percent_from_timestamp(int(timestamp_ns))
 
         # Find publisher + msg type for this topic
         pub_and_type = self._topic_publishers.get(topic)


### PR DESCRIPTION
## Summary
- remove the debug print for `T_rgb_to_infra1` in `build_map_node.py`

## Why
This print is noisy and not needed in normal map building.