### PR TITLE
docs(readme): add Looper Robotics sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 **TinyNav** : *A lightweight, hackable system to guide your robots anywhere.*
  Maintained by [Uniflex AI](https://x.com/UniflexAI).
+ Sponsored by [Looper Robotics](https://looper-robotics.com/).
 
 <h3>
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 **TinyNav** : *A lightweight, hackable system to guide your robots anywhere.*
  Maintained by [Uniflex AI](https://x.com/UniflexAI).
- Sponsored by [Looper Robotics](https://looper-robotics.com/).
 
 <h3>
 
@@ -368,4 +367,6 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 Thanks to our sponsor(s) for supporting the development of this project:
 
 **DeepMirror** - https://www.deepmirror.com/
+
+**Looper Robotics** - https://looper-robotics.com/
 


### PR DESCRIPTION
## Summary
- add Looper Robotics to the sponsor section in README.md

## Why
This keeps the project README aligned with current sponsorship information.