### PR TITLE
feat(perception): warn on sparse keyframe imu integration

### DIFF
--- a/scripts/run_realsense_sensor.sh
+++ b/scripts/run_realsense_sensor.sh
@@ -8,9 +8,16 @@ if ! command -v rs-enumerate-devices >/dev/null 2>&1; then
 	exit 1
 fi
 
-FW_VERSION="$(rs-enumerate-devices | awk -F: '/Firmware Version/ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}')"
+RS_ENUM_OUTPUT="$(rs-enumerate-devices 2>&1)" || {
+	echo "Could not enumerate RealSense devices."
+	echo "$RS_ENUM_OUTPUT"
+	exit 1
+}
+
+FW_VERSION="$(awk -F: '/Firmware Version/ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}' <<<"$RS_ENUM_OUTPUT")"
 if [[ -z "$FW_VERSION" ]]; then
 	echo "Could not detect RealSense firmware version."
+	echo "$RS_ENUM_OUTPUT"
 	exit 1
 fi
 

--- a/scripts/run_realsense_sensor.sh
+++ b/scripts/run_realsense_sensor.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
+set -euo pipefail
+
+MIN_FW_VERSION="5.17"
+
+if ! command -v rs-enumerate-devices >/dev/null 2>&1; then
+	echo "rs-enumerate-devices is not installed; cannot check RealSense firmware."
+	exit 1
+fi
+
+FW_VERSION="$(rs-enumerate-devices | awk -F: '/Firmware Version/ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}')"
+if [[ -z "$FW_VERSION" ]]; then
+	echo "Could not detect RealSense firmware version."
+	exit 1
+fi
+
+if [[ "$(printf '%s\n%s\n' "$MIN_FW_VERSION" "$FW_VERSION" | sort -V | head -n1)" != "$MIN_FW_VERSION" ]]; then
+	echo "RealSense firmware $FW_VERSION is too old; expected at least $MIN_FW_VERSION."
+	exit 1
+fi
+
+echo "RealSense firmware $FW_VERSION detected."
+
 ros2 launch realsense2_camera rs_launch.py \
 	initial_reset:=true \
 	depth_module.auto_exposure_limit:=1000 \

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -80,6 +80,7 @@ class Keyframe:
     bias: gtsam.imuBias.ConstantBias
     preintegrated_imu: gtsam.PreintegratedCombinedMeasurements
     latest_imu_timestamp: float
+    imu_measurement_count: int = 0
 
 class PerceptionNode(Node):
     def __init__(self, verbose_timer: bool = True):
@@ -292,6 +293,7 @@ class PerceptionNode(Node):
 
             self.keyframe_queue[-1].preintegrated_imu.integrateMeasurement(accel, gyro, dt) #todo
             self.keyframe_queue[-1].latest_imu_timestamp = timestamp
+            self.keyframe_queue[-1].imu_measurement_count += 1
 
             self.imu_measurements.popleft()
         # specially process the last imu
@@ -299,6 +301,7 @@ class PerceptionNode(Node):
             timestamp, accel, gyro = self.imu_measurements[0]
             dt = current_timestamp - self.keyframe_queue[-1].latest_imu_timestamp
             self.keyframe_queue[-1].preintegrated_imu.integrateMeasurement(accel, gyro, dt)
+            self.keyframe_queue[-1].imu_measurement_count += 1
 
         with Timer(name="[PnP]", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.logger.debug):
         # do simple pose estimation between last keyframe and current frame
@@ -357,9 +360,17 @@ class PerceptionNode(Node):
 
                     # per pose -- preintegrated IMU factor, only between two keyframes
                     if i != len(self.keyframe_queue[-_N:]) - 1:
+                        if keyframe.imu_measurement_count < 26:
+                            self.logger.warning(
+                                f"keyframe {i} at {keyframe.timestamp} only used "
+                                f"{keyframe.imu_measurement_count} imu measurements; expected at least 26"
+                            )
                         imu_factor = gtsam.CombinedImuFactor(X(i), V(i), X(i+1), V(i+1), B(i), B(i+1), keyframe.preintegrated_imu)
                         graph.add(imu_factor)
-                    self.logger.debug(f"for frame {i} at {keyframe.timestamp}, added imufactor up to {keyframe.latest_imu_timestamp}")
+                    self.logger.debug(
+                        f"for frame {i} at {keyframe.timestamp}, added imufactor up to "
+                        f"{keyframe.latest_imu_timestamp} using {keyframe.imu_measurement_count} imu measurements"
+                    )
 
             #with Timer(name="[stats]", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.logger.debug):
             #    self.frame_diff_t = []


### PR DESCRIPTION
## Summary
- track IMU integration sample count per keyframe in perception preintegration
- warn when a keyframe used fewer than 26 IMU measurements before adding IMU factors
- include IMU measurement count in debug logs for keyframe IMU factor construction
- harden RealSense startup precheck: require firmware >= 5.17 and print enumerate output when detection fails

## Validation
- python -m py_compile tinynav/core/perception_node.py
- bash -n scripts/run_realsense_sensor.sh