### PR TITLE
fix(devcontainer): use HOME-based tinynav data mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     "--device-cgroup-rule=c 81:* rwm",
     "--device-cgroup-rule=c 234:* rwm",
     "--shm-size=16gb",
-    "-v", "${localEnv:XDG_DATA_HOME:-${localEnv:HOME}/.local/share}/tinynav:/root/.local/share/tinynav",
+    "-v", "${localEnv:HOME}/.local/share/tinynav:/root/.local/share/tinynav",
     "-v", "${localWorkspaceFolder}:/tinynav"
   ],
 


### PR DESCRIPTION
## Summary
- replace the unsupported devcontainer fallback expression with a direct HOME-based mount path

## Why
The devcontainer CLI does not support the shell-style fallback syntax we tried before. Using `${localEnv:HOME}/.local/share/tinynav` keeps the mount simple and valid.