### PR TITLE
fix(mapping): reduce build-map sync queue to prevent Jetson OOM

### DIFF
--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -435,7 +435,8 @@ class BuildMapNode(Node):
         # Add stop signal subscription and save finished publisher
         self.mapping_stop_sub = self.create_subscription(Bool, '/benchmark/stop', self.mapping_stop_callback, 10)
         self.mapping_save_finished_pub = self.create_publisher(Bool, '/benchmark/data_saved', 10)
-        self.ts = ApproximateTimeSynchronizer([self.keyframe_image_sub, self.keyframe_odom_sub, self.depth_sub, self.rgb_image_sub], 1000, 0.02)
+        # Keep sync queue bounded to reduce memory spikes/OOM risk on Jetson during map building.
+        self.ts = ApproximateTimeSynchronizer([self.keyframe_image_sub, self.keyframe_odom_sub, self.depth_sub, self.rgb_image_sub], 200, 0.02)
         self.ts.registerCallback(self.keyframe_callback)
 
         self.K = None


### PR DESCRIPTION
## Summary
- reduce `ApproximateTimeSynchronizer` queue size in `build_map_node.py` from `1000` to `200`
- add inline note explaining this bound is to reduce memory spikes during map building

## Motivation
On Jetson, a very large sync queue can increase memory pressure and trigger OOM during map building. This change bounds queue growth while keeping synchronization behavior unchanged (`slop=0.02`).

## Testing
- `python -m py_compile tinynav/core/build_map_node.py`

## Impact
- lower peak memory usage during mapping on constrained devices
- no API/topic changes
