### PR TITLE
feat(bridge): publish /slam/odometry_visual and wire planning subscriber

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -349,7 +349,7 @@ class PlanningNode(Node):
         self.occupancy_cloud_esdf_pub = self.create_publisher(PointCloud2, '/planning/occupied_voxels_with_esdf', 10)
         self.occupancy_grid_pub = self.create_publisher(OccupancyGrid, '/planning/occupancy_grid', 10)
         self.depth_sub = message_filters.Subscriber(self, Image, '/slam/depth')
-        self.pose_sub = message_filters.Subscriber(self, Odometry, '/slam/odometry')
+        self.pose_sub = message_filters.Subscriber(self, Odometry, '/slam/odometry_visual')
 
         self.ts = message_filters.TimeSynchronizer([self.depth_sub, self.pose_sub], queue_size=10)
         self.ts.registerCallback(self.sync_callback)

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -58,6 +58,9 @@ class LooperBridgeNode(Node):
         self.sync.registerCallback(self.sync_callback)
 
         self.odom_pub = self.create_publisher(Odometry, "/slam/odometry", 10)
+        self.odom_visual_pub = self.create_publisher(
+            Odometry, "/slam/odometry_visual", 10
+        )
         self.depth_pub = self.create_publisher(Image, "/slam/depth", 10)
         self.disparity_pub_vis = self.create_publisher(Image, "/slam/disparity_vis", 10)
         self.slam_camera_info_pub = self.create_publisher(CameraInfo, "/slam/camera_info", 10)
@@ -195,6 +198,7 @@ class LooperBridgeNode(Node):
         stamp = pose_msg.header.stamp
 
         odom_msg = self.build_odom(T_world_camera, stamp)
+        self.odom_visual_pub.publish(odom_msg)
         depth_m = self.decode_depth_meters(depth_msg)
         depth_out = self.build_depth_msg(depth_m, stamp)
         disparity_vis_msg = self.build_disparity_vis(depth_m, stamp)


### PR DESCRIPTION
## Summary
- add `/slam/odometry_visual` publisher in `tool/looper_bridge_node.py`
- publish synchronized visual odometry from `/insight/vio_20hz` in `sync_callback`
- switch `tinynav/core/planning_node.py` subscription from `/slam/odometry` to `/slam/odometry_visual`

## Motivation
Planning should consume the visual odometry stream synchronized with `/slam/depth` from the bridge path.

## Testing
- code changes verified by reviewing local diff
- not run: runtime ROS integration test in this environment
