### PR TITLE
docker: override apt message_filters with humble overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,16 @@ RUN apt-get update && apt-get install -y \
     ros-humble-foxglove-bridge \
     ros-humble-foxglove-msgs \
     ros-humble-foxglove-compressed-video-transport \
+    python3-pytest \
     && rm -rf /var/lib/apt/lists/*
+
+# Override apt-installed message_filters with UniflexAI/message_filters humble branch
+RUN mkdir -p /3rdparty/message_filters_ws/src \
+    && git clone --branch humble https://github.com/UniflexAI/message_filters.git /3rdparty/message_filters_ws/src/message_filters \
+    && cd /3rdparty/message_filters_ws \
+    && . /opt/ros/humble/setup.sh \
+    && colcon build --packages-select message_filters --allow-overriding message_filters
+RUN echo "source /3rdparty/message_filters_ws/install/local_setup.bash" >> ~/.bashrc
 
 # clean
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,6 @@ RUN apt-get update && apt-get install -y \
     ros-humble-foxglove-bridge \
     ros-humble-foxglove-msgs \
     ros-humble-foxglove-compressed-video-transport \
-    python3-pytest \
     && rm -rf /var/lib/apt/lists/*
 
 # Override apt-installed message_filters with UniflexAI/message_filters humble branch


### PR DESCRIPTION
## Summary
- build `UniflexAI/message_filters` from the `humble` branch inside the Docker image
- overlay it on top of the apt-installed ROS package with a dedicated workspace
- source the overlay in the container shell environment

## Why
We want tinynav to use the Humble-based `message_filters` branch that contains the Python `InputAligner` work, while still keeping the rest of ROS installed from apt.

## Cache behavior
The overlay build is intentionally placed near the end of the Dockerfile, just before the clean section, to avoid invalidating earlier stable layers during iteration.