### PR TITLE
 feat(preview): live camera preview on Map tab  

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .state import runner
-from .routers import bag, device, nav
+from .routers import bag, device, nav, sensor
 from .routers import map as map_router
 from .routers import poi
 from . import ws
@@ -38,4 +38,5 @@ app.include_router(bag.router, prefix='/bag')
 app.include_router(map_router.router)
 app.include_router(poi.router)
 app.include_router(nav.router, prefix='/nav')
+app.include_router(sensor.router)
 app.include_router(ws.router)

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -120,14 +120,18 @@ class BackendNode(Ros2NodeManager):
     # ------------------------------------------------------------------ #
 
     def _detect_and_init_sensor(self):
+        domain = os.environ.get('ROS_DOMAIN_ID', '0')
+        self.get_logger().info(f'BackendNode ROS_DOMAIN_ID={domain}')
         try:
             result = subprocess.run(
                 ['ros2', 'node', 'list'], capture_output=True, text=True, timeout=3
             )
             if '/insight_full' in result.stdout.splitlines():
                 self._sensor_mode = 'looper'
+                self.get_logger().info('Sensor mode: looper')
             else:
                 self._sensor_mode = 'realsense'
+                self.get_logger().info('Sensor mode: realsense — launching driver and perception')
                 self._realsense_proc = subprocess.Popen(['bash', _REALSENSE_SCRIPT])
                 self._perception_proc = subprocess.Popen(
                     ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py']

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -24,6 +24,7 @@ from std_msgs.msg import Float32, String
 from tool.ros2_node_manager import Ros2NodeManager
 
 _REALSENSE_SCRIPT = '/tinynav/scripts/run_realsense_sensor.sh'
+_VENV_SITE = '/tinynav/.venv/lib/python3.10/site-packages'
 _IMAGE_TOPICS_ALL = [
     '/camera/camera/color/image_raw',
     '/camera/camera/infra1/image_rect_raw',
@@ -135,9 +136,13 @@ class BackendNode(Ros2NodeManager):
                 self._realsense_proc = subprocess.Popen(
                     ['bash', _REALSENSE_SCRIPT], preexec_fn=os.setsid
                 )
+                _env = os.environ.copy()
+                _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
                 self._perception_proc = subprocess.Popen(
                     ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py'],
                     preexec_fn=os.setsid,
+                    cwd='/tinynav',
+                    env=_env,
                 )
         except Exception as e:
             self.get_logger().warn(f'Sensor detection failed: {e}')

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -25,8 +25,10 @@ from tool.ros2_node_manager import Ros2NodeManager
 
 _REALSENSE_SCRIPT = '/tinynav/scripts/run_realsense_sensor.sh'
 _IMAGE_TOPICS_ALL = [
-    '/camera/camera/infra1/image_rect_raw',
     '/camera/camera/color/image_raw',
+    '/camera/camera/infra1/image_rect_raw',
+    '/camera/camera/infra2/image_rect_raw',
+    '/camera/camera/depth/image_rect_raw',
 ]
 _PREVIEW_MIN_INTERVAL = 0.2  # 5 fps
 

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -132,9 +132,12 @@ class BackendNode(Ros2NodeManager):
             else:
                 self._sensor_mode = 'realsense'
                 self.get_logger().info('Sensor mode: realsense — launching driver and perception')
-                self._realsense_proc = subprocess.Popen(['bash', _REALSENSE_SCRIPT])
+                self._realsense_proc = subprocess.Popen(
+                    ['bash', _REALSENSE_SCRIPT], preexec_fn=os.setsid
+                )
                 self._perception_proc = subprocess.Popen(
-                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py']
+                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py'],
+                    preexec_fn=os.setsid,
                 )
         except Exception as e:
             self.get_logger().warn(f'Sensor detection failed: {e}')
@@ -278,6 +281,10 @@ class NodeRunner:
             for proc in (self.node._realsense_proc, self.node._perception_proc):
                 if proc and proc.poll() is None:
                     try:
-                        proc.terminate()
+                        os.killpg(os.getpgid(proc.pid), 15)
+                        proc.wait(timeout=2)
                     except Exception:
-                        pass
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -128,15 +128,9 @@ class BackendNode(Ros2NodeManager):
                 self._sensor_mode = 'looper'
             else:
                 self._sensor_mode = 'realsense'
-                self._realsense_proc = subprocess.Popen(
-                    ['bash', _REALSENSE_SCRIPT],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-                self._perception_proc = subprocess.Popen(
-                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py'],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
+                self._realsense_proc = self._spawn(['bash', _REALSENSE_SCRIPT])
+                self._perception_proc = self._spawn(
+                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py']
                 )
         except Exception as e:
             self.get_logger().warn(f'Sensor detection failed: {e}')

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -6,16 +6,29 @@ from __future__ import annotations
 
 import math
 import os
+import subprocess
 import sys
 import threading
+import time
+
+import cv2
+import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 import rclpy
 from nav_msgs.msg import Odometry
+from sensor_msgs.msg import Image
 from std_msgs.msg import Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
+
+_REALSENSE_SCRIPT = '/tinynav/scripts/run_realsense_sensor.sh'
+_IMAGE_TOPICS_ALL = [
+    '/camera/camera/infra1/image_rect_raw',
+    '/camera/camera/color/image_raw',
+]
+_PREVIEW_MIN_INTERVAL = 0.2  # 5 fps
 
 
 class BackendNode(Ros2NodeManager):
@@ -32,6 +45,7 @@ class BackendNode(Ros2NodeManager):
         # Keep them cheap — just put data on a queue or set an event.
         self.pose_callbacks: list = []
         self.state_callbacks: list = []
+        self.preview_callbacks: dict[str, list] = {}  # topic -> [callbacks]
 
         self.create_subscription(Float32, '/mapping/percent', self._on_mapping_percent, 10)
         self.create_subscription(Odometry, '/slam/odometry', self._on_slam_odom, 10)
@@ -41,6 +55,14 @@ class BackendNode(Ros2NodeManager):
 
         # Publisher for nav target (consumed by map_node in the future)
         self._nav_target_pub = self.create_publisher(String, '/service/nav_target', 10)
+
+        # Sensor mode detection and image subscriptions
+        self._sensor_mode: str = 'unknown'  # 'looper' | 'realsense' | 'unknown'
+        self._image_subs: dict = {}
+        self._last_frame: dict[str, bytes] = {}   # topic -> latest JPEG bytes
+        self._last_frame_time: dict[str, float] = {}
+        self._realsense_proc: subprocess.Popen | None = None
+        self._detect_and_init_sensor()
 
     # ------------------------------------------------------------------ #
     # ROS callbacks                                                        #
@@ -89,6 +111,72 @@ class BackendNode(Ros2NodeManager):
             'timestamp': msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9,
             'source': source,
         }
+
+    # ------------------------------------------------------------------ #
+    # Sensor / camera                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _detect_and_init_sensor(self):
+        try:
+            result = subprocess.run(
+                ['ros2', 'node', 'list'], capture_output=True, text=True, timeout=3
+            )
+            if '/insight_full' in result.stdout.splitlines():
+                self._sensor_mode = 'looper'
+            else:
+                self._sensor_mode = 'realsense'
+                self._realsense_proc = subprocess.Popen(
+                    ['bash', _REALSENSE_SCRIPT],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+        except Exception as e:
+            self.get_logger().warn(f'Sensor detection failed: {e}')
+            self._sensor_mode = 'unknown'
+
+        for topic in _IMAGE_TOPICS_ALL:
+            self._image_subs[topic] = self.create_subscription(
+                Image, topic,
+                lambda msg, t=topic: self._on_image(msg, t),
+                1,
+            )
+            self._last_frame[topic] = b''
+            self._last_frame_time[topic] = 0.0
+            self.preview_callbacks[topic] = []
+
+    def _on_image(self, msg: Image, topic: str):
+        now = time.time()
+        if now - self._last_frame_time.get(topic, 0.0) < _PREVIEW_MIN_INTERVAL:
+            return
+        self._last_frame_time[topic] = now
+
+        try:
+            arr = np.frombuffer(msg.data, dtype=np.uint8).reshape(msg.height, msg.width, -1)
+            if arr.shape[2] == 1:
+                arr = arr[:, :, 0]
+            _, buf = cv2.imencode('.jpg', arr, [cv2.IMWRITE_JPEG_QUALITY, 50])
+            frame = buf.tobytes()
+        except Exception:
+            return
+
+        with self._lock:
+            self._last_frame[topic] = frame
+
+        for cb in self.preview_callbacks.get(topic, []):
+            try:
+                cb(frame)
+            except Exception:
+                pass
+
+    def get_sensor_mode(self) -> str:
+        return self._sensor_mode
+
+    def get_image_topics(self) -> list[str]:
+        return _IMAGE_TOPICS_ALL
+
+    def get_preview_frame(self, topic: str) -> bytes:
+        with self._lock:
+            return self._last_frame.get(topic, b'')
 
     # ------------------------------------------------------------------ #
     # Command API (called from FastAPI handlers — thread-safe enough)     #
@@ -181,3 +269,8 @@ class NodeRunner:
                 self.node.destroy_node()
             except Exception:
                 pass
+            if self.node._realsense_proc and self.node._realsense_proc.poll() is None:
+                try:
+                    self.node._realsense_proc.terminate()
+                except Exception:
+                    pass

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -128,8 +128,8 @@ class BackendNode(Ros2NodeManager):
                 self._sensor_mode = 'looper'
             else:
                 self._sensor_mode = 'realsense'
-                self._realsense_proc = self._spawn(['bash', _REALSENSE_SCRIPT])
-                self._perception_proc = self._spawn(
+                self._realsense_proc = subprocess.Popen(['bash', _REALSENSE_SCRIPT])
+                self._perception_proc = subprocess.Popen(
                     ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py']
                 )
         except Exception as e:

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -28,7 +28,7 @@ _IMAGE_TOPICS_ALL = [
     '/camera/camera/color/image_raw',
     '/camera/camera/infra1/image_rect_raw',
     '/camera/camera/infra2/image_rect_raw',
-    '/camera/camera/depth/image_rect_raw',
+    '/slam/depth',
 ]
 _PREVIEW_MIN_INTERVAL = 0.2  # 5 fps
 
@@ -64,6 +64,7 @@ class BackendNode(Ros2NodeManager):
         self._last_frame: dict[str, bytes] = {}   # topic -> latest JPEG bytes
         self._last_frame_time: dict[str, float] = {}
         self._realsense_proc: subprocess.Popen | None = None
+        self._perception_proc: subprocess.Popen | None = None
         self._detect_and_init_sensor()
 
     # ------------------------------------------------------------------ #
@@ -129,6 +130,11 @@ class BackendNode(Ros2NodeManager):
                 self._sensor_mode = 'realsense'
                 self._realsense_proc = subprocess.Popen(
                     ['bash', _REALSENSE_SCRIPT],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                self._perception_proc = subprocess.Popen(
+                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py'],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
@@ -271,8 +277,9 @@ class NodeRunner:
                 self.node.destroy_node()
             except Exception:
                 pass
-            if self.node._realsense_proc and self.node._realsense_proc.poll() is None:
-                try:
-                    self.node._realsense_proc.terminate()
-                except Exception:
-                    pass
+            for proc in (self.node._realsense_proc, self.node._perception_proc):
+                if proc and proc.poll() is None:
+                    try:
+                        proc.terminate()
+                    except Exception:
+                        pass

--- a/app/backend/routers/sensor.py
+++ b/app/backend/routers/sensor.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from ..state import runner
+
+router = APIRouter(tags=['sensor'])
+
+
+@router.get('/sensor/mode')
+def get_sensor_mode():
+    node = runner.node
+    return {'mode': node.get_sensor_mode() if node else 'unknown'}
+
+
+@router.get('/sensor/image-topics')
+def get_image_topics():
+    node = runner.node
+    return {'topics': node.get_image_topics() if node else []}

--- a/app/backend/ws.py
+++ b/app/backend/ws.py
@@ -3,6 +3,7 @@ WebSocket endpoints:
   WS /ws/status      — pushes device status every ~1 s
   WS /ws/pose        — pushes pose whenever a new Odometry arrives
   WS /ws/map-update  — pushes a notification when map files change
+  WS /ws/preview     — streams JPEG frames for a given image topic
 """
 from __future__ import annotations
 
@@ -11,7 +12,7 @@ import json
 import os
 import time
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
 
 from .state import runner
 
@@ -106,3 +107,39 @@ async def ws_map_update(ws: WebSocket):
             await asyncio.sleep(2.0)
     except WebSocketDisconnect:
         pass
+
+
+# --------------------------------------------------------------------------- #
+# /ws/preview  — streams JPEG frames for a given image topic                  #
+# --------------------------------------------------------------------------- #
+
+@router.websocket('/ws/preview')
+async def ws_preview(ws: WebSocket, topic: str = Query(...)):
+    await ws.accept()
+
+    node = runner.node
+    if node is None or topic not in node.preview_callbacks:
+        await ws.close(code=1013)
+        return
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=4)
+    loop = asyncio.get_event_loop()
+
+    def _on_frame(frame: bytes):
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, frame)
+        except Exception:
+            pass
+
+    node.preview_callbacks[topic].append(_on_frame)
+    try:
+        while True:
+            frame = await queue.get()
+            await ws.send_bytes(frame)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        try:
+            node.preview_callbacks[topic].remove(_on_frame)
+        except ValueError:
+            pass

--- a/app/frontend/lib/core/providers.dart
+++ b/app/frontend/lib/core/providers.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -66,6 +67,53 @@ final mapInfoProvider = FutureProvider.autoDispose<MapInfo?>((ref) async {
     if (e.response?.statusCode == 404 || e.response?.statusCode == 503) return null;
     rethrow;
   }
+});
+
+/// Sensor mode: 'looper' | 'realsense' | 'unknown'
+final sensorModeProvider = FutureProvider.autoDispose<String>((ref) async {
+  final dio = ref.watch(dioProvider);
+  final baseUrl = ref.watch(baseUrlProvider);
+  if (baseUrl == null) return 'unknown';
+  try {
+    final resp = await dio.get('/sensor/mode');
+    return (resp.data['mode'] as String?) ?? 'unknown';
+  } catch (_) {
+    return 'unknown';
+  }
+});
+
+/// Available image topics from the backend.
+final imageTopicsProvider = FutureProvider.autoDispose<List<String>>((ref) async {
+  final dio = ref.watch(dioProvider);
+  final baseUrl = ref.watch(baseUrlProvider);
+  if (baseUrl == null) return [];
+  try {
+    final resp = await dio.get('/sensor/image-topics');
+    return (resp.data['topics'] as List).cast<String>();
+  } catch (_) {
+    return [];
+  }
+});
+
+/// Currently selected preview topic (null = preview closed).
+final selectedPreviewTopicProvider = StateProvider<String?>((ref) => null);
+
+/// Streams raw JPEG bytes from WS /ws/preview?topic=<topic>.
+final previewStreamProvider =
+    StreamProvider.family.autoDispose<Uint8List, String>((ref, topic) {
+  final ip = ref.watch(deviceIpProvider);
+  if (ip == null) return const Stream.empty();
+
+  final encoded = Uri.encodeQueryComponent(topic);
+  final channel =
+      WebSocketChannel.connect(Uri.parse('ws://$ip:8000/ws/preview?topic=$encoded'));
+  ref.onDispose(() => channel.sink.close());
+
+  return channel.stream.map((data) {
+    if (data is Uint8List) return data;
+    if (data is List<int>) return Uint8List.fromList(data);
+    return Uint8List(0);
+  }).where((b) => b.isNotEmpty);
 });
 
 /// One-shot fetch of POI list from GET /map/pois.

--- a/app/frontend/lib/pages/map_tab.dart
+++ b/app/frontend/lib/pages/map_tab.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,40 +18,47 @@ class MapTab extends ConsumerWidget {
     final poseAsync = ref.watch(poseStreamProvider);
     final baseUrl = ref.watch(baseUrlProvider);
 
-    return RefreshIndicator(
-      onRefresh: () async {
-        ref.invalidate(mapInfoProvider);
-        ref.invalidate(poisProvider);
-      },
-      child: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // Map image
-          mapAsync.when(
-            data: (mapInfo) => mapInfo == null
-                ? const _NoMapCard()
-                : _MapView(
-                    mapInfo: mapInfo,
-                    imageUrl: '${baseUrl!}${mapInfo.imageUrl}',
-                    pose: poseAsync.valueOrNull,
-                    pois: poisAsync.valueOrNull ?? [],
+    return Stack(
+      children: [
+        RefreshIndicator(
+          onRefresh: () async {
+            ref.invalidate(mapInfoProvider);
+            ref.invalidate(poisProvider);
+          },
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              mapAsync.when(
+                data: (mapInfo) => mapInfo == null
+                    ? const _NoMapCard()
+                    : _MapView(
+                        mapInfo: mapInfo,
+                        imageUrl: '${baseUrl!}${mapInfo.imageUrl}',
+                        pose: poseAsync.valueOrNull,
+                        pois: poisAsync.valueOrNull ?? [],
+                      ),
+                loading: () => const Card(
+                  child: Padding(padding: EdgeInsets.all(48), child: Center(child: CircularProgressIndicator())),
+                ),
+                error: (e, _) => Card(
+                  color: Colors.red.shade50,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Text('$e', style: const TextStyle(color: Colors.red)),
                   ),
-            loading: () => const Card(
-              child: Padding(padding: EdgeInsets.all(48), child: Center(child: CircularProgressIndicator())),
-            ),
-            error: (e, _) => Card(
-              color: Colors.red.shade50,
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text('$e', style: const TextStyle(color: Colors.red)),
+                ),
               ),
-            ),
+              const SizedBox(height: 12),
+              _PoiCard(poisAsync: poisAsync, pose: poseAsync.valueOrNull),
+            ],
           ),
-          const SizedBox(height: 12),
-          // POI management
-          _PoiCard(poisAsync: poisAsync, pose: poseAsync.valueOrNull),
-        ],
-      ),
+        ),
+        const Positioned(
+          right: 12,
+          bottom: 16,
+          child: _CameraPreviewPip(),
+        ),
+      ],
     );
   }
 }
@@ -126,6 +135,109 @@ class _NoMapCard extends StatelessWidget {
               style: TextStyle(color: Colors.grey, fontSize: 12)),
         ]),
       ),
+    );
+  }
+}
+
+// ── Camera PiP ───────────────────────────────────────────────────────────────
+
+class _CameraPreviewPip extends ConsumerStatefulWidget {
+  const _CameraPreviewPip();
+
+  @override
+  ConsumerState<_CameraPreviewPip> createState() => _CameraPreviewPipState();
+}
+
+class _CameraPreviewPipState extends ConsumerState<_CameraPreviewPip> {
+  Uint8List? _latestFrame;
+
+  @override
+  Widget build(BuildContext context) {
+    final topicsAsync = ref.watch(imageTopicsProvider);
+    final selectedTopic = ref.watch(selectedPreviewTopicProvider);
+    final topics = topicsAsync.valueOrNull ?? [];
+
+    // Listen to preview stream when a topic is selected.
+    if (selectedTopic != null) {
+      ref.listen<AsyncValue<Uint8List>>(
+        previewStreamProvider(selectedTopic),
+        (_, next) {
+          if (next case AsyncData(:final value)) {
+            if (mounted) setState(() => _latestFrame = value);
+          }
+        },
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        // Topic selector row
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.black87,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.videocam_outlined, color: Colors.white70, size: 14),
+              const SizedBox(width: 4),
+              DropdownButton<String?>(
+                value: selectedTopic,
+                hint: const Text('Camera', style: TextStyle(color: Colors.white54, fontSize: 12)),
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+                dropdownColor: Colors.black87,
+                underline: const SizedBox(),
+                isDense: true,
+                items: [
+                  const DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text('Off', style: TextStyle(color: Colors.white54, fontSize: 12)),
+                  ),
+                  ...topics.map((t) {
+                    final label = t.split('/').last;
+                    return DropdownMenuItem<String?>(
+                      value: t,
+                      child: Text(label, style: const TextStyle(fontSize: 12)),
+                    );
+                  }),
+                ],
+                onChanged: (v) {
+                  ref.read(selectedPreviewTopicProvider.notifier).state = v;
+                  if (v == null) setState(() => _latestFrame = null);
+                },
+              ),
+            ],
+          ),
+        ),
+        // Preview frame
+        if (selectedTopic != null)
+          ClipRRect(
+            borderRadius: const BorderRadius.vertical(bottom: Radius.circular(8)),
+            child: SizedBox(
+              width: 176,
+              height: 132,
+              child: _latestFrame != null
+                  ? Image.memory(
+                      _latestFrame!,
+                      fit: BoxFit.cover,
+                      gaplessPlayback: true,
+                    )
+                  : Container(
+                      color: Colors.black,
+                      child: const Center(
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white54,
+                        ),
+                      ),
+                    ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/app/frontend/lib/pages/map_tab.dart
+++ b/app/frontend/lib/pages/map_tab.dart
@@ -207,7 +207,13 @@ class _CameraPreviewPipState extends ConsumerState<_CameraPreviewPip> {
                     child: Text('Off', style: TextStyle(color: Colors.white54, fontSize: 12)),
                   ),
                   ...topics.map((t) {
-                    final label = t.split('/').last;
+                    const labels = {
+                      '/camera/camera/color/image_raw': 'color',
+                      '/camera/camera/infra1/image_rect_raw': 'left',
+                      '/camera/camera/infra2/image_rect_raw': 'right',
+                      '/camera/camera/depth/image_rect_raw': 'depth',
+                    };
+                    final label = labels[t] ?? t.split('/').last;
                     return DropdownMenuItem<String?>(
                       value: t,
                       child: Text(label, style: const TextStyle(fontSize: 12)),
@@ -240,11 +246,16 @@ class _CameraPreviewPipState extends ConsumerState<_CameraPreviewPip> {
                             fit: BoxFit.cover,
                             gaplessPlayback: true,
                           ),
-                          const Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: EdgeInsets.all(4),
-                              child: Icon(Icons.fullscreen, color: Colors.white70, size: 16),
+                          Align(
+                            alignment: Alignment.bottomRight,
+                            child: Container(
+                              margin: const EdgeInsets.all(4),
+                              decoration: BoxDecoration(
+                                color: Colors.black54,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              padding: const EdgeInsets.all(2),
+                              child: const Icon(Icons.fullscreen, color: Colors.white, size: 20),
                             ),
                           ),
                         ],

--- a/app/frontend/lib/pages/map_tab.dart
+++ b/app/frontend/lib/pages/map_tab.dart
@@ -211,7 +211,7 @@ class _CameraPreviewPipState extends ConsumerState<_CameraPreviewPip> {
                       '/camera/camera/color/image_raw': 'color',
                       '/camera/camera/infra1/image_rect_raw': 'left',
                       '/camera/camera/infra2/image_rect_raw': 'right',
-                      '/camera/camera/depth/image_rect_raw': 'depth',
+                      '/slam/depth': 'depth',
                     };
                     final label = labels[t] ?? t.split('/').last;
                     return DropdownMenuItem<String?>(

--- a/app/frontend/lib/pages/map_tab.dart
+++ b/app/frontend/lib/pages/map_tab.dart
@@ -151,6 +151,15 @@ class _CameraPreviewPip extends ConsumerStatefulWidget {
 class _CameraPreviewPipState extends ConsumerState<_CameraPreviewPip> {
   Uint8List? _latestFrame;
 
+  void _showFullscreen(BuildContext context) {
+    final topic = ref.read(selectedPreviewTopicProvider);
+    if (topic == null) return;
+    showDialog(
+      context: context,
+      builder: (_) => _FullscreenPreview(topic: topic),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final topicsAsync = ref.watch(imageTopicsProvider);
@@ -215,29 +224,92 @@ class _CameraPreviewPipState extends ConsumerState<_CameraPreviewPip> {
         ),
         // Preview frame
         if (selectedTopic != null)
-          ClipRRect(
-            borderRadius: const BorderRadius.vertical(bottom: Radius.circular(8)),
-            child: SizedBox(
-              width: 176,
-              height: 132,
-              child: _latestFrame != null
-                  ? Image.memory(
-                      _latestFrame!,
-                      fit: BoxFit.cover,
-                      gaplessPlayback: true,
-                    )
-                  : Container(
-                      color: Colors.black,
-                      child: const Center(
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: Colors.white54,
+          GestureDetector(
+            onTap: _latestFrame != null ? () => _showFullscreen(context) : null,
+            child: ClipRRect(
+              borderRadius: const BorderRadius.vertical(bottom: Radius.circular(8)),
+              child: SizedBox(
+                width: 176,
+                height: 132,
+                child: _latestFrame != null
+                    ? Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          Image.memory(
+                            _latestFrame!,
+                            fit: BoxFit.cover,
+                            gaplessPlayback: true,
+                          ),
+                          const Align(
+                            alignment: Alignment.topRight,
+                            child: Padding(
+                              padding: EdgeInsets.all(4),
+                              child: Icon(Icons.fullscreen, color: Colors.white70, size: 16),
+                            ),
+                          ),
+                        ],
+                      )
+                    : Container(
+                        color: Colors.black,
+                        child: const Center(
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white54,
+                          ),
                         ),
                       ),
-                    ),
+              ),
             ),
           ),
       ],
+    );
+  }
+}
+
+// ── Fullscreen preview dialog ─────────────────────────────────────────────────
+
+class _FullscreenPreview extends ConsumerStatefulWidget {
+  final String topic;
+  const _FullscreenPreview({required this.topic});
+
+  @override
+  ConsumerState<_FullscreenPreview> createState() => _FullscreenPreviewState();
+}
+
+class _FullscreenPreviewState extends ConsumerState<_FullscreenPreview> {
+  Uint8List? _frame;
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<Uint8List>>(
+      previewStreamProvider(widget.topic),
+      (_, next) {
+        if (next case AsyncData(:final value)) {
+          if (mounted) setState(() => _frame = value);
+        }
+      },
+    );
+
+    return Dialog(
+      backgroundColor: Colors.black,
+      insetPadding: const EdgeInsets.all(12),
+      child: Stack(
+        children: [
+          Center(
+            child: _frame != null
+                ? Image.memory(_frame!, fit: BoxFit.contain, gaplessPlayback: true)
+                : const CircularProgressIndicator(color: Colors.white54),
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: IconButton(
+              icon: const Icon(Icons.close, color: Colors.white),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                             
                                                                                                                                                                         
  - Backend detects sensor mode at startup (looper via /insight_full node, else realsense);
    in realsense mode auto-launches realsense driver + perception_node                                                                                                   
  - Subscribes to color / infra1 / infra2 / /slam/depth at 5 fps(temporarily), CPU JPEG encode (quality 50)
  - New endpoints: GET /sensor/mode, GET /sensor/image-topics                                                                                                            
  - New WS /ws/preview?topic=<topic> — streams binary JPEG frames to clients                                                                                             
  - Map tab: bottom-right PiP overlay with topic dropdown (color/left/right/depth),                                                                                      
    tap frame to open fullscreen dialog 

## Connect test jetson orin with rs435i

https://github.com/user-attachments/assets/01a288bb-f9af-4d2d-9c83-49e93bc7cb73

