### PR TITLE
ci(cloc): exclude app/backend from line counts

### DIFF
--- a/.github/workflows/cloc-action.yml
+++ b/.github/workflows/cloc-action.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Count Lines of Code with additional options
         uses: djdefi/cloc-action@main
         with:
-          options: --exclude-dir=tests,tool --exclude-lang=YAML,'Jupyter Notebook',SVG --md --report-file=cloc.md
+          options: --exclude-dir=tests,tool,app/backend --exclude-lang=YAML,'Jupyter Notebook',SVG --md --report-file=cloc.md
 
       - name: Add comment to PR
         uses: actions/github-script@v6


### PR DESCRIPTION
## Summary
- exclude `app/backend` from the cloc workflow directory counts

## Why
We do not want `app/backend` included in the cloc statistics reported by CI.