### PR TITLE
build(docker): add patched plotjuggler ros plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,8 +152,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /3rdparty/plotjuggler_ws/src \
     && git clone https://github.com/dvorak0/plotjuggler-ros-plugins.git /3rdparty/plotjuggler_ws/src/plotjuggler_ros \
-    && cd /3rdparty/plotjuggler_ws/src/plotjuggler_ros \
-    && git checkout feat/json-string-parser \
     && cd /3rdparty/plotjuggler_ws \
     && . /opt/ros/humble/setup.sh \
     && colcon build --packages-select plotjuggler_ros --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,17 @@ RUN apt-get update && \
     apt-get install -y clang-tidy ros-humble-ament-clang-tidy ros-humble-ament-lint \
     && rm -rf /var/lib/apt/lists/*
 
+# gtsam from source
+RUN apt-get update && apt-get install -y python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install pyparsing==3.1.1
+RUN git clone https://github.com/dvorak0/gtsam.git -b yzf/add_smart_factor_python_export \
+    && cd gtsam \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DGTSAM_BUILD_PYTHON=ON -DGTSAM_THROW_CHEIRALITY_EXCEPTION=OFF .. \
+    && make -j2
+ENV PYTHONPATH="/3rdparty/gtsam/build/python:${PYTHONPATH}"
+
 # plotjuggler ROS2 String JSON parser patch
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nlohmann-json3-dev \
@@ -147,17 +158,6 @@ RUN mkdir -p /3rdparty/plotjuggler_ws/src \
     && . /opt/ros/humble/setup.sh \
     && colcon build --packages-select plotjuggler_ros --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
 RUN echo "source /3rdparty/plotjuggler_ws/install/local_setup.bash" >> ~/.bashrc
-
-# gtsam from source
-RUN apt-get update && apt-get install -y python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-RUN pip3 install pyparsing==3.1.1
-RUN git clone https://github.com/dvorak0/gtsam.git -b yzf/add_smart_factor_python_export \
-    && cd gtsam \
-    && mkdir build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -DGTSAM_BUILD_PYTHON=ON -DGTSAM_THROW_CHEIRALITY_EXCEPTION=OFF .. \
-    && make -j2
-ENV PYTHONPATH="/3rdparty/gtsam/build/python:${PYTHONPATH}"
 
 # clean
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,21 @@ RUN apt-get update && \
     apt-get install -y clang-tidy ros-humble-ament-clang-tidy ros-humble-ament-lint \
     && rm -rf /var/lib/apt/lists/*
 
+# plotjuggler ROS2 String JSON parser patch
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nlohmann-json3-dev \
+    ros-humble-plotjuggler \
+    ros-humble-plotjuggler-ros \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /3rdparty/plotjuggler_ws/src \
+    && git clone https://github.com/dvorak0/plotjuggler-ros-plugins.git /3rdparty/plotjuggler_ws/src/plotjuggler_ros \
+    && cd /3rdparty/plotjuggler_ws/src/plotjuggler_ros \
+    && git checkout feat/json-string-parser \
+    && cd /3rdparty/plotjuggler_ws \
+    && . /opt/ros/humble/setup.sh \
+    && colcon build --packages-select plotjuggler_ros --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
+RUN echo "source /3rdparty/plotjuggler_ws/install/local_setup.bash" >> ~/.bashrc
+
 # gtsam from source
 RUN apt-get update && apt-get install -y python3-pip \
     && rm -rf /var/lib/apt/lists/*

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -200,7 +200,7 @@ class PerceptionNode(Node):
     async def process(self, left_msg, right_msg):
         if self.K is None or self.T_body_last is None:
             return {
-            "stats": {"loop_ms": 0.0, "process_cnt": 0},
+            "stats": {"process_cnt": 0},
             "metrics": {"num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
         }
         self.process_cnt += 1
@@ -223,7 +223,7 @@ class PerceptionNode(Node):
                 )
             )
             return {
-            "stats": {"loop_ms": 0.0, "process_cnt": 0},
+            "stats": {"process_cnt": 0},
             "metrics": {"num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
         }
 
@@ -516,7 +516,6 @@ class PerceptionNode(Node):
 
         return {
             "stats": {
-                "loop_ms": loop_ms,
                 "process_cnt": self.process_cnt,
             },
             "metrics": {

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -194,15 +194,13 @@ class PerceptionNode(Node):
         with Timer(name="Perception Loop", text="[{name}] Elapsed time: {milliseconds:.0f} ms\n\n", logger=self.logger.info):
             processed = asyncio.run(self.process(left_msg, right_msg))
         if processed:
-            loop_ms = (time.perf_counter() - loop_start) * 1000.0
-            self.stats_pub.publish(String(data=json.dumps({
-                "loop_ms": loop_ms,
-                "process_cnt": self.process_cnt,
-            })))
+            stats = processed
+            stats["loop_ms"] = (time.perf_counter() - loop_start) * 1000.0
+            self.stats_pub.publish(String(data=json.dumps(stats)))
 
     async def process(self, left_msg, right_msg):
         if self.K is None or self.T_body_last is None:
-            return False
+            return {"loop_ms": 0.0, "process_cnt": 0, "num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
         self.process_cnt += 1
         left_img = self.bridge.imgmsg_to_cv2(left_msg, "mono8")
         right_img = self.bridge.imgmsg_to_cv2(right_msg, "mono8")
@@ -222,7 +220,7 @@ class PerceptionNode(Node):
                     latest_imu_timestamp=current_timestamp
                 )
             )
-            return True
+            return {"loop_ms": 0.0, "process_cnt": 0, "num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
 
         with Timer(name="[Stereo Inference]", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.logger.debug):
             disparity, depth = await self.stereo_engine.infer(left_img, right_img, np.array([[self.baseline]]), np.array([[self.K[0,0]]]))
@@ -511,7 +509,16 @@ class PerceptionNode(Node):
             else:
                 self.keyframe_queue.pop()
 
-        return True
+        return {
+            "loop_ms": loop_ms,
+            "process_cnt": self.process_cnt,
+            "num_keyframes": len(self.keyframe_queue),
+            "num_tracks": len(tracks),
+            "num_factors": graph.size(),
+            "num_variables": initial_estimate.size(),
+            "initial_error": graph.error(initial_estimate),
+            "final_error": graph.error(result),
+        }
 
 
 def main(args=None):

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -117,7 +117,7 @@ class PerceptionNode(Node):
         self.keyframe_pose_pub = self.create_publisher(Odometry, "/slam/keyframe_odom", 10)
         self.keyframe_image_pub = self.create_publisher(Image, "/slam/keyframe_image", 10)
         self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
-        self.stats_pub = self.create_publisher(String, "/slam/stats", 10)
+        self.stats_pub = self.create_publisher(String, "/slam/data", 10)
 
         self.accel_readings = []
         self.last_processed_timestamp = 0.0
@@ -194,13 +194,15 @@ class PerceptionNode(Node):
         with Timer(name="Perception Loop", text="[{name}] Elapsed time: {milliseconds:.0f} ms\n\n", logger=self.logger.info):
             processed = asyncio.run(self.process(left_msg, right_msg))
         if processed:
-            stats = processed
-            stats["loop_ms"] = (time.perf_counter() - loop_start) * 1000.0
-            self.stats_pub.publish(String(data=json.dumps(stats)))
+            processed["stats"]["loop_ms"] = (time.perf_counter() - loop_start) * 1000.0
+            self.stats_pub.publish(String(data=json.dumps(processed)))
 
     async def process(self, left_msg, right_msg):
         if self.K is None or self.T_body_last is None:
-            return {"loop_ms": 0.0, "process_cnt": 0, "num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
+            return {
+            "stats": {"loop_ms": 0.0, "process_cnt": 0},
+            "metrics": {"num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
+        }
         self.process_cnt += 1
         left_img = self.bridge.imgmsg_to_cv2(left_msg, "mono8")
         right_img = self.bridge.imgmsg_to_cv2(right_msg, "mono8")
@@ -220,7 +222,10 @@ class PerceptionNode(Node):
                     latest_imu_timestamp=current_timestamp
                 )
             )
-            return {"loop_ms": 0.0, "process_cnt": 0, "num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
+            return {
+            "stats": {"loop_ms": 0.0, "process_cnt": 0},
+            "metrics": {"num_keyframes": 0, "num_tracks": 0, "num_factors": 0, "num_variables": 0, "initial_error": 0.0, "final_error": 0.0}
+        }
 
         with Timer(name="[Stereo Inference]", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.logger.debug):
             disparity, depth = await self.stereo_engine.infer(left_img, right_img, np.array([[self.baseline]]), np.array([[self.K[0,0]]]))
@@ -510,14 +515,18 @@ class PerceptionNode(Node):
                 self.keyframe_queue.pop()
 
         return {
-            "loop_ms": loop_ms,
-            "process_cnt": self.process_cnt,
-            "num_keyframes": len(self.keyframe_queue),
-            "num_tracks": len(tracks),
-            "num_factors": graph.size(),
-            "num_variables": initial_estimate.size(),
-            "initial_error": graph.error(initial_estimate),
-            "final_error": graph.error(result),
+            "stats": {
+                "loop_ms": loop_ms,
+                "process_cnt": self.process_cnt,
+            },
+            "metrics": {
+                "num_keyframes": len(self.keyframe_queue),
+                "num_tracks": len(tracks),
+                "num_factors": graph.size(),
+                "num_variables": initial_estimate.size(),
+                "initial_error": graph.error(initial_estimate),
+                "final_error": graph.error(result),
+            },
         }
 
 

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import sys
 import time
@@ -12,7 +13,7 @@ from tinynav.core.models_trt import LightGlueTRT, SuperPointTRT, StereoEngineTRT
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from sensor_msgs.msg import Image, Imu, CameraInfo
-from std_msgs.msg import Float32MultiArray
+from std_msgs.msg import String
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from tinynav.core.math_utils import rot_from_two_vector, np2msg, np2tf, estimate_pose, se3_inv
 from tinynav.core.math_utils import uf_init, uf_union, uf_all_sets_list
@@ -116,7 +117,7 @@ class PerceptionNode(Node):
         self.keyframe_pose_pub = self.create_publisher(Odometry, "/slam/keyframe_odom", 10)
         self.keyframe_image_pub = self.create_publisher(Image, "/slam/keyframe_image", 10)
         self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
-        self.stats_pub = self.create_publisher(Float32MultiArray, "/slam/stats", 10)
+        self.stats_pub = self.create_publisher(String, "/slam/stats", 10)
 
         self.accel_readings = []
         self.last_processed_timestamp = 0.0
@@ -194,7 +195,10 @@ class PerceptionNode(Node):
             processed = asyncio.run(self.process(left_msg, right_msg))
         if processed:
             loop_ms = (time.perf_counter() - loop_start) * 1000.0
-            self.stats_pub.publish(Float32MultiArray(data=[float(loop_ms)]))
+            self.stats_pub.publish(String(data=json.dumps({
+                "loop_ms": loop_ms,
+                "process_cnt": self.process_cnt,
+            })))
 
     async def process(self, left_msg, right_msg):
         if self.K is None or self.T_body_last is None:


### PR DESCRIPTION
## Summary
- install PlotJuggler ROS packages and nlohmann-json3-dev in the image
- clone dvorak0/plotjuggler-ros-plugins on the feat/json-string-parser branch
- build the patched plotjuggler_ros workspace inside the image and source it from ~/.bashrc

## Notes
- kept the Dockerfile change localized to a later ROS/tooling section to preserve earlier cache layers
- this integrates the JSON parsing support for ROS2 std_msgs/String into the tinynav dev image