### PR TITLE
fix: sensor init bug and clean up app READMEs

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -4,19 +4,22 @@ Mobile / web control interface for the TinyNav visual navigation module.
 
 ## Quick start
 
-The fastest way to build and run everything is the provided shell script:
+### Backend
 
 ```bash
-bash /tinynav/scripts/run_web_app.sh
+cd /tinynav
+TINYNAV_DB_PATH=/tinynav/tinynav_db uv run uvicorn app.backend.main:app --host 0.0.0.0 --port 8000
 ```
 
-What it does:
+### Frontend
 
-1. **Starts the backend** — launches FastAPI/uvicorn on port `8000` (sources ROS 2 Humble if available).
-2. **Serves the frontend** — serves `app/frontend/build/web/` on port `8080` with COOP/COEP headers for SharedArrayBuffer support.
-3. **Prints the device IP** and waits; `Ctrl+C` shuts both processes down cleanly.
-
-> **Note:** You must build the frontend first: `cd app/frontend && flutter build web --release`
+```bash
+cd /tinynav/app/frontend
+flutter pub get
+flutter build web --release
+# Then serve build/web/ on your preferred port, e.g.:
+cd build/web && python3 -m http.server 8080
+```
 
 ### Environment variables
 
@@ -25,12 +28,6 @@ What it does:
 | `TINYNAV_DB_PATH` | `<repo>/tinynav_db` | Root path for bag, map, and nav data |
 | `BACKEND_PORT`   | `8000` | Override the backend port |
 | `FRONTEND_PORT`  | `8080` | Override the frontend port |
-
-Example with overrides:
-
-```bash
-TINYNAV_DB_PATH=/data/mydb FRONTEND_PORT=9090 bash /tinynav/scripts/run_web_app.sh
-```
 
 ---
 

--- a/app/README.md
+++ b/app/README.md
@@ -18,7 +18,7 @@ cd /tinynav/app/frontend
 flutter pub get
 flutter build web --release
 # Then serve build/web/ on your preferred port, e.g.:
-cd build/web && python3 -m http.server 8080
+cd build/web && uv run python -m http.server 8080
 ```
 
 ### Environment variables

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -302,26 +302,15 @@ class BackendNode(Ros2NodeManager):
             )
             if '/insight_full' in result.stdout.splitlines():
                 self._sensor_mode = 'looper'
-                self.get_logger().info('Sensor mode: looper — launching looper bridge')
+                self.get_logger().info('Sensor mode: looper — launching looper bridge + planning')
             else:
                 self._sensor_mode = 'realsense'
-                self.get_logger().info('Sensor mode: realsense — launching driver and perception')
+                self.get_logger().info('Sensor mode: realsense — launching driver + perception + planning')
 
             if self._sensor_mode in ('looper', 'realsense'):
                 _env = os.environ.copy()
                 _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
-                lf = self._make_log('perception')
-                self._perception_proc = subprocess.Popen(
-                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py'],
-                    preexec_fn=os.setsid, cwd='/tinynav', env=_env,
-                    stdout=lf, stderr=subprocess.STDOUT,
-                )
-                self._perception_proc = subprocess.Popen(
-                    ['uv', 'run', 'python', '/tinynav/tinynav/core/perception_node.py'],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-                lf.close()
+                self._launch_sensor_procs(_env)
         except Exception as e:
             self.get_logger().warn(f'Sensor detection failed: {e}')
             self._sensor_mode = 'unknown'

--- a/app/frontend/README.md
+++ b/app/frontend/README.md
@@ -8,7 +8,7 @@ Flutter Web / Android / iOS app for controlling the TinyNav visual navigation mo
 cd /tinynav/app/frontend
 flutter pub get
 flutter build web --release
-cd build/web && python3 -m http.server 8080
+uv run python -m http.server 8080 --directory build/web
 ```
 
 Open `http://<device-ip>:8080` in a browser on the same network.

--- a/app/frontend/README.md
+++ b/app/frontend/README.md
@@ -4,14 +4,6 @@ Flutter Web / Android / iOS app for controlling the TinyNav visual navigation mo
 
 ## Quick start
 
-The easiest way is the top-level script (auto-installs Flutter if needed):
-
-```bash
-bash /tinynav/scripts/run_web_app.sh
-```
-
-Or build and serve manually inside the container:
-
 ```bash
 cd /tinynav/app/frontend
 flutter pub get


### PR DESCRIPTION
## Changes
### Bug fix: `_detect_and_init_sensor` incomplete startup
- Previously only launched `perception_node` (launched twice, first process leaked)
- Now calls `_launch_sensor_procs` to start the full stack per mode:
  - **looper**: looper_bridge + planning
  - **realsense**: realsense driver + perception + planning
### README cleanup
- Remove references to non-existent `run_web_app.sh`
- Use `uv run python` instead of `python3` for consistency