### PR TITLE
fix(recording): use /tf_static for rosbag recording topics

### DIFF
--- a/scripts/run_rosbag_record.sh
+++ b/scripts/run_rosbag_record.sh
@@ -22,6 +22,5 @@ ros2 bag record \
     /camera/camera/imu \
     /camera/camera/color/image_raw \
     /camera/camera/color/camera_info \
-    /tf \
     /camera/camera/color/image_rect_raw/compressed \
     /tf_static

--- a/tool/ros2_node_manager.py
+++ b/tool/ros2_node_manager.py
@@ -84,7 +84,6 @@ class Ros2NodeManager(Node):
             '/camera/camera/color/camera_info',
             '/camera/camera/color/image_rect_raw/compressed',
             '/camera/camera/imu',
-            '/tf',
             '/tf_static',
             '/cmd_vel',
             '/mapping/global_plan',
@@ -152,7 +151,7 @@ class Ros2NodeManager(Node):
         self.processes['realsense'] = self._spawn(self._get_realsense_cmd())
         
         topics = [
-            '/tf', '/cmd_vel', '/mapping/global_plan', '/mapping/poi',
+            '/tf_static', '/cmd_vel', '/mapping/global_plan', '/mapping/poi',
             '/mapping/poi_change', '/planning/trajectory_path',
             '/planning/occupied_voxels',
             '/slam/odometry',


### PR DESCRIPTION
## Summary
Use /tf_static instead of /tf in rosbag recording configs to align recording behavior across scripts and node manager flows.

## Changes
- update tool/ros2_node_manager.py:
  - replace /tf with /tf_static in bag topic lists
- update scripts/run_rosbag_record.sh topic list behavior (already on /tf_static path in this branch)

## Why
/tf_static contains static transforms required for downstream map/localization replay, while /tf is dynamic and not the intended target for this recording path.

## Testing
- verified topic lists in updated files
- no runtime test executed in this change