### PR TITLE
refactor(mapping): remove unused edges tracking in build_map_node

### DIFF
--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -465,8 +465,6 @@ class BuildMapNode(Node):
         self.rgb_camera_info_sub.registerCallback(self.rgb_camera_info_callback)
         self.rgb_camera_K = None
 
-        self.edges = set()
-
     def tf_callback(self, msg:TFMessage):
         T_infra1_to_link = None
         T_infra1_optical_to_infra1 = None
@@ -578,7 +576,6 @@ class BuildMapNode(Node):
                 last_keyframe_odom_pose = self.odom[self.last_keyframe_timestamp]
                 T_prev_curr = np.linalg.inv(last_keyframe_odom_pose) @ odom
                 self.relative_pose_constraint.append((keyframe_image_timestamp, self.last_keyframe_timestamp, T_prev_curr))
-                self.edges.add((self.last_keyframe_timestamp, keyframe_image_timestamp))
                 self.pose_graph_used_pose[keyframe_image_timestamp] = odom
                 self.odom[keyframe_image_timestamp] = odom
 
@@ -602,7 +599,6 @@ class BuildMapNode(Node):
                             if success and len(inliers) >= 100:
                                 self.relative_pose_constraint.append((curr_timestamp, prev_timestamp, T_prev_curr))
                                 print(f"Added loop relative pose constraint: {curr_timestamp} -> {prev_timestamp}")
-                                self.edges.add((prev_timestamp, curr_timestamp))
                     with Timer(name = "solve pose graph", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
                         self.pose_graph_used_pose = solve_pose_graph(self.pose_graph_used_pose, self.relative_pose_constraint, max_iteration_num = 5)
                 find_loop_and_pose_graph(keyframe_image_timestamp)
@@ -677,8 +673,6 @@ class BuildMapNode(Node):
         print(f"T_rgb_to_infra1: {self.T_rgb_to_infra1}")
         np.save(f"{self.map_save_path}/T_rgb_to_infra1.npy", self.T_rgb_to_infra1, allow_pickle = True)
         np.save(f"{self.map_save_path}/rgb_camera_intrinsics.npy", self.rgb_camera_K, allow_pickle = True)
-        np.save(f"{self.map_save_path}/edges.npy", list(self.edges), allow_pickle = True)
-
         # Generate occupancy map
         occupancy_resolution = 0.05
         occupancy_step = 10


### PR DESCRIPTION
## Summary
Remove unused `edges` tracking from `build_map_node.py`.

## What Changed
- Removed `self.edges` member initialization.
- Removed appending edge tuples during sequential and loop-closure updates.
- Removed writing `edges.npy` during map save.

## Why
`edges` was no longer consumed by runtime logic or downstream tooling, so keeping it introduced unnecessary state and output artifacts.

## Impact
- No functional change to pose graph optimization or map outputs used by navigation.
- `edges.npy` is no longer emitted.
