### PR TITLE
feat(app): add start_app.sh to launch backend and frontend via tmux

### DIFF
--- a/scripts/start_app.sh
+++ b/scripts/start_app.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-80}"
+TINYNAV_DB_PATH="${TINYNAV_DB_PATH:-/tinynav/tinynav_db}"
+
+tmux new-session -s app \; \
+  split-window -h \; \
+  select-pane -t 0 \; send-keys "cd /tinynav && TINYNAV_DB_PATH=$TINYNAV_DB_PATH uvicorn app.backend.main:app --host 0.0.0.0 --port $BACKEND_PORT" C-m \; \
+  select-pane -t 1 \; send-keys "python -m http.server $FRONTEND_PORT --directory /tinynav/app/frontend/build/web" C-m


### PR DESCRIPTION
How about adding a `scripts/start_app.sh` to start the backend and frontend in a single command.                                
                                                                                    
  Opens a tmux session with two panes:                                                                              
  - Left: FastAPI backend via uvicorn (default port 8000)
  - Right: Flutter web frontend via http.server (default port 80)                                                   
                                                                                                                    
  All three variables can be overridden at runtime:                                                                 
  - `BACKEND_PORT` (default: 8000)                                                                                  
  - `FRONTEND_PORT` (default: 80)                                                                                   
  - `TINYNAV_DB_PATH` (default: /tinynav/tinynav_db)  

Simple it is：

https://github.com/user-attachments/assets/3ae0afb3-6530-43ac-be74-d96a8211e713

