### PR TITLE
refactor(tool): hardcode looper nav pipeline defaults

### DIFF
--- a/scripts/run_looper_navigation.sh
+++ b/scripts/run_looper_navigation.sh
@@ -1,16 +1,12 @@
 #!/bin/bash
 
-map_path="${TINYNAV_MAP_PATH:-/tinynav/output/map_hangzhou_juluo_0415}"
-pose_topic="${LOOPER_POSE_TOPIC:-/insight/vio_pose}"
-depth_topic="${LOOPER_DEPTH_TOPIC:-/camera/camera/depth/image_rect_raw}"
-image_topic="${LOOPER_IMAGE_TOPIC:-/camera/camera/infra1/image_rect_raw}"
-camera_info_topic="${LOOPER_CAMERA_INFO_TOPIC:-/camera/camera/infra1/camera_info}"
+map_path="/tinynav/output/map_hangzhou_juluo_0415"
 
 tmux new-session \; \
   split-window -h \; \
   split-window -v \; \
   select-pane -t 0 \; split-window -v \; \
-  select-pane -t 0 \; send-keys "uv run python /tinynav/tool/looper_bridge_node.py --pose-topic $pose_topic --depth-topic $depth_topic --image-topic $image_topic --camera-info-topic $camera_info_topic" C-m \; \
+  select-pane -t 0 \; send-keys "uv run python /tinynav/tool/looper_bridge_node.py" C-m \; \
   select-pane -t 1 \; send-keys 'uv run python /tinynav/tinynav/core/planning_node.py' C-m \; \
   select-pane -t 2 \; send-keys "uv run python /tinynav/tinynav/core/map_node.py --tinynav_map_path $map_path" C-m \; \
   select-pane -t 3 \; send-keys "uv run python /tinynav/tinynav/platforms/cmd_vel_control.py" C-m \; \

--- a/scripts/run_looper_navigation.sh
+++ b/scripts/run_looper_navigation.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+map_path="${TINYNAV_MAP_PATH:-/tinynav/output/map_hangzhou_juluo_0415}"
+pose_topic="${LOOPER_POSE_TOPIC:-/insight/vio_pose}"
+depth_topic="${LOOPER_DEPTH_TOPIC:-/camera/camera/depth/image_rect_raw}"
+image_topic="${LOOPER_IMAGE_TOPIC:-/camera/camera/infra1/image_rect_raw}"
+camera_info_topic="${LOOPER_CAMERA_INFO_TOPIC:-/camera/camera/infra1/camera_info}"
+
+tmux new-session \; \
+  split-window -h \; \
+  split-window -v \; \
+  select-pane -t 0 \; split-window -v \; \
+  select-pane -t 0 \; send-keys "uv run python /tinynav/tool/looper_bridge_node.py --pose-topic $pose_topic --depth-topic $depth_topic --image-topic $image_topic --camera-info-topic $camera_info_topic" C-m \; \
+  select-pane -t 1 \; send-keys 'uv run python /tinynav/tinynav/core/planning_node.py' C-m \; \
+  select-pane -t 2 \; send-keys "uv run python /tinynav/tinynav/core/map_node.py --tinynav_map_path $map_path" C-m \; \
+  select-pane -t 3 \; send-keys "uv run python /tinynav/tinynav/platforms/cmd_vel_control.py" C-m \; \
+  select-pane -t 4 \; send-keys 'ros2 run rviz2 rviz2 -d /tinynav/docs/vis.rviz' C-m

--- a/tool/global_pointcloud_publisher.py
+++ b/tool/global_pointcloud_publisher.py
@@ -10,7 +10,7 @@ from cv_bridge import CvBridge
 from geometry_msgs.msg import PoseStamped, TransformStamped
 from nav_msgs.msg import Path
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, ReliabilityPolicy
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CameraInfo, CompressedImage, Image, PointCloud2, PointField
 from scipy.spatial.transform import Rotation as R
 from std_msgs.msg import Header
@@ -219,13 +219,18 @@ class GlobalPointCloudPublisher(Node):
         self._logged_color_tf = False
         self.image_topic = "/camera/camera/infra1/image_rect_raw" if args.image_mode == "grayscale" else "/camera/camera/color/image_rect_raw/compressed"
         self.sensor_qos = QoSProfile(depth=50, reliability=ReliabilityPolicy.RELIABLE)
+        self.tf_static_qos = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
 
         self.camera_info_sub = self.create_subscription(CameraInfo, "/camera/camera/infra1/camera_info", self.camera_info_callback, self.sensor_qos)
         self.color_camera_info_sub = None
         if args.image_mode == "color":
             self.color_camera_info_sub = self.create_subscription(CameraInfo, "/camera/camera/color/camera_info", self.color_camera_info_callback, self.sensor_qos)
-        self.tf_sub = self.create_subscription(TFMessage, "/tf", self.tf_callback, 10)
-        self.tf_static_sub = self.create_subscription(TFMessage, "/tf_static", self.tf_callback, 10)
+        self.tf_static_sub = self.create_subscription(TFMessage, "/tf_static", self.tf_callback, self.tf_static_qos)
         self.tf_broadcaster = TransformBroadcaster(self)
         self.cloud_pub = self.create_publisher(PointCloud2, "/slam/global_cloud", 10)
         self.path_pub = self.create_publisher(Path, "/slam/global_cloud_path", 10)

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -1,0 +1,280 @@
+import argparse
+import copy
+from collections import deque
+
+import cv2
+import message_filters
+import numpy as np
+import rclpy
+from cv_bridge import CvBridge
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CameraInfo, Image
+from tf2_msgs.msg import TFMessage
+
+from tinynav.core.math_utils import np2msg, pose_msg2np, tf2np
+
+
+class LooperBridgeNode(Node):
+    def __init__(self, args):
+        super().__init__("looper_bridge_node")
+        self.args = args
+        self.bridge = CvBridge()
+
+        self.depth_frame_id = None
+        self.cached_camera_info = None
+        self.T_i_depth = None
+        self.tf_edges = {}
+        self.last_keyframe_pose = None
+        self.last_pose = None
+        self.last_pose_time = None
+        self._missing_input_counter = 0
+
+        self.sensor_qos = QoSProfile(depth=50, reliability=ReliabilityPolicy.RELIABLE)
+        self.tf_static_qos = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+
+        self.camera_info_sub = self.create_subscription(
+            CameraInfo, args.camera_info_topic, self.camera_info_callback, self.sensor_qos
+        )
+        self.tf_static_sub = self.create_subscription(
+            TFMessage, "/tf_static", self.tf_callback, self.tf_static_qos
+        )
+
+        self.depth_sub = message_filters.Subscriber(
+            self, Image, args.depth_topic, qos_profile=self.sensor_qos
+        )
+        self.pose_sub = message_filters.Subscriber(self, PoseStamped, args.pose_topic)
+        self.image_sub = message_filters.Subscriber(
+            self, Image, args.image_topic, qos_profile=self.sensor_qos
+        )
+        self.sync = message_filters.ApproximateTimeSynchronizer(
+            [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20, slop=args.sync_slop
+        )
+        self.sync.registerCallback(self.sync_callback)
+
+        self.odom_pub = self.create_publisher(Odometry, "/slam/odometry", 10)
+        self.depth_pub = self.create_publisher(Image, "/slam/depth", 10)
+        self.disparity_pub_vis = self.create_publisher(Image, "/slam/disparity_vis", 10)
+        self.slam_camera_info_pub = self.create_publisher(CameraInfo, "/slam/camera_info", 10)
+        self.camera_info_alias_pub = self.create_publisher(
+            CameraInfo, "/camera/camera/infra2/camera_info", 10
+        )
+        self.keyframe_pose_pub = self.create_publisher(Odometry, "/slam/keyframe_odom", 10)
+        self.keyframe_image_pub = self.create_publisher(Image, "/slam/keyframe_image", 10)
+        self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
+
+        self.get_logger().info(
+            f"Bridging {args.pose_topic} + {args.depth_topic} + {args.image_topic} into TinyNav /slam topics."
+        )
+
+    def camera_info_callback(self, msg: CameraInfo):
+        self.cached_camera_info = msg
+        if msg.header.frame_id:
+            self.depth_frame_id = msg.header.frame_id
+        self.try_update_depth_transform()
+        self.get_logger().info(
+            f"Received camera info from {self.args.camera_info_topic} with frame {msg.header.frame_id}.",
+            once=True,
+        )
+
+    def tf_callback(self, msg: TFMessage):
+        for transform in msg.transforms:
+            frame_id, child_frame_id, T = tf2np(transform)
+            self.store_transform(frame_id, child_frame_id, T)
+        self.try_update_depth_transform()
+        self.get_logger().info("Received TF_STATIC for Looper bridge.", once=True)
+
+    def store_transform(self, parent_frame: str, child_frame: str, T: np.ndarray):
+        self.tf_edges.setdefault(parent_frame, {})[child_frame] = T.astype(np.float32, copy=False)
+        self.tf_edges.setdefault(child_frame, {})[parent_frame] = np.linalg.inv(T).astype(
+            np.float32, copy=False
+        )
+
+    def lookup_transform(self, source_frame: str, target_frame: str):
+        if source_frame == target_frame:
+            return np.eye(4, dtype=np.float32)
+        if source_frame not in self.tf_edges or target_frame not in self.tf_edges:
+            return None
+
+        queue = deque([(source_frame, np.eye(4, dtype=np.float32))])
+        visited = {source_frame}
+        while queue:
+            frame, T_source_frame = queue.popleft()
+            for next_frame, T_frame_next in self.tf_edges.get(frame, {}).items():
+                if next_frame in visited:
+                    continue
+                T_source_next = T_source_frame @ T_frame_next
+                if next_frame == target_frame:
+                    return T_source_next.astype(np.float32, copy=False)
+                visited.add(next_frame)
+                queue.append((next_frame, T_source_next))
+        return None
+
+    def try_update_depth_transform(self):
+        if self.depth_frame_id is None:
+            return
+        T_i_depth = self.lookup_transform("imu", self.depth_frame_id)
+        if T_i_depth is not None:
+            self.T_i_depth = T_i_depth
+            self.get_logger().info(
+                f"Resolved imu -> {self.depth_frame_id} transform for Looper bridge.",
+                once=True,
+            )
+
+    def log_missing_inputs(self):
+        self._missing_input_counter += 1
+        if self._missing_input_counter % 30 != 1:
+            return
+        missing = []
+        if self.cached_camera_info is None:
+            missing.append(self.args.camera_info_topic)
+        if self.T_i_depth is None:
+            missing.append(f"imu->{self.depth_frame_id or 'depth'} TF")
+        self.get_logger().info(f"Waiting for Looper bridge inputs: {', '.join(missing)}")
+
+    def should_add_keyframe(self, T_world_camera: np.ndarray) -> bool:
+        if self.last_keyframe_pose is None:
+            return True
+        translation = np.linalg.norm(
+            T_world_camera[:3, 3] - self.last_keyframe_pose[:3, 3]
+        )
+        relative_rotation = self.last_keyframe_pose[:3, :3].T @ T_world_camera[:3, :3]
+        rotation_angle = np.arccos(
+            np.clip((np.trace(relative_rotation) - 1.0) * 0.5, -1.0, 1.0)
+        )
+        return (
+            translation >= self.args.keyframe_translation
+            or rotation_angle >= np.deg2rad(self.args.keyframe_rotation_deg)
+        )
+
+    def build_odom(self, T_world_camera: np.ndarray, stamp) -> Odometry:
+        velocity = None
+        current_time = stamp.sec + stamp.nanosec * 1e-9
+        if self.last_pose is not None and self.last_pose_time is not None:
+            dt = current_time - self.last_pose_time
+            if dt > 1e-3:
+                velocity = (T_world_camera[:3, 3] - self.last_pose[:3, 3]) / dt
+
+        odom_msg = np2msg(
+            T_world_camera,
+            stamp,
+            self.args.world_frame,
+            self.args.child_frame,
+            velocity=velocity,
+        )
+        self.last_pose = T_world_camera.copy()
+        self.last_pose_time = current_time
+        return odom_msg
+
+    def decode_depth_meters(self, depth_msg: Image) -> np.ndarray:
+        depth = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="passthrough")
+        depth = np.asarray(depth)
+        if depth_msg.encoding in ("mono16", "16UC1"):
+            depth = depth.astype(np.float32) / 1000.0
+        else:
+            depth = depth.astype(np.float32)
+        return depth
+
+    def build_depth_msg(self, depth_m: np.ndarray, stamp) -> Image:
+        depth_out = self.bridge.cv2_to_imgmsg(depth_m, encoding="32FC1")
+        depth_out.header.stamp = stamp
+        depth_out.header.frame_id = self.args.child_frame
+        return depth_out
+
+    def build_disparity_vis(self, depth_m: np.ndarray, stamp) -> Image:
+        depth = np.asarray(depth_m, dtype=np.float32)
+
+        valid = np.isfinite(depth) & (depth > 1e-3)
+        disparity_u8 = np.zeros(depth.shape, dtype=np.uint8)
+        if np.any(valid):
+            inv_depth = np.zeros(depth.shape, dtype=np.float32)
+            inv_depth[valid] = 1.0 / depth[valid]
+            disp_min = float(np.min(inv_depth[valid]))
+            disp_max = float(np.max(inv_depth[valid]))
+            if disp_max > disp_min:
+                disparity_u8[valid] = np.clip(
+                    255.0 * (inv_depth[valid] - disp_min) / (disp_max - disp_min),
+                    0.0,
+                    255.0,
+                ).astype(np.uint8)
+            else:
+                disparity_u8[valid] = 255
+
+        disp_color = cv2.applyColorMap(disparity_u8, cv2.COLORMAP_PLASMA)
+        disp_color[~valid] = 0
+        disp_color_msg = self.bridge.cv2_to_imgmsg(disp_color, encoding="bgr8")
+        disp_color_msg.header.stamp = stamp
+        disp_color_msg.header.frame_id = self.args.child_frame
+        return disp_color_msg
+
+    def sync_callback(self, depth_msg: Image, pose_msg: PoseStamped, image_msg: Image):
+        if self.cached_camera_info is None or self.T_i_depth is None:
+            self.log_missing_inputs()
+            return
+
+        T_world_imu = pose_msg2np(pose_msg)
+        T_world_camera = T_world_imu @ self.T_i_depth
+        stamp = pose_msg.header.stamp
+
+        odom_msg = self.build_odom(T_world_camera, stamp)
+        depth_m = self.decode_depth_meters(depth_msg)
+        depth_out = self.build_depth_msg(depth_m, stamp)
+        disparity_vis_msg = self.build_disparity_vis(depth_m, stamp)
+
+        image_out = copy.deepcopy(image_msg)
+        image_out.header.stamp = stamp
+        image_out.header.frame_id = self.args.child_frame
+
+        camera_info_out = copy.deepcopy(self.cached_camera_info)
+        camera_info_out.header.stamp = stamp
+        camera_info_out.header.frame_id = self.args.child_frame
+
+        self.odom_pub.publish(odom_msg)
+        self.depth_pub.publish(depth_out)
+        self.disparity_pub_vis.publish(disparity_vis_msg)
+        self.slam_camera_info_pub.publish(camera_info_out)
+        self.camera_info_alias_pub.publish(camera_info_out)
+
+        if self.should_add_keyframe(T_world_camera):
+            self.keyframe_pose_pub.publish(odom_msg)
+            self.keyframe_image_pub.publish(image_out)
+            self.keyframe_depth_pub.publish(depth_out)
+            self.last_keyframe_pose = T_world_camera.copy()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pose-topic", default="/insight/vio_pose")
+    parser.add_argument("--depth-topic", default="/camera/camera/depth/image_rect_raw")
+    parser.add_argument("--image-topic", default="/camera/camera/infra1/image_rect_raw")
+    parser.add_argument("--camera-info-topic", default="/camera/camera/infra1/camera_info")
+    parser.add_argument("--world-frame", default="world")
+    parser.add_argument("--child-frame", default="camera")
+    parser.add_argument("--sync-slop", type=float, default=0.08)
+    parser.add_argument("--keyframe-translation", type=float, default=0.03)
+    parser.add_argument("--keyframe-rotation-deg", type=float, default=1.0)
+    return parser.parse_args()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = LooperBridgeNode(parse_args())
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -40,22 +40,14 @@ class LooperBridgeNode(Node):
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
         )
 
-        self.camera_info_sub = self.create_subscription(
-            CameraInfo, args.camera_info_topic, self.camera_info_callback, self.sensor_qos
-        )
-        self.tf_static_sub = self.create_subscription(
-            TFMessage, "/tf_static", self.tf_callback, self.tf_static_qos
-        )
+        self.camera_info_sub = self.create_subscription(CameraInfo, "/camera/camera/infra1/camera_info", self.camera_info_callback, self.sensor_qos)
+        self.tf_static_sub = self.create_subscription(TFMessage, "/tf_static", self.tf_callback, self.tf_static_qos)
 
-        self.depth_sub = message_filters.Subscriber(
-            self, Image, args.depth_topic, qos_profile=self.sensor_qos
-        )
-        self.pose_sub = message_filters.Subscriber(self, PoseStamped, args.pose_topic)
-        self.image_sub = message_filters.Subscriber(
-            self, Image, args.image_topic, qos_profile=self.sensor_qos
-        )
+        self.depth_sub = message_filters.Subscriber(self, Image, "/camera/camera/depth/image_rect_raw", qos_profile=self.sensor_qos)
+        self.pose_sub = message_filters.Subscriber(self, PoseStamped, "/insight/vio_pose")
+        self.image_sub = message_filters.Subscriber(self, Image, "/camera/camera/infra1/image_rect_raw", qos_profile=self.sensor_qos)
         self.sync = message_filters.ApproximateTimeSynchronizer(
-            [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20, slop=args.sync_slop
+            [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20, slop=0.08
         )
         self.sync.registerCallback(self.sync_callback)
 
@@ -71,7 +63,7 @@ class LooperBridgeNode(Node):
         self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
 
         self.get_logger().info(
-            f"Bridging {args.pose_topic} + {args.depth_topic} + {args.image_topic} into TinyNav /slam topics."
+            "Bridging /insight/vio_pose + /camera/camera/depth/image_rect_raw + /camera/camera/infra1/image_rect_raw into TinyNav /slam topics."
         )
 
     def camera_info_callback(self, msg: CameraInfo):
@@ -80,7 +72,7 @@ class LooperBridgeNode(Node):
             self.depth_frame_id = msg.header.frame_id
         self.try_update_depth_transform()
         self.get_logger().info(
-            f"Received camera info from {self.args.camera_info_topic} with frame {msg.header.frame_id}.",
+            f"Received camera info from /camera/camera/infra1/camera_info with frame {msg.header.frame_id}.",
             once=True,
         )
 
@@ -134,7 +126,7 @@ class LooperBridgeNode(Node):
             return
         missing = []
         if self.cached_camera_info is None:
-            missing.append(self.args.camera_info_topic)
+            missing.append("/camera/camera/infra1/camera_info")
         if self.T_i_depth is None:
             missing.append(f"imu->{self.depth_frame_id or 'depth'} TF")
         self.get_logger().info(f"Waiting for Looper bridge inputs: {', '.join(missing)}")
@@ -165,8 +157,8 @@ class LooperBridgeNode(Node):
         odom_msg = np2msg(
             T_world_camera,
             stamp,
-            self.args.world_frame,
-            self.args.child_frame,
+            "world",
+            "camera",
             velocity=velocity,
         )
         self.last_pose = T_world_camera.copy()
@@ -185,7 +177,7 @@ class LooperBridgeNode(Node):
     def build_depth_msg(self, depth_m: np.ndarray, stamp) -> Image:
         depth_out = self.bridge.cv2_to_imgmsg(depth_m, encoding="32FC1")
         depth_out.header.stamp = stamp
-        depth_out.header.frame_id = self.args.child_frame
+        depth_out.header.frame_id = "camera"
         return depth_out
 
     def build_disparity_vis(self, depth_m: np.ndarray, stamp) -> Image:
@@ -211,7 +203,7 @@ class LooperBridgeNode(Node):
         disp_color[~valid] = 0
         disp_color_msg = self.bridge.cv2_to_imgmsg(disp_color, encoding="bgr8")
         disp_color_msg.header.stamp = stamp
-        disp_color_msg.header.frame_id = self.args.child_frame
+        disp_color_msg.header.frame_id = "camera"
         return disp_color_msg
 
     def sync_callback(self, depth_msg: Image, pose_msg: PoseStamped, image_msg: Image):
@@ -230,11 +222,11 @@ class LooperBridgeNode(Node):
 
         image_out = copy.deepcopy(image_msg)
         image_out.header.stamp = stamp
-        image_out.header.frame_id = self.args.child_frame
+        image_out.header.frame_id = "camera"
 
         camera_info_out = copy.deepcopy(self.cached_camera_info)
         camera_info_out.header.stamp = stamp
-        camera_info_out.header.frame_id = self.args.child_frame
+        camera_info_out.header.frame_id = "camera"
 
         self.odom_pub.publish(odom_msg)
         self.depth_pub.publish(depth_out)
@@ -251,13 +243,6 @@ class LooperBridgeNode(Node):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--pose-topic", default="/insight/vio_pose")
-    parser.add_argument("--depth-topic", default="/camera/camera/depth/image_rect_raw")
-    parser.add_argument("--image-topic", default="/camera/camera/infra1/image_rect_raw")
-    parser.add_argument("--camera-info-topic", default="/camera/camera/infra1/camera_info")
-    parser.add_argument("--world-frame", default="world")
-    parser.add_argument("--child-frame", default="camera")
-    parser.add_argument("--sync-slop", type=float, default=0.08)
     parser.add_argument("--keyframe-translation", type=float, default=0.03)
     parser.add_argument("--keyframe-rotation-deg", type=float, default=1.0)
     return parser.parse_args()


### PR DESCRIPTION
## Summary
- hardcode the looper navigation pipeline topics and frames instead of exposing them as CLI/env options
- collapse the message_filters subscriber construction to single lines
- keep only the keyframe threshold args configurable

## Why
This keeps the looper bridge and runner script aligned with the current intended deployment setup and removes option surface that we do not plan to vary.