### PR TITLE
feat(tools): move NeRF export out of build_map_node and read TF from saved npy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,11 @@ unitree = [
     "unitree-sdk2py @ git+https://github.com/unitreerobotics/unitree_sdk2_python.git@404fe44d76f705c002c97e773276f2a8fefb57e4",
 ]
 3dgs = [
+    "torch>=2.4,<2.11",
+    "pillow>=10,<12",
     "lightglue @ git+https://github.com/cvg/LightGlue.git@746fac2c042e05d1865315b1413419f1c1e7ba55",
     "plyfile",
     "nerfstudio @ git+https://github.com/junlinp/nerfstudio.git@d69136d198beea473aaa148cbd5114d01c2f847e",
     "pymeshlab==2022.2.post4",
     "newrawpy<=1.0.0b0",
 ]
-

--- a/scripts/run_3dgs_generation.sh
+++ b/scripts/run_3dgs_generation.sh
@@ -2,6 +2,7 @@
 uv pip install .[3dgs]
 data_path=/tinynav/output/map_color_benchmark01
 output_path=/tinynav/output/map_color_benchmark01
+uv run python tool/convert_to_nerf_format.py --map-dir "$data_path"
 MAX_JOBS=1 ns-train splatfacto \
       --output-dir $output_path \
       --experiment-name experiment \

--- a/scripts/run_3dgs_generation.sh
+++ b/scripts/run_3dgs_generation.sh
@@ -3,7 +3,7 @@ uv pip install .[3dgs]
 data_path=/tinynav/output/map_color_benchmark01
 output_path=/tinynav/output/map_color_benchmark01
 uv run python tool/convert_to_nerf_format.py --map-dir "$data_path"
-MAX_JOBS=1 ns-train splatfacto \
+MAX_JOBS=1 uv run ns-train splatfacto \
       --output-dir $output_path \
       --experiment-name experiment \
       --method-name splatfacto \
@@ -16,4 +16,4 @@ MAX_JOBS=1 ns-train splatfacto \
       --center-method none \
       --auto-scale-poses False \
       --orientation_method none
-ns-export gaussian-splat --load-config "$output_path/experiment/splatfacto/0/config.yml"  --output-dir "$output_path"
+uv run ns-export gaussian-splat --load-config "$output_path/experiment/splatfacto/0/config.yml"  --output-dir "$output_path"

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -461,6 +461,7 @@ class BuildMapNode(Node):
         self.tf_static_sub = Subscriber(self, TFMessage, "/tf_static")
         self.tf_static_sub.registerCallback(self.tf_callback)
         self.tf_messages: Dict[int, Dict[str, np.ndarray]] = {}
+        self.tf_capture_completed = False
         self.T_rgb_to_infra1 = None
         self.rgb_camera_info_sub = Subscriber(self, CameraInfo, "/camera/camera/color/camera_info")
         self.rgb_camera_info_sub.registerCallback(self.rgb_camera_info_callback)
@@ -469,16 +470,21 @@ class BuildMapNode(Node):
         self.edges = set()
 
     def tf_callback(self, msg:TFMessage):
+        if self.tf_capture_completed:
+            return
+
         T_infra1_to_link = None
         T_infra1_optical_to_infra1 = None
         T_rgb_to_link = None
         T_rgb_optical_to_rgb = None
+        tf_updated = False
         for t in msg.transforms:
             frame_id, child_frame_id, T = tf2np(t)
             timestamp_ns = int(t.header.stamp.sec * 1e9) + int(t.header.stamp.nanosec)
             if timestamp_ns not in self.tf_messages:
                 self.tf_messages[timestamp_ns] = {}
             self.tf_messages[timestamp_ns][f"{frame_id}->{child_frame_id}"] = T
+            tf_updated = True
             if frame_id == "camera_link" and child_frame_id == "camera_infra1_frame":
                 T_infra1_to_link = T
             if frame_id == "camera_infra1_frame" and child_frame_id == "camera_infra1_optical_frame":
@@ -494,6 +500,16 @@ class BuildMapNode(Node):
 
         if T_infra1_optical_to_infra1 is not None and T_rgb_optical_to_rgb is not None and T_infra1_to_link is not None and T_rgb_to_link is not None:
             self.T_rgb_to_infra1 = np.linalg.inv(T_infra1_optical_to_infra1) @ np.linalg.inv(T_infra1_to_link) @ T_rgb_to_link @ T_rgb_optical_to_rgb
+        if tf_updated and self.T_rgb_to_infra1 is not None:
+            np.save(f"{self.map_save_path}/tf_messages.npy", self.tf_messages, allow_pickle=True)
+            self.tf_capture_completed = True
+            if self.tf_sub is not None:
+                self.destroy_subscription(self.tf_sub.sub)
+                self.tf_sub = None
+            if self.tf_static_sub is not None:
+                self.destroy_subscription(self.tf_static_sub.sub)
+                self.tf_static_sub = None
+            self.get_logger().info("Saved tf_messages.npy and unsubscribed from /tf and /tf_static")
 
     def rgb_camera_info_callback(self, msg:CameraInfo):
         if self.rgb_camera_K is None:
@@ -667,7 +683,6 @@ class BuildMapNode(Node):
         np.save(f"{self.map_save_path}/baseline.npy", self.baseline)
         print(f"T_rgb_to_infra1: {self.T_rgb_to_infra1}")
         np.save(f"{self.map_save_path}/T_rgb_to_infra1.npy", self.T_rgb_to_infra1, allow_pickle = True)
-        np.save(f"{self.map_save_path}/tf_messages.npy", self.tf_messages, allow_pickle = True)
         np.save(f"{self.map_save_path}/rgb_camera_intrinsics.npy", self.rgb_camera_K, allow_pickle = True)
         np.save(f"{self.map_save_path}/edges.npy", list(self.edges), allow_pickle = True)
 

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -29,8 +29,7 @@ import shelve
 from tqdm import tqdm
 import einops
 from tf2_msgs.msg import TFMessage
-from typing import Tuple, Dict
-import json
+from typing import Dict
 
 from tf2_ros import TransformBroadcaster
 from geometry_msgs.msg import TransformStamped,Point
@@ -62,38 +61,6 @@ def z_value_to_color(z, z_min, z_max):
         color.r = 1.0
         color.g = 1.0 - (normalized_z - 0.75) * 4.0
     return color
-
-def convert_nerf_format(output_dir: str, infra1_poses: dict, rgb_intrinscis:np.ndarray, image_size: Tuple[int, int], T_rgb_to_infra1:np.ndarray):
-    camera_model = "PINHOLE"
-    fl_x = rgb_intrinscis[0, 0]
-    fl_y = rgb_intrinscis[1, 1]
-    cx = rgb_intrinscis[0, 2]
-    cy = rgb_intrinscis[1, 2]
-    w = image_size[1]
-    h = image_size[0]
-    frames = []
-    opencv_to_opengl_convention = np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
-    for timestmap, camera_to_world_pose in infra1_poses.items():
-        camera_to_world_opengl = camera_to_world_pose @ T_rgb_to_infra1 @ opencv_to_opengl_convention
-        frame = {
-            "file_path": f"images/image_{timestmap}.png",
-            "transform_matrix": camera_to_world_opengl.tolist(),
-        }
-        frames.append(frame)
-
-    data = {
-        "camera_model": camera_model,
-        "fl_x": fl_x,
-        "fl_y": fl_y,
-        "cx": cx,
-        "cy": cy,
-        "w": w,
-        "h": h,
-        "frames": frames
-    }
-
-    with open(f"{output_dir}/transforms.json", "w") as f:
-        json.dump(data, f, indent=4)
 
 def merge_local_into_global(global_grid:np.ndarray, global_origin:np.ndarray, local_grid:np.ndarray, local_origin:np.ndarray, resolution:float) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -493,6 +460,7 @@ class BuildMapNode(Node):
         self.tf_sub.registerCallback(self.tf_callback)
         self.tf_static_sub = Subscriber(self, TFMessage, "/tf_static")
         self.tf_static_sub.registerCallback(self.tf_callback)
+        self.tf_messages: Dict[int, Dict[str, np.ndarray]] = {}
         self.T_rgb_to_infra1 = None
         self.rgb_camera_info_sub = Subscriber(self, CameraInfo, "/camera/camera/color/camera_info")
         self.rgb_camera_info_sub.registerCallback(self.rgb_camera_info_callback)
@@ -507,6 +475,10 @@ class BuildMapNode(Node):
         T_rgb_optical_to_rgb = None
         for t in msg.transforms:
             frame_id, child_frame_id, T = tf2np(t)
+            timestamp_ns = int(t.header.stamp.sec * 1e9) + int(t.header.stamp.nanosec)
+            if timestamp_ns not in self.tf_messages:
+                self.tf_messages[timestamp_ns] = {}
+            self.tf_messages[timestamp_ns][f"{frame_id}->{child_frame_id}"] = T
             if frame_id == "camera_link" and child_frame_id == "camera_infra1_frame":
                 T_infra1_to_link = T
             if frame_id == "camera_infra1_frame" and child_frame_id == "camera_infra1_optical_frame":
@@ -695,6 +667,7 @@ class BuildMapNode(Node):
         np.save(f"{self.map_save_path}/baseline.npy", self.baseline)
         print(f"T_rgb_to_infra1: {self.T_rgb_to_infra1}")
         np.save(f"{self.map_save_path}/T_rgb_to_infra1.npy", self.T_rgb_to_infra1, allow_pickle = True)
+        np.save(f"{self.map_save_path}/tf_messages.npy", self.tf_messages, allow_pickle = True)
         np.save(f"{self.map_save_path}/rgb_camera_intrinsics.npy", self.rgb_camera_K, allow_pickle = True)
         np.save(f"{self.map_save_path}/edges.npy", list(self.edges), allow_pickle = True)
 
@@ -708,14 +681,6 @@ class BuildMapNode(Node):
         np.save(f"{self.map_save_path}/sdf_map.npy", sdf_map)
         cv2.imwrite(f"{self.map_save_path}/occupancy_2d_image.png", occupancy_2d_image)
 
-        image_size = None
-        os.makedirs(f"{self.map_save_path}/images", exist_ok=True)
-        for timestamp, infra1_pose in self.pose_graph_used_pose.items():
-            _, _, _, rgb_image, _ = self.db.get_depth_embedding_features_images(timestamp)
-            if image_size is None:
-                image_size = rgb_image.shape[:2]
-            cv2.imwrite(f"{self.map_save_path}/images/image_{timestamp}.png", rgb_image)
-        convert_nerf_format(self.map_save_path, self.pose_graph_used_pose, self.rgb_camera_K, image_size, self.T_rgb_to_infra1)
         self.db.close()
 
         self._save_completed = True

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -460,8 +460,6 @@ class BuildMapNode(Node):
         self.tf_sub.registerCallback(self.tf_callback)
         self.tf_static_sub = Subscriber(self, TFMessage, "/tf_static")
         self.tf_static_sub.registerCallback(self.tf_callback)
-        self.tf_messages: Dict[int, Dict[str, np.ndarray]] = {}
-        self.tf_capture_completed = False
         self.T_rgb_to_infra1 = None
         self.rgb_camera_info_sub = Subscriber(self, CameraInfo, "/camera/camera/color/camera_info")
         self.rgb_camera_info_sub.registerCallback(self.rgb_camera_info_callback)
@@ -470,21 +468,17 @@ class BuildMapNode(Node):
         self.edges = set()
 
     def tf_callback(self, msg:TFMessage):
-        if self.tf_capture_completed:
-            return
-
         T_infra1_to_link = None
         T_infra1_optical_to_infra1 = None
         T_rgb_to_link = None
         T_rgb_optical_to_rgb = None
-        tf_updated = False
+        tf_messages: Dict[int, Dict[str, np.ndarray]] = {}
         for t in msg.transforms:
             frame_id, child_frame_id, T = tf2np(t)
             timestamp_ns = int(t.header.stamp.sec * 1e9) + int(t.header.stamp.nanosec)
-            if timestamp_ns not in self.tf_messages:
-                self.tf_messages[timestamp_ns] = {}
-            self.tf_messages[timestamp_ns][f"{frame_id}->{child_frame_id}"] = T
-            tf_updated = True
+            if timestamp_ns not in tf_messages:
+                tf_messages[timestamp_ns] = {}
+            tf_messages[timestamp_ns][f"{frame_id}->{child_frame_id}"] = T
             if frame_id == "camera_link" and child_frame_id == "camera_infra1_frame":
                 T_infra1_to_link = T
             if frame_id == "camera_infra1_frame" and child_frame_id == "camera_infra1_optical_frame":
@@ -500,9 +494,8 @@ class BuildMapNode(Node):
 
         if T_infra1_optical_to_infra1 is not None and T_rgb_optical_to_rgb is not None and T_infra1_to_link is not None and T_rgb_to_link is not None:
             self.T_rgb_to_infra1 = np.linalg.inv(T_infra1_optical_to_infra1) @ np.linalg.inv(T_infra1_to_link) @ T_rgb_to_link @ T_rgb_optical_to_rgb
-        if tf_updated and self.T_rgb_to_infra1 is not None:
-            np.save(f"{self.map_save_path}/tf_messages.npy", self.tf_messages, allow_pickle=True)
-            self.tf_capture_completed = True
+        if tf_messages and self.T_rgb_to_infra1 is not None:
+            np.save(f"{self.map_save_path}/tf_messages.npy", tf_messages, allow_pickle=True)
             if self.tf_sub is not None:
                 self.destroy_subscription(self.tf_sub.sub)
                 self.tf_sub = None

--- a/tool/convert_to_colmap_format.py
+++ b/tool/convert_to_colmap_format.py
@@ -19,39 +19,7 @@ import cv2
 from typing import Dict, List, Tuple
 import shelve
 from tqdm import tqdm
-import json
-
-def convert_nerf_format(output_dir: str, poses: dict, intrinscis:np.ndarray, image_size: Tuple[int, int], T_rgb_to_infra1:np.ndarray):
-    camera_model = "PINHOLE"
-    fl_x = intrinscis[0, 0]
-    fl_y = intrinscis[1, 1]
-    cx = intrinscis[0, 2]
-    cy = intrinscis[1, 2]
-    w = image_size[1]
-    h = image_size[0]
-    frames = []
-    opencv_to_opengl_convention = np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
-    for timestmap, camera_to_world_pose in poses.items():
-        camera_to_world_opengl = camera_to_world_pose @ T_rgb_to_infra1 @ opencv_to_opengl_convention
-        frame = {
-            "file_path": f"images/image_{timestmap}.png",
-            "transform_matrix": camera_to_world_opengl.tolist(),
-        }
-        frames.append(frame)
-
-    data = {
-        "camera_model": camera_model,
-        "fl_x": fl_x,
-        "fl_y": fl_y,
-        "cx": cx,
-        "cy": cy,
-        "w": w,
-        "h": h,
-        "frames": frames
-    }
-
-    with open(f"{output_dir}/transforms.json", "w") as f:
-        json.dump(data, f, indent=4)
+from convert_to_nerf_format import convert_nerf_format
 
 
 
@@ -369,5 +337,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-
 

--- a/tool/convert_to_nerf_format.py
+++ b/tool/convert_to_nerf_format.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Convert TinyNav map artifacts into NeRF/Nerfstudio transforms.json format.
+
+Usage:
+    python tool/convert_to_nerf_format.py --map-dir tinynav_map
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+import cv2
+import numpy as np
+import shelve
+
+
+def convert_nerf_format(
+    output_dir: Path,
+    poses: Dict[int, np.ndarray],
+    intrinsics: np.ndarray,
+    image_size: Tuple[int, int],
+    t_rgb_to_infra1: np.ndarray,
+) -> None:
+    camera_model = "PINHOLE"
+    fl_x = float(intrinsics[0, 0])
+    fl_y = float(intrinsics[1, 1])
+    cx = float(intrinsics[0, 2])
+    cy = float(intrinsics[1, 2])
+    h = int(image_size[0])
+    w = int(image_size[1])
+    frames = []
+    opencv_to_opengl_convention = np.array(
+        [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]],
+        dtype=np.float64,
+    )
+
+    for timestamp, camera_to_world_pose in poses.items():
+        camera_to_world_opengl = (
+            camera_to_world_pose @ t_rgb_to_infra1 @ opencv_to_opengl_convention
+        )
+        frames.append(
+            {
+                "file_path": f"images/image_{timestamp}.png",
+                "transform_matrix": camera_to_world_opengl.tolist(),
+            }
+        )
+
+    data = {
+        "camera_model": camera_model,
+        "fl_x": fl_x,
+        "fl_y": fl_y,
+        "cx": cx,
+        "cy": cy,
+        "w": w,
+        "h": h,
+        "frames": frames,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with (output_dir / "transforms.json").open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+
+
+def infer_image_size(images_dir: Path) -> Tuple[int, int]:
+    image_candidates = sorted(images_dir.glob("image_*.png"))
+    if not image_candidates:
+        raise FileNotFoundError(f"No image_*.png found under: {images_dir}")
+
+    image = cv2.imread(str(image_candidates[0]), cv2.IMREAD_UNCHANGED)
+    if image is None:
+        raise RuntimeError(f"Failed to read image: {image_candidates[0]}")
+    return image.shape[:2]
+
+
+def export_rgb_images(
+    map_dir: Path,
+    images_dir: Path,
+    timestamps: list[int],
+) -> Tuple[int, int]:
+    images_dir.mkdir(parents=True, exist_ok=True)
+    image_size = None
+    with shelve.open(str(map_dir / "rgb_images")) as rgb_db:
+        for timestamp in timestamps:
+            key = str(timestamp)
+            if key not in rgb_db:
+                raise KeyError(f"Missing rgb image for timestamp {timestamp} in {map_dir / 'rgb_images'}")
+            rgb_image = rgb_db[key]
+            if image_size is None:
+                image_size = rgb_image.shape[:2]
+            cv2.imwrite(str(images_dir / f"image_{timestamp}.png"), rgb_image)
+
+    if image_size is None:
+        raise RuntimeError("No RGB images exported; poses may be empty")
+    return image_size
+
+
+def infer_t_rgb_to_infra1_from_tf_messages(
+    tf_messages: Dict[int, Dict[str, np.ndarray]]
+) -> np.ndarray:
+    latest_tf: Dict[str, np.ndarray] = {}
+    for timestamp_ns in sorted(tf_messages.keys()):
+        for edge_key, transform in tf_messages[timestamp_ns].items():
+            latest_tf[edge_key] = np.asarray(transform, dtype=np.float64)
+
+    # Looper bags use cam_left/cam_rgb directly as camera frames.
+    if "cam_left->cam_rgb" in latest_tf:
+        return latest_tf["cam_left->cam_rgb"]
+
+    required_keys = [
+        "camera_link->camera_infra1_frame",
+        "camera_infra1_frame->camera_infra1_optical_frame",
+        "camera_link->camera_color_frame",
+        "camera_color_frame->camera_color_optical_frame",
+    ]
+    missing = [k for k in required_keys if k not in latest_tf]
+    if missing:
+        raise KeyError(
+            "Missing TF edges in tf_messages.npy required to derive T_rgb_to_infra1: "
+            + ", ".join(missing)
+        )
+
+    t_infra1_to_link = latest_tf["camera_link->camera_infra1_frame"]
+    t_infra1_optical_to_infra1 = latest_tf[
+        "camera_infra1_frame->camera_infra1_optical_frame"
+    ]
+    t_rgb_to_link = latest_tf["camera_link->camera_color_frame"]
+    t_rgb_optical_to_rgb = latest_tf["camera_color_frame->camera_color_optical_frame"]
+    return (
+        np.linalg.inv(t_infra1_optical_to_infra1)
+        @ np.linalg.inv(t_infra1_to_link)
+        @ t_rgb_to_link
+        @ t_rgb_optical_to_rgb
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert TinyNav map directory to NeRF transforms.json"
+    )
+    parser.add_argument(
+        "--map-dir",
+        required=True,
+        help="TinyNav map directory containing poses.npy/intrinsics/images",
+    )
+    parser.add_argument(
+        "--images-dir",
+        default=None,
+        help="Override images directory (default: <map-dir>/images)",
+    )
+    parser.add_argument(
+        "--reuse-existing-images",
+        action="store_true",
+        help="Do not export from rgb_images shelve; reuse existing image_*.png files",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    map_dir = Path(args.map_dir)
+    images_dir = Path(args.images_dir) if args.images_dir else map_dir / "images"
+
+    poses = np.load(map_dir / "poses.npy", allow_pickle=True).item()
+    intrinsics = np.load(map_dir / "rgb_camera_intrinsics.npy", allow_pickle=True)
+    tf_messages_path = map_dir / "tf_messages.npy"
+    if tf_messages_path.exists():
+        tf_messages = np.load(tf_messages_path, allow_pickle=True).item()
+        t_rgb_to_infra1 = infer_t_rgb_to_infra1_from_tf_messages(tf_messages)
+        print(f"Using TF data from {tf_messages_path} to derive T_rgb_to_infra1")
+    else:
+        t_rgb_to_infra1 = np.load(map_dir / "T_rgb_to_infra1.npy", allow_pickle=True)
+        print("tf_messages.npy not found; using T_rgb_to_infra1.npy")
+    timestamps = sorted(int(k) for k in poses.keys())
+    if args.reuse_existing_images:
+        image_size = infer_image_size(images_dir)
+    else:
+        image_size = export_rgb_images(map_dir, images_dir, timestamps)
+
+    convert_nerf_format(
+        output_dir=map_dir,
+        poses=poses,
+        intrinsics=intrinsics,
+        image_size=image_size,
+        t_rgb_to_infra1=t_rgb_to_infra1,
+    )
+    print(f"Wrote NeRF transforms to {map_dir / 'transforms.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/convert_to_nerf_format.py
+++ b/tool/convert_to_nerf_format.py
@@ -14,6 +14,7 @@ from typing import Dict, Tuple
 import cv2
 import numpy as np
 import shelve
+from tqdm import tqdm
 
 
 def convert_nerf_format(
@@ -82,7 +83,7 @@ def export_rgb_images(
     images_dir.mkdir(parents=True, exist_ok=True)
     image_size = None
     with shelve.open(str(map_dir / "rgb_images")) as rgb_db:
-        for timestamp in timestamps:
+        for timestamp in tqdm(timestamps, desc="Exporting RGB images", unit="img"):
             key = str(timestamp)
             if key not in rgb_db:
                 raise KeyError(f"Missing rgb image for timestamp {timestamp} in {map_dir / 'rgb_images'}")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.12, <3.11"
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'darwin'",
@@ -2668,21 +2668,28 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
-    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5d/45a3553a253ac8763f3561371432a90bdbe6000fbdcf1397ffe502aa206c/pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860", size = 5316554, upload-time = "2025-07-01T09:13:39.342Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c8/67c12ab069ef586a25a4a79ced553586748fad100c77c0ce59bb4983ac98/pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad", size = 4686548, upload-time = "2025-07-01T09:13:41.835Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/6741ebd56263390b382ae4c5de02979af7f8bd9807346d068700dd6d5cf9/pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0", size = 5859742, upload-time = "2025-07-03T13:09:47.439Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0b/c412a9e27e1e6a829e6ab6c2dca52dd563efbedf4c9c6aa453d9a9b77359/pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b", size = 7633087, upload-time = "2025-07-03T13:09:51.796Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9d/9b7076aaf30f5dd17e5e5589b2d2f5a5d7e30ff67a171eb686e4eecc2adf/pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50", size = 5963350, upload-time = "2025-07-01T09:13:43.865Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae", size = 6631840, upload-time = "2025-07-01T09:13:46.161Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e6/6ff7077077eb47fde78739e7d570bdcd7c10495666b6afcd23ab56b19a43/pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9", size = 6074005, upload-time = "2025-07-01T09:13:47.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/3a/b13f36832ea6d279a697231658199e0a03cd87ef12048016bdcc84131601/pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e", size = 6708372, upload-time = "2025-07-01T09:13:52.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e4/61b2e1a7528740efbc70b3d581f33937e38e98ef3d50b05007267a55bcb2/pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6", size = 6277090, upload-time = "2025-07-01T09:13:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d3/60c781c83a785d6afbd6a326ed4d759d141de43aa7365725cbcd65ce5e54/pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f", size = 6985988, upload-time = "2025-07-01T09:13:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/28/4f4a0203165eefb3763939c6789ba31013a2e90adffb456610f30f613850/pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f", size = 2422899, upload-time = "2025-07-01T09:13:57.497Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/209bd6b62ce8367f47e68a218bffac88888fdf2c9fcf1ecadc6c3ec1ebc7/pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967", size = 5270556, upload-time = "2025-07-01T09:16:09.961Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e6/231a0b76070c2cfd9e260a7a5b504fb72da0a95279410fa7afd99d9751d6/pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe", size = 4654625, upload-time = "2025-07-01T09:16:11.913Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f4/10cf94fda33cb12765f2397fc285fa6d8eb9c29de7f3185165b702fc7386/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c", size = 4874207, upload-time = "2025-07-03T13:11:10.201Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c9/583821097dc691880c92892e8e2d41fe0a5a3d6021f4963371d2f6d57250/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25", size = 6583939, upload-time = "2025-07-03T13:11:15.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8e/5c9d410f9217b12320efc7c413e72693f48468979a013ad17fd690397b9a/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27", size = 4957166, upload-time = "2025-07-01T09:16:13.74Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/78347dbe13219991877ffb3a91bf09da8317fbfcd4b5f9140aeae020ad71/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a", size = 5581482, upload-time = "2025-07-01T09:16:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/28/1000353d5e61498aaeaaf7f1e4b49ddb05f2c6575f9d4f9f914a3538b6e1/pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f", size = 6984596, upload-time = "2025-07-01T09:16:18.07Z" },
 ]
 
 [[package]]
@@ -3980,8 +3987,10 @@ dependencies = [
     { name = "lightglue" },
     { name = "nerfstudio" },
     { name = "newrawpy" },
+    { name = "pillow" },
     { name = "plyfile" },
     { name = "pymeshlab" },
+    { name = "torch" },
 ]
 lekiwi = [
     { name = "lerobot", extra = ["lekiwi"] },
@@ -4015,6 +4024,7 @@ requires-dist = [
     { name = "numpy", specifier = "==1.26.1" },
     { name = "opencv-python" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pillow", marker = "extra == '3dgs'", specifier = ">=10,<12" },
     { name = "plyfile" },
     { name = "plyfile", marker = "extra == '3dgs'" },
     { name = "pybind11" },
@@ -4023,6 +4033,7 @@ requires-dist = [
     { name = "reportlab", specifier = ">=4.4.3" },
     { name = "scipy" },
     { name = "tabulate" },
+    { name = "torch", marker = "extra == '3dgs'", specifier = ">=2.4,<2.11" },
     { name = "tyro" },
     { name = "unitree-sdk2py", marker = "extra == 'unitree'", git = "https://github.com/unitreerobotics/unitree_sdk2_python.git?rev=404fe44d76f705c002c97e773276f2a8fefb57e4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },


### PR DESCRIPTION
## Summary
Move NeRF dataset export responsibilities from runtime mapping node into offline tooling.

## What Changed
- Added `tool/convert_to_nerf_format.py`:
  - Exports `images/image_<timestamp>.png` from `rgb_images` shelve
  - Generates `transforms.json` for Nerfstudio/NeRF
  - Reads TF from `tf_messages.npy` to derive `T_rgb_to_infra1`
  - Falls back to `T_rgb_to_infra1.npy` when TF npy is missing
- Updated `tinynav/core/build_map_node.py`:
  - Removed in-node NeRF export and image dumping logic
  - Added saving of TF records to `tf_messages.npy` in `save_mapping()`
- Updated `scripts/run_3dgs_generation.sh` to run:
  - `uv run python tool/convert_to_nerf_format.py --map-dir "$data_path"`
- Updated `tool/convert_to_colmap_format.py` to reuse shared `convert_nerf_format` function.

## Why
- Keeps `build_map_node` focused on mapping outputs only.
- Makes NeRF/3DGS export reproducible and rerunnable offline.
- Removes duplicated conversion logic and centralizes format handling.

## Validation
- `python -m py_compile tinynav/core/build_map_node.py tool/convert_to_nerf_format.py tool/convert_to_colmap_format.py`
- `bash -n scripts/run_3dgs_generation.sh`

## Impact
- `build_map_node.py` no longer writes `images/` or `transforms.json` directly.
- NeRF export now happens via tool/script workflow.
