### PR TITLE
docs: recommend nvm before devcontainer CLI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,17 @@ TinyNav supports [Dev Containers](https://containers.dev/) for a consistent and 
 
 If you prefer the command line:
 
+#### Recommended: install a newer Node.js/npm with nvm first
+
+Some systems ship with an older npm. We recommend installing a newer Node.js/npm via `nvm` before installing the Dev Containers CLI:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+nvm install --lts
+```
+
+Then install and use the Dev Containers CLI:
+
 ```bash
 # Install the Dev Containers CLI
 npm install -g @devcontainers/cli


### PR DESCRIPTION
## Summary
- add a short README note recommending `nvm` for a newer Node.js/npm before installing `@devcontainers/cli`
- keep the existing Dev Container CLI flow intact

## Why
Some systems ship with an older npm, which makes the CLI install less reliable.