### PR TITLE
feat(mapping): align looper bridge replay with /insight/vio_20hz

### DIFF
--- a/scripts/run_rosbag_build_map.sh
+++ b/scripts/run_rosbag_build_map.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
+set -euo pipefail
+
 rosbag_path=$(uv run hf download --repo-type dataset --cache-dir /tinynav UniflexAI/rosbag2_go2_looper)
 map_save_path=/tinynav/output/map_go2_looper
+
+mode="${1:-perception}" # looper_direct | perception
+
+if [[ "${mode}" == "looper_direct" ]]; then
+  source_cmd='uv run python /tinynav/tool/looper_bridge_node.py'
+elif [[ "${mode}" == "perception" ]]; then
+  source_cmd='uv run python /tinynav/tinynav/core/perception_node.py'
+else
+  echo "Usage: $0 [looper_direct|perception]"
+  exit 1
+fi
 
 tmux new-session \; \
   split-window -h \; \
   split-window -v \; \
   select-pane -t 0 \; split-window -v \; \
-  select-pane -t 0 \; send-keys 'uv run python /tinynav/tinynav/core/perception_node.py' C-m \; \
   select-pane -t 1 \; send-keys "uv run python /tinynav/tinynav/core/build_map_node.py --map_save_path $map_save_path --bag_file $rosbag_path" C-m \; \
+  select-pane -t 2 \; send-keys "${source_cmd}" C-m \; \
   select-pane -t 3 \; send-keys 'ros2 run rviz2 rviz2 -d /tinynav/docs/vis.rviz' C-m

--- a/scripts/run_rosbag_record.sh
+++ b/scripts/run_rosbag_record.sh
@@ -17,10 +17,12 @@ ros2 bag record \
     /camera/camera/infra2/camera_info \
     /camera/camera/infra2/image_rect_raw \
     /camera/camera/infra2/metadata \
+    /camera/camera/depth/image_rect_raw \
     /camera/camera/extrinsics/depth_to_infra1 \
     /camera/camera/extrinsics/depth_to_infra2 \
     /camera/camera/imu \
     /camera/camera/color/image_raw \
     /camera/camera/color/camera_info \
     /camera/camera/color/image_rect_raw/compressed \
+    /insight/vio_20hz \
     /tf_static

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -329,6 +329,10 @@ class BagPlayer(Node):
             pub = self.create_publisher(msg_type, topic_info.name, 10)
             self._topic_publishers[topic_info.name] = (pub, msg_type)
 
+        self.get_logger().info("Bag topics and message types:")
+        for topic_info in sorted(topic_infos, key=lambda t: t.name):
+            self.get_logger().info(f"  {topic_info.name} -> {topic_info.type}")
+
         # /clock publisher (for use_sim_time)
         self._clock_pub = self.create_publisher(Clock, "/clock", 10)
         self._mapping_percent_pub = self.create_publisher(Float32, "/mapping/percent", 10)

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -110,7 +110,7 @@ class LooperBridgeNode(Node):
         return float(stamp.sec) + float(stamp.nanosec) * 1e-9
 
     def should_add_keyframe(self, T_world_camera: np.ndarray, stamp) -> bool:
-        if self.last_keyframe_pose is None:
+        if self.last_keyframe_pose is None or self.last_keyframe_time is None:
             return True
         current_time = self.stamp_to_sec(stamp)
         translation = np.linalg.norm(

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -1,6 +1,5 @@
 import argparse
 import copy
-from collections import deque
 
 import cv2
 import message_filters
@@ -10,11 +9,10 @@ from cv_bridge import CvBridge
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
-from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.qos import QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CameraInfo, Image
-from tf2_msgs.msg import TFMessage
 
-from tinynav.core.math_utils import np2msg, pose_msg2np, tf2np
+from tinynav.core.math_utils import np2msg, pose_msg2np
 
 
 class LooperBridgeNode(Node):
@@ -23,10 +21,7 @@ class LooperBridgeNode(Node):
         self.args = args
         self.bridge = CvBridge()
 
-        self.depth_frame_id = None
         self.cached_camera_info = None
-        self.T_i_depth = None
-        self.tf_edges = {}
         self.last_keyframe_pose = None
         self.last_keyframe_time = None
         self.last_pose = None
@@ -34,18 +29,11 @@ class LooperBridgeNode(Node):
         self._missing_input_counter = 0
 
         self.sensor_qos = QoSProfile(depth=50, reliability=ReliabilityPolicy.RELIABLE)
-        self.tf_static_qos = QoSProfile(
-            history=HistoryPolicy.KEEP_LAST,
-            depth=1,
-            reliability=ReliabilityPolicy.RELIABLE,
-            durability=DurabilityPolicy.TRANSIENT_LOCAL,
-        )
 
         self.camera_info_sub = self.create_subscription(CameraInfo, "/camera/camera/infra1/camera_info", self.camera_info_callback, self.sensor_qos)
-        self.tf_static_sub = self.create_subscription(TFMessage, "/tf_static", self.tf_callback, self.tf_static_qos)
 
         self.depth_sub = message_filters.Subscriber(self, Image, "/camera/camera/depth/image_rect_raw", qos_profile=self.sensor_qos)
-        self.pose_sub = message_filters.Subscriber(self, PoseStamped, "/insight/vio_pose")
+        self.pose_sub = message_filters.Subscriber(self, PoseStamped, "/insight/vio_20hz")
         self.image_sub = message_filters.Subscriber(self, Image, "/camera/camera/infra1/image_rect_raw", qos_profile=self.sensor_qos)
         self.sync = message_filters.ApproximateTimeSynchronizer(
             [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20, slop=0.08
@@ -64,73 +52,22 @@ class LooperBridgeNode(Node):
         self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
 
         self.get_logger().info(
-            "Bridging /insight/vio_pose + /camera/camera/depth/image_rect_raw + /camera/camera/infra1/image_rect_raw into TinyNav /slam topics."
+            "Bridging /insight/vio_20hz + /camera/camera/depth/image_rect_raw + /camera/camera/infra1/image_rect_raw into TinyNav /slam topics."
         )
 
     def camera_info_callback(self, msg: CameraInfo):
         self.cached_camera_info = msg
-        if msg.header.frame_id:
-            self.depth_frame_id = msg.header.frame_id
-        self.try_update_depth_transform()
         self.get_logger().info(
             f"Received camera info from /camera/camera/infra1/camera_info with frame {msg.header.frame_id}.",
             once=True,
         )
 
-    def tf_callback(self, msg: TFMessage):
-        for transform in msg.transforms:
-            frame_id, child_frame_id, T = tf2np(transform)
-            self.store_transform(frame_id, child_frame_id, T)
-        self.try_update_depth_transform()
-        self.get_logger().info("Received TF_STATIC for Looper bridge.", once=True)
-
-    def store_transform(self, parent_frame: str, child_frame: str, T: np.ndarray):
-        self.tf_edges.setdefault(parent_frame, {})[child_frame] = T.astype(np.float32, copy=False)
-        self.tf_edges.setdefault(child_frame, {})[parent_frame] = np.linalg.inv(T).astype(
-            np.float32, copy=False
-        )
-
-    def lookup_transform(self, source_frame: str, target_frame: str):
-        if source_frame == target_frame:
-            return np.eye(4, dtype=np.float32)
-        if source_frame not in self.tf_edges or target_frame not in self.tf_edges:
-            return None
-
-        queue = deque([(source_frame, np.eye(4, dtype=np.float32))])
-        visited = {source_frame}
-        while queue:
-            frame, T_source_frame = queue.popleft()
-            for next_frame, T_frame_next in self.tf_edges.get(frame, {}).items():
-                if next_frame in visited:
-                    continue
-                T_source_next = T_source_frame @ T_frame_next
-                if next_frame == target_frame:
-                    return T_source_next.astype(np.float32, copy=False)
-                visited.add(next_frame)
-                queue.append((next_frame, T_source_next))
-        return None
-
-    def try_update_depth_transform(self):
-        if self.depth_frame_id is None:
-            return
-        T_i_depth = self.lookup_transform("imu", self.depth_frame_id)
-        if T_i_depth is not None:
-            self.T_i_depth = T_i_depth
-            self.get_logger().info(
-                f"Resolved imu -> {self.depth_frame_id} transform for Looper bridge.",
-                once=True,
-            )
-
     def log_missing_inputs(self):
         self._missing_input_counter += 1
         if self._missing_input_counter % 30 != 1:
             return
-        missing = []
         if self.cached_camera_info is None:
-            missing.append("/camera/camera/infra1/camera_info")
-        if self.T_i_depth is None:
-            missing.append(f"imu->{self.depth_frame_id or 'depth'} TF")
-        self.get_logger().info(f"Waiting for Looper bridge inputs: {', '.join(missing)}")
+            self.get_logger().info("Waiting for Looper bridge inputs: /camera/camera/infra1/camera_info")
 
     @staticmethod
     def stamp_to_sec(stamp) -> float:
@@ -214,18 +151,23 @@ class LooperBridgeNode(Node):
         return disp_color_msg
 
     def sync_callback(self, depth_msg: Image, pose_msg: PoseStamped, image_msg: Image):
-        if self.cached_camera_info is None or self.T_i_depth is None:
+        if self.cached_camera_info is None:
             self.log_missing_inputs()
             return
 
-        T_world_imu = pose_msg2np(pose_msg)
-        T_world_camera = T_world_imu @ self.T_i_depth
+        T_world_camera = pose_msg2np(pose_msg)
         stamp = pose_msg.header.stamp
 
         odom_msg = self.build_odom(T_world_camera, stamp)
         depth_m = self.decode_depth_meters(depth_msg)
         depth_out = self.build_depth_msg(depth_m, stamp)
         disparity_vis_msg = self.build_disparity_vis(depth_m, stamp)
+
+        self.get_logger().info(
+            "sync_callback: "
+            f"t={self.stamp_to_sec(stamp):.3f}, "
+            f"depth={depth_m.shape}, image={image_msg.height}x{image_msg.width}"
+        )
 
         image_out = copy.deepcopy(image_msg)
         image_out.header.stamp = stamp


### PR DESCRIPTION
## Summary
- switch looper bridge pose source from `/insight/vio_pose` to `/insight/vio_20hz`
- simplify looper bridge by removing `/tf_static` dependency and using incoming pose directly
- add sync callback runtime logging for easier replay debugging
- update rosbag record topics to include `/camera/camera/depth/image_rect_raw` and `/insight/vio_20hz`
- add BagPlayer startup log of bag topic -> message type
- make `run_rosbag_build_map.sh` source selectable via mode: `perception` (default) or `looper_direct`

## Motivation
Ensure looper-based map replay uses the same VIO topic recorded in rosbag and make sync failures easier to diagnose.

## Testing
- `python -m py_compile tool/looper_bridge_node.py`
- `python -m py_compile tinynav/core/build_map_node.py`
- `bash -n scripts/run_rosbag_build_map.sh`

## Notes
- No changes to map serialization format.
- Existing perception-based flow remains available as default mode in the build-map script.
