### PR TITLE
ci(cloc): exclude app from line counts

### DIFF
--- a/.github/workflows/cloc-action.yml
+++ b/.github/workflows/cloc-action.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Count Lines of Code with additional options
         uses: djdefi/cloc-action@main
         with:
-          options: --exclude-dir=tests,tool,app/backend --exclude-lang=YAML,'Jupyter Notebook',SVG --md --report-file=cloc.md
+          options: --exclude-dir=tests,tool,app --exclude-lang=YAML,'Jupyter Notebook',SVG --md --report-file=cloc.md
 
       - name: Add comment to PR
         uses: actions/github-script@v6


### PR DESCRIPTION
## Summary
- update the cloc workflow to exclude the entire `app` directory from reported line counts

## Why
This avoids the `app/backend` path handling issue and keeps cloc focused on the parts of the repository we want to track.