### PR TITLE
feat(bridge): sync looper keyframes with vio_20hz and odometry with vio_100hz

### DIFF
--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -76,16 +76,9 @@ class LooperBridgeNode(Node):
         )
 
     def vio_100hz_callback(self, pose_msg: PoseStamped):
-        T_world_imu = pose_msg2np(pose_msg)
-        if self.T_i_depth is not None:
-            T_world_camera = T_world_imu @ self.T_i_depth
-            odom_msg = np2msg(T_world_camera, pose_msg.header.stamp, "world", "camera")
-        else:
-            self.get_logger().warning(
-                "T_i_depth unavailable for /insight/vio_100hz; publishing imu frame on /slam/odometry.",
-                throttle_duration_sec=2.0,
-            )
-            odom_msg = np2msg(T_world_imu, pose_msg.header.stamp, "world", "imu")
+        # /insight/vio_100hz already reports T_world_camera.
+        T_world_camera = pose_msg2np(pose_msg)
+        odom_msg = np2msg(T_world_camera, pose_msg.header.stamp, "world", "camera")
         self.odom_pub.publish(odom_msg)
         self.get_logger().info(
             f"Bridged first /insight/vio_100hz message at "

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -43,12 +43,15 @@ class LooperBridgeNode(Node):
 
         self.camera_info_sub = self.create_subscription(CameraInfo, "/camera/camera/infra1/camera_info", self.camera_info_callback, self.sensor_qos)
         self.tf_static_sub = self.create_subscription(TFMessage, "/tf_static", self.tf_callback, self.tf_static_qos)
+        self.vio_100hz_sub = self.create_subscription(
+            PoseStamped, "/insight/vio_100hz", self.vio_100hz_callback, 50
+        )
 
         self.depth_sub = message_filters.Subscriber(self, Image, "/camera/camera/depth/image_rect_raw", qos_profile=self.sensor_qos)
-        self.pose_sub = message_filters.Subscriber(self, PoseStamped, "/insight/vio_pose")
+        self.pose_sub = message_filters.Subscriber(self, PoseStamped, "/insight/vio_20hz")
         self.image_sub = message_filters.Subscriber(self, Image, "/camera/camera/infra1/image_rect_raw", qos_profile=self.sensor_qos)
-        self.sync = message_filters.ApproximateTimeSynchronizer(
-            [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20, slop=0.08
+        self.sync = message_filters.TimeSynchronizer(
+            [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20
         )
         self.sync.registerCallback(self.sync_callback)
 
@@ -59,12 +62,35 @@ class LooperBridgeNode(Node):
         self.camera_info_alias_pub = self.create_publisher(
             CameraInfo, "/camera/camera/infra2/camera_info", 10
         )
-        self.keyframe_pose_pub = self.create_publisher(Odometry, "/slam/keyframe_odom", 10)
+        self.keyframe_pose_visual_pub = self.create_publisher(
+            Odometry, "/slam/keyframe_odom", 10
+        )
         self.keyframe_image_pub = self.create_publisher(Image, "/slam/keyframe_image", 10)
         self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
 
         self.get_logger().info(
-            "Bridging /insight/vio_pose + /camera/camera/depth/image_rect_raw + /camera/camera/infra1/image_rect_raw into TinyNav /slam topics."
+            "Bridging /insight/vio_20hz + /camera/camera/depth/image_rect_raw + /camera/camera/infra1/image_rect_raw into TinyNav /slam topics."
+        )
+        self.get_logger().info(
+            "Bridging /insight/vio_100hz into /slam/odometry."
+        )
+
+    def vio_100hz_callback(self, pose_msg: PoseStamped):
+        T_world_imu = pose_msg2np(pose_msg)
+        if self.T_i_depth is not None:
+            T_world_camera = T_world_imu @ self.T_i_depth
+            odom_msg = np2msg(T_world_camera, pose_msg.header.stamp, "world", "camera")
+        else:
+            self.get_logger().warning(
+                "T_i_depth unavailable for /insight/vio_100hz; publishing imu frame on /slam/odometry.",
+                throttle_duration_sec=2.0,
+            )
+            odom_msg = np2msg(T_world_imu, pose_msg.header.stamp, "world", "imu")
+        self.odom_pub.publish(odom_msg)
+        self.get_logger().info(
+            f"Bridged first /insight/vio_100hz message at "
+            f"{pose_msg.header.stamp.sec}.{pose_msg.header.stamp.nanosec:09d} to /slam/odometry.",
+            once=True,
         )
 
     def camera_info_callback(self, msg: CameraInfo):
@@ -235,14 +261,13 @@ class LooperBridgeNode(Node):
         camera_info_out.header.stamp = stamp
         camera_info_out.header.frame_id = "camera"
 
-        self.odom_pub.publish(odom_msg)
         self.depth_pub.publish(depth_out)
         self.disparity_pub_vis.publish(disparity_vis_msg)
         self.slam_camera_info_pub.publish(camera_info_out)
         self.camera_info_alias_pub.publish(camera_info_out)
 
         if self.should_add_keyframe(T_world_camera, stamp):
-            self.keyframe_pose_pub.publish(odom_msg)
+            self.keyframe_pose_visual_pub.publish(odom_msg)
             self.keyframe_image_pub.publish(image_out)
             self.keyframe_depth_pub.publish(depth_out)
             self.last_keyframe_pose = T_world_camera.copy()


### PR DESCRIPTION
## Summary
- bridge synchronized depth + infra1 + /insight/vio_20hz using exact timestamp sync
- publish /slam/odometry from /insight/vio_100hz
- publish keyframe outputs on /slam/keyframe_odom, /slam/keyframe_image, /slam/keyframe_depth
- add bridge info logs for /insight/vio_100hz path

## Validation
- python -m py_compile tool/looper_bridge_node.py
