### PR TITLE
feat(devcontainer): mount XDG data dir for tinynav

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,30 +2,26 @@
   "name": "tinynav-dev",
   "image": "uniflexai/tinynav:latest",
   "context": "..",
+
   "containerEnv": {
     "DISPLAY": "${localEnv:DISPLAY}",
     "GDK_SCALE": "2"
   },
+
   "runArgs": [
-    "--gpus",
-    "all",
+    "--gpus", "all",
     "--privileged",
-    "--network",
-    "host",
-    "-v",
-    "/tmp/.X11-unix:/tmp/.X11-unix",
-    "-v",
-    "/dev:/dev",
-    "-v",
-    "/etc/localtime:/etc/localtime",
+    "--network", "host",
+    "-v", "/tmp/.X11-unix:/tmp/.X11-unix",
+    "-v", "/dev:/dev",
+    "-v", "/etc/localtime:/etc/localtime",
     "--device-cgroup-rule=c 81:* rwm",
     "--device-cgroup-rule=c 234:* rwm",
     "--shm-size=16gb",
-    "-v",
-    "${localEnv:XDG_DATA_HOME:-${localEnv:HOME}/.local/share}/tinynav:/root/.local/share/tinynav",
-    "-v",
-    "${localWorkspaceFolder}:/tinynav"
+    "-v", "${localEnv:XDG_DATA_HOME:-${localEnv:HOME}/.local/share}/tinynav:/root/.local/share/tinynav",
+    "-v", "${localWorkspaceFolder}:/tinynav"
   ],
+
   "workspaceFolder": "/tinynav",
   "remoteUser": "root",
   "features": {},
@@ -33,3 +29,4 @@
   "postCreateCommand": "echo 'Devcontainer ready.'",
   "postStartCommand": "/usr/local/bin/entrypoint.sh"
 }
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,25 +2,30 @@
   "name": "tinynav-dev",
   "image": "uniflexai/tinynav:latest",
   "context": "..",
-
   "containerEnv": {
     "DISPLAY": "${localEnv:DISPLAY}",
     "GDK_SCALE": "2"
   },
-
   "runArgs": [
-    "--gpus", "all",
+    "--gpus",
+    "all",
     "--privileged",
-    "--network", "host",
-    "-v", "/tmp/.X11-unix:/tmp/.X11-unix",
-    "-v", "/dev:/dev",
-    "-v", "/etc/localtime:/etc/localtime",
+    "--network",
+    "host",
+    "-v",
+    "/tmp/.X11-unix:/tmp/.X11-unix",
+    "-v",
+    "/dev:/dev",
+    "-v",
+    "/etc/localtime:/etc/localtime",
     "--device-cgroup-rule=c 81:* rwm",
     "--device-cgroup-rule=c 234:* rwm",
     "--shm-size=16gb",
-    "-v", "${localWorkspaceFolder}:/tinynav"
+    "-v",
+    "${localEnv:XDG_DATA_HOME:-${localEnv:HOME}/.local/share}/tinynav:/root/.local/share/tinynav",
+    "-v",
+    "${localWorkspaceFolder}:/tinynav"
   ],
-
   "workspaceFolder": "/tinynav",
   "remoteUser": "root",
   "features": {},
@@ -28,4 +33,3 @@
   "postCreateCommand": "echo 'Devcontainer ready.'",
   "postStartCommand": "/usr/local/bin/entrypoint.sh"
 }
-


### PR DESCRIPTION
## Summary
- add an XDG data dir bind mount to the devcontainer config
- mirror the tinynav-cli convention of using `${XDG_DATA_HOME:-~/.local/share}/tinynav` for persisted workspace data

## Why
This keeps the main tinynav devcontainer aligned with the storage convention already used in tinynav-cli.