### PR TITLE
feat(nav): checkbox POI select, backward recovery, and cmd_vel tuning  

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -23,10 +23,11 @@ import base64
 import rclpy
 import rclpy.time
 import tf2_ros
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
 from sensor_msgs.msg import CompressedImage, Image
-from std_msgs.msg import Float32, String
+from std_msgs.msg import Bool, Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
 
@@ -123,6 +124,11 @@ class BackendNode(Ros2NodeManager):
 
         # Publisher for POI nav target consumed by map_node via /mapping/cmd_pois
         self._cmd_pois_pub = self.create_publisher(String, '/mapping/cmd_pois', 10)
+
+        # Latched publisher — new subscribers (cmd_vel_control) get current state immediately on connect
+        _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self._pause_pub = self.create_publisher(Bool, '/nav/paused', _latched_qos)
+        self._nav_paused = False
 
         # Publisher for robot action commands (sit / stand)
         self._action_pub = self.create_publisher(String, '/service/command', 10)
@@ -500,6 +506,7 @@ class BackendNode(Ros2NodeManager):
             pct = self.mapping_percent
             battery = self._battery
             nav_nodes = self._nav_nodes_running
+            nav_paused = self._nav_paused
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -511,6 +518,7 @@ class BackendNode(Ros2NodeManager):
             'navStatus': 'navigating' if raw == 'navigation' else 'idle',
             'rawState': raw,
             'navNodesRunning': nav_nodes,
+            'navPaused': nav_paused,
         }
 
     @staticmethod
@@ -635,6 +643,7 @@ class BackendNode(Ros2NodeManager):
             self._map_pose = None
             self._global_path = []
             self._nav_target_pose = None
+            self._nav_paused = False
         self.get_logger().info('Nav nodes stopped')
 
     def cmd_restart_nav_nodes(self):
@@ -854,6 +863,28 @@ class BackendNode(Ros2NodeManager):
         payload = {'0': pois[key]}
         self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
 
+    def cmd_send_pois(self, poi_ids: list[int]):
+        """Publish selected POIs to map_node and transition to navigation state."""
+        if not poi_ids:
+            self._cmd_pois_pub.publish(String(data='{}'))
+        else:
+            pois_file = os.path.join(self.map_path, 'pois.json')
+            if not os.path.exists(pois_file):
+                self.get_logger().warn('No pois.json found, cannot publish cmd_pois')
+                return
+            with open(pois_file) as f:
+                all_pois = json.load(f)
+            payload = {str(pid): all_pois[str(pid)] for pid in poi_ids if str(pid) in all_pois}
+            self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
+        with self._lock:
+            nav_running = self._nav_nodes_running
+        if nav_running:
+            self.state = 'navigation'
+            self._pub_state()
+        else:
+            self._stop_all()
+            self._start('navigation')
+
     def cmd_nav_start(self, poi_id: str | None = None):
         if poi_id is not None:
             self._publish_cmd_pois(int(poi_id))
@@ -879,6 +910,16 @@ class BackendNode(Ros2NodeManager):
             self._pub_state()
         else:
             self._stop_all()
+
+    def cmd_nav_pause(self):
+        with self._lock:
+            self._nav_paused = True
+        self._pause_pub.publish(Bool(data=True))
+
+    def cmd_nav_resume(self):
+        with self._lock:
+            self._nav_paused = False
+        self._pause_pub.publish(Bool(data=False))
 
     def cmd_action(self, action: str):
         self._action_pub.publish(String(data=f'play {action}'))

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -34,6 +34,23 @@ _REALSENSE_SCRIPT = '/tinynav/scripts/run_realsense_sensor.sh'
 _VENV_SITE = '/tinynav/.venv/lib/python3.10/site-packages'
 _MAP_BUILD_DOMAIN_LOOPER = '231'  # isolated domain to avoid live looper topic collision during map build
 
+# Minimal ROS node that subscribes to /mapping/percent on domain 231 and writes
+# float values line-by-line to stdout so the parent process can read them via pipe.
+_PERCENT_BRIDGE_SCRIPT = """\
+import os, rclpy
+from rclpy.node import Node
+from std_msgs.msg import Float32
+
+class _B(Node):
+    def __init__(self):
+        super().__init__('_map_pct_bridge')
+        self.create_subscription(Float32, '/mapping/percent',
+                                 lambda m: print(m.data, flush=True), 10)
+
+rclpy.init()
+rclpy.spin(_B())
+"""
+
 _COLOR_TOPIC_REALSENSE = '/camera/camera/color/image_raw'
 _COLOR_TOPIC_LOOPER = '/camera/camera/color/image_rect_raw/compressed'
 
@@ -123,6 +140,7 @@ class BackendNode(Ros2NodeManager):
         self._perception_proc: subprocess.Popen | None = None
         self._planning_proc: subprocess.Popen | None = None
         self._unitree_proc: subprocess.Popen | None = None
+        self._percent_bridge_proc: subprocess.Popen | None = None
 
         # Battery level from /battery topic (published by unitree_control)
         self._battery: float | None = None
@@ -742,7 +760,36 @@ class BackendNode(Ros2NodeManager):
             env=_env,
         )
 
+        if self._sensor_mode == 'looper':
+            self._start_percent_bridge()
+
         threading.Thread(target=self._on_build_map_done, daemon=True).start()
+
+    def _start_percent_bridge(self):
+        """Spawn a subprocess on domain 231 that forwards /mapping/percent to self.mapping_percent."""
+        bridge_env = os.environ.copy()
+        bridge_env['ROS_DOMAIN_ID'] = _MAP_BUILD_DOMAIN_LOOPER
+        bridge_env['PYTHONPATH'] = _VENV_SITE + ':' + bridge_env.get('PYTHONPATH', '')
+        self._percent_bridge_proc = subprocess.Popen(
+            ['python3', '-c', _PERCENT_BRIDGE_SCRIPT],
+            env=bridge_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=os.setsid,
+        )
+        threading.Thread(target=self._read_percent_bridge, daemon=True).start()
+
+    def _read_percent_bridge(self):
+        proc = self._percent_bridge_proc
+        if proc is None or proc.stdout is None:
+            return
+        for line in proc.stdout:
+            try:
+                pct = float(line.strip())
+                with self._lock:
+                    self.mapping_percent = pct
+            except (ValueError, AttributeError):
+                pass
 
     def _on_build_map_done(self):
         """Wait for build_map to finish, then convert, archive, and restart."""
@@ -775,6 +822,8 @@ class BackendNode(Ros2NodeManager):
                 )
             self.get_logger().info('Auto-created home POI at (0,0,0)')
 
+        self._kill_proc(self._percent_bridge_proc)
+        self._percent_bridge_proc = None
         self._stop_all()
         self.state = 'idle'
         self._pub_state()
@@ -882,7 +931,7 @@ class NodeRunner:
                 self.node.destroy_node()
             except Exception:
                 pass
-            for proc in (self.node._looper_bridge_proc, self.node._realsense_proc, self.node._perception_proc, self.node._planning_proc, self.node._unitree_proc, self.node._map_node_proc, self.node._cmd_vel_proc):
+            for proc in (self.node._looper_bridge_proc, self.node._realsense_proc, self.node._perception_proc, self.node._planning_proc, self.node._unitree_proc, self.node._map_node_proc, self.node._cmd_vel_proc, self.node._percent_bridge_proc):
                 if proc and proc.poll() is None:
                     try:
                         os.killpg(os.getpgid(proc.pid), 15)

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -766,7 +766,6 @@ class BackendNode(Ros2NodeManager):
         threading.Thread(target=self._on_build_map_done, daemon=True).start()
 
     def _start_percent_bridge(self):
-        """Spawn a subprocess on domain 231 that forwards /mapping/percent to self.mapping_percent."""
         bridge_env = os.environ.copy()
         bridge_env['ROS_DOMAIN_ID'] = _MAP_BUILD_DOMAIN_LOOPER
         bridge_env['PYTHONPATH'] = _VENV_SITE + ':' + bridge_env.get('PYTHONPATH', '')

--- a/app/backend/routers/nav.py
+++ b/app/backend/routers/nav.py
@@ -16,6 +16,19 @@ class GoToPoiRequest(BaseModel):
     poi_id: int
 
 
+class SendPoisRequest(BaseModel):
+    poi_ids: list[int]
+
+
+@router.post('/send-pois')
+def nav_send_pois(req: SendPoisRequest):
+    node = _require_node()
+    if not node._localized:
+        raise HTTPException(409, 'Not localized')
+    node.cmd_send_pois(req.poi_ids)
+    return {'ok': True}
+
+
 @router.post('/go-to-poi')
 def nav_go_to_poi(req: GoToPoiRequest):
     node = _require_node()
@@ -60,6 +73,20 @@ def nav_restart():
     if not node._nav_nodes_running:
         raise HTTPException(409, 'Nav nodes not running')
     node.cmd_restart_nav_nodes()
+    return {'ok': True}
+
+
+@router.post('/pause')
+def nav_pause():
+    node = _require_node()
+    node.cmd_nav_pause()
+    return {'ok': True}
+
+
+@router.post('/resume')
+def nav_resume():
+    node = _require_node()
+    node.cmd_nav_resume()
     return {'ok': True}
 
 

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -11,6 +11,7 @@ class DeviceStatus {
   final String navStatus;
   final String rawState;
   final bool navNodesRunning;
+  final bool navPaused;
 
   const DeviceStatus({
     required this.online,
@@ -22,6 +23,7 @@ class DeviceStatus {
     required this.navStatus,
     required this.rawState,
     required this.navNodesRunning,
+    required this.navPaused,
   });
 
   factory DeviceStatus.fromJson(Map<String, dynamic> json) => DeviceStatus(
@@ -34,6 +36,7 @@ class DeviceStatus {
         navStatus: json['navStatus'] as String? ?? 'idle',
         rawState: json['rawState'] as String? ?? 'unknown',
         navNodesRunning: json['navNodesRunning'] as bool? ?? false,
+        navPaused: json['navPaused'] as bool? ?? false,
       );
 }
 

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -494,51 +494,11 @@ class _PoiSheet extends ConsumerStatefulWidget {
 
 class _PoiSheetState extends ConsumerState<_PoiSheet> {
   bool _canceling = false;
-
-  Future<void> _addPoi() async {
-    final pose = widget.pose;
-    if (pose == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('No pose — robot must be localized first')),
-      );
-      return;
-    }
-    final ctrl = TextEditingController();
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('New POI'),
-        content: TextField(
-          controller: ctrl,
-          decoration: const InputDecoration(labelText: 'Name', hintText: 'e.g. Entrance'),
-          autofocus: true,
-          textCapitalization: TextCapitalization.sentences,
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Create')),
-        ],
-      ),
-    );
-    if (ok != true || ctrl.text.trim().isEmpty) return;
-    try {
-      await ref.read(dioProvider).post('/map/pois', data: {
-        'name': ctrl.text.trim(),
-        'position': [pose.x, pose.y, 0.0],
-      });
-      ref.invalidate(poisProvider);
-    } on DioException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
-          backgroundColor: Colors.red,
-        ));
-      }
-    }
-  }
+  final Set<int> _checkedIds = {};
+  List<int> _navQueue = [];
 
   Future<void> _cancelNav() async {
-    setState(() => _canceling = true);
+    setState(() { _canceling = true; _navQueue = []; });
     try {
       await ref.read(dioProvider).post('/nav/cancel');
     } on DioException catch (e) {
@@ -572,9 +532,36 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     if (ok != true) return;
     try {
       await ref.read(dioProvider).delete('/poi/${poi.id}');
+      setState(() => _checkedIds.remove(poi.id));
       ref.invalidate(poisProvider);
     } on DioException catch (e) {
       if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
+          backgroundColor: Colors.red,
+        ));
+      }
+    }
+  }
+
+  Future<void> _startNav(List<Poi> pois) async {
+    final queue = pois
+        .where((p) => _checkedIds.contains(p.id))
+        .map((p) => p.id)
+        .toList();
+    if (queue.isEmpty) return;
+    setState(() => _navQueue = queue);
+    await _goToNext();
+  }
+
+  Future<void> _goToNext() async {
+    if (_navQueue.isEmpty) return;
+    final nextId = _navQueue.removeAt(0);
+    try {
+      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': nextId});
+    } on DioException catch (e) {
+      if (mounted) {
+        setState(() => _navQueue = []);
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
           backgroundColor: Colors.red,
@@ -590,6 +577,15 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     final status = statusAsync.valueOrNull;
     final isNavigating = status?.rawState == 'navigation';
     final canGo = status != null && status.online && status.rawState == 'idle';
+
+    // Auto-advance to next POI in queue when navigation completes.
+    ref.listen<AsyncValue<DeviceStatus>>(deviceStatusProvider, (prev, next) {
+      final wasNav = prev?.valueOrNull?.rawState == 'navigation';
+      final isNowIdle = next.valueOrNull?.rawState == 'idle';
+      if (wasNav && isNowIdle && _navQueue.isNotEmpty) {
+        _goToNext();
+      }
+    });
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -624,10 +620,16 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
                 label: const Text('Cancel Nav'),
               )
             else
-              TextButton.icon(
-                onPressed: _addPoi,
-                icon: const Icon(Icons.add_location_alt_outlined, size: 18),
-                label: const Text('Add here'),
+              FilledButton.icon(
+                onPressed: (canGo && _checkedIds.isNotEmpty)
+                    ? () => poisAsync.whenData((pois) => _startNav(pois))
+                    : null,
+                icon: const Icon(Icons.navigation_rounded, size: 16),
+                label: const Text('Nav'),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  minimumSize: Size.zero,
+                ),
               ),
           ]),
           const Divider(height: 20),
@@ -644,7 +646,11 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
                     children: pois
                         .map((poi) => _PoiTile(
                               poi: poi,
-                              canGo: canGo,
+                              checked: _checkedIds.contains(poi.id),
+                              onChecked: (v) => setState(() {
+                                if (v) _checkedIds.add(poi.id);
+                                else _checkedIds.remove(poi.id);
+                              }),
                               onDelete: () => _deletePoi(poi),
                             ))
                         .toList(),
@@ -658,66 +664,36 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   }
 }
 
-class _PoiTile extends ConsumerStatefulWidget {
+class _PoiTile extends StatelessWidget {
   final Poi poi;
-  final bool canGo;
+  final bool checked;
+  final ValueChanged<bool> onChecked;
   final VoidCallback onDelete;
 
-  const _PoiTile({required this.poi, required this.canGo, required this.onDelete});
-
-  @override
-  ConsumerState<_PoiTile> createState() => _PoiTileState();
-}
-
-class _PoiTileState extends ConsumerState<_PoiTile> {
-  bool _loading = false;
-
-  Future<void> _go() async {
-    setState(() => _loading = true);
-    try {
-      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': widget.poi.id});
-    } on DioException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
-          backgroundColor: Colors.red,
-        ));
-      }
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
+  const _PoiTile({
+    required this.poi,
+    required this.checked,
+    required this.onChecked,
+    required this.onDelete,
+  });
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const Icon(Icons.place, color: Colors.amber),
-      title: Text(widget.poi.name),
+      leading: Checkbox(
+        value: checked,
+        onChanged: (v) => onChecked(v ?? false),
+      ),
+      title: Text(poi.name),
       subtitle: Text(
-        '(${widget.poi.x.toStringAsFixed(2)}, ${widget.poi.y.toStringAsFixed(2)})',
+        '(${poi.x.toStringAsFixed(2)}, ${poi.y.toStringAsFixed(2)})',
         style: const TextStyle(fontSize: 12),
       ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _loading
-              ? const SizedBox(width: 28, height: 28, child: CircularProgressIndicator(strokeWidth: 2))
-              : FilledButton(
-                  onPressed: widget.canGo ? _go : null,
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                    minimumSize: Size.zero,
-                  ),
-                  child: const Text('Go', style: TextStyle(fontSize: 12)),
-                ),
-          const SizedBox(width: 4),
-          IconButton(
-            icon: const Icon(Icons.delete_outline, color: Colors.red, size: 18),
-            onPressed: widget.onDelete,
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
-          ),
-        ],
+      trailing: IconButton(
+        icon: const Icon(Icons.delete_outline, color: Colors.red, size: 18),
+        onPressed: onDelete,
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(),
       ),
       dense: true,
       contentPadding: const EdgeInsets.symmetric(horizontal: 4),

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -495,10 +495,9 @@ class _PoiSheet extends ConsumerStatefulWidget {
 class _PoiSheetState extends ConsumerState<_PoiSheet> {
   bool _canceling = false;
   final Set<int> _checkedIds = {};
-  List<int> _navQueue = [];
 
   Future<void> _cancelNav() async {
-    setState(() { _canceling = true; _navQueue = []; });
+    setState(() => _canceling = true);
     try {
       await ref.read(dioProvider).post('/nav/cancel');
     } on DioException catch (e) {
@@ -545,23 +544,15 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   }
 
   Future<void> _startNav(List<Poi> pois) async {
-    final queue = pois
+    final ids = pois
         .where((p) => _checkedIds.contains(p.id))
         .map((p) => p.id)
         .toList();
-    if (queue.isEmpty) return;
-    setState(() => _navQueue = queue);
-    await _goToNext();
-  }
-
-  Future<void> _goToNext() async {
-    if (_navQueue.isEmpty) return;
-    final nextId = _navQueue.removeAt(0);
+    if (ids.isEmpty) return;
     try {
-      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': nextId});
+      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': ids.first});
     } on DioException catch (e) {
       if (mounted) {
-        setState(() => _navQueue = []);
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
           backgroundColor: Colors.red,
@@ -577,15 +568,6 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     final status = statusAsync.valueOrNull;
     final isNavigating = status?.rawState == 'navigation';
     final canGo = status != null && status.online && status.rawState == 'idle';
-
-    // Auto-advance to next POI in queue when navigation completes.
-    ref.listen<AsyncValue<DeviceStatus>>(deviceStatusProvider, (prev, next) {
-      final wasNav = prev?.valueOrNull?.rawState == 'navigation';
-      final isNowIdle = next.valueOrNull?.rawState == 'idle';
-      if (wasNav && isNowIdle && _navQueue.isNotEmpty) {
-        _goToNext();
-      }
-    });
 
     return Padding(
       padding: EdgeInsets.fromLTRB(

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -141,6 +141,14 @@ class _OperateTabState extends ConsumerState<OperateTab> {
               ),
               Positioned(
                 bottom: 10,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: _PauseButton(statusAsync: ref.watch(deviceStatusProvider)),
+                ),
+              ),
+              Positioned(
+                bottom: 10,
                 right: 10,
                 child: _NavNodesButton(statusAsync: ref.watch(deviceStatusProvider)),
               ),
@@ -441,7 +449,7 @@ class _LocalizationChip extends StatelessWidget {
 
 // ── POI button + bottom sheet ─────────────────────────────────────────────────
 
-class _PoiButton extends ConsumerWidget {
+class _PoiButton extends ConsumerStatefulWidget {
   final AsyncValue<List<Poi>> poisAsync;
   final AsyncValue<DeviceStatus> statusAsync;
   final Pose? pose;
@@ -453,48 +461,11 @@ class _PoiButton extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final count = poisAsync.valueOrNull?.length ?? 0;
-    final isNavigating = statusAsync.valueOrNull?.rawState == 'navigation';
-
-    return FilledButton.icon(
-      onPressed: () => showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        builder: (_) => _PoiSheet(pose: pose),
-      ),
-      style: FilledButton.styleFrom(
-        backgroundColor: isNavigating
-            ? const Color(0xFF34C759).withOpacity(0.9)
-            : Colors.black87,
-        foregroundColor: Colors.white,
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-      ),
-      icon: Icon(
-        isNavigating ? Icons.navigation_rounded : Icons.place_outlined,
-        size: 16,
-      ),
-      label: Text(isNavigating
-          ? 'Navigating'
-          : 'POIs${count > 0 ? ' ($count)' : ''}'),
-    );
-  }
+  ConsumerState<_PoiButton> createState() => _PoiButtonState();
 }
 
-class _PoiSheet extends ConsumerStatefulWidget {
-  final Pose? pose;
-  const _PoiSheet({this.pose});
-
-  @override
-  ConsumerState<_PoiSheet> createState() => _PoiSheetState();
-}
-
-class _PoiSheetState extends ConsumerState<_PoiSheet> {
+class _PoiButtonState extends ConsumerState<_PoiButton> {
   bool _canceling = false;
-  final Set<int> _checkedIds = {};
 
   Future<void> _cancelNav() async {
     setState(() => _canceling = true);
@@ -511,6 +482,57 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
       if (mounted) setState(() => _canceling = false);
     }
   }
+
+  @override
+  Widget build(BuildContext context) {
+    final count = widget.poisAsync.valueOrNull?.length ?? 0;
+    final isNavigating = widget.statusAsync.valueOrNull?.rawState == 'navigation';
+
+    if (isNavigating) {
+      return FilledButton.icon(
+        onPressed: _canceling ? null : _cancelNav,
+        style: FilledButton.styleFrom(
+          backgroundColor: Colors.red.withOpacity(0.85),
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        ),
+        icon: _canceling
+            ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+            : const Icon(Icons.cancel_outlined, size: 16),
+        label: const Text('Cancel'),
+      );
+    }
+
+    return FilledButton.icon(
+      onPressed: () => showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        builder: (_) => _PoiSheet(pose: widget.pose),
+      ),
+      style: FilledButton.styleFrom(
+        backgroundColor: Colors.black87,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      ),
+      icon: const Icon(Icons.place_outlined, size: 16),
+      label: Text('POIs${count > 0 ? ' ($count)' : ''}'),
+    );
+  }
+}
+
+class _PoiSheet extends ConsumerStatefulWidget {
+  final Pose? pose;
+  const _PoiSheet({this.pose});
+
+  @override
+  ConsumerState<_PoiSheet> createState() => _PoiSheetState();
+}
+
+class _PoiSheetState extends ConsumerState<_PoiSheet> {
+  final Set<int> _checkedIds = {};
 
   Future<void> _deletePoi(Poi poi) async {
     final ok = await showDialog<bool>(
@@ -550,7 +572,7 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
         .toList();
     if (ids.isEmpty) return;
     try {
-      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': ids.first});
+      await ref.read(dioProvider).post('/nav/send-pois', data: {'poi_ids': ids});
     } on DioException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
@@ -564,10 +586,9 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   @override
   Widget build(BuildContext context) {
     final poisAsync = ref.watch(poisProvider);
-    final statusAsync = ref.watch(deviceStatusProvider);
-    final status = statusAsync.valueOrNull;
-    final isNavigating = status?.rawState == 'navigation';
-    final canGo = status != null && status.online && status.rawState == 'idle';
+    final status = ref.watch(deviceStatusProvider).valueOrNull;
+    final localized = ref.watch(planningStreamProvider).valueOrNull?.localized ?? false;
+    final canGo = status != null && status.online && localized;
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -592,27 +613,17 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
             const SizedBox(width: 8),
             const Text('POIs', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
             const Spacer(),
-            if (isNavigating)
-              OutlinedButton.icon(
-                onPressed: _canceling ? null : _cancelNav,
-                style: OutlinedButton.styleFrom(foregroundColor: Colors.red),
-                icon: _canceling
-                    ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2))
-                    : const Icon(Icons.cancel_outlined, size: 16),
-                label: const Text('Cancel Nav'),
-              )
-            else
-              FilledButton.icon(
-                onPressed: (canGo && _checkedIds.isNotEmpty)
-                    ? () => poisAsync.whenData((pois) => _startNav(pois))
-                    : null,
-                icon: const Icon(Icons.navigation_rounded, size: 16),
-                label: const Text('Nav'),
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  minimumSize: Size.zero,
-                ),
+            FilledButton.icon(
+              onPressed: (canGo && _checkedIds.isNotEmpty)
+                  ? () => poisAsync.whenData((pois) => _startNav(pois))
+                  : null,
+              icon: const Icon(Icons.navigation_rounded, size: 16),
+              label: const Text('Go'),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                minimumSize: Size.zero,
               ),
+            ),
           ]),
           const Divider(height: 20),
           // ── POI list ────────────────────────────────────────────────
@@ -739,6 +750,59 @@ class _NavNodesButtonState extends ConsumerState<_NavNodesButton> {
               size: 16,
             ),
       label: Text(running ? 'Nav ON' : 'Nav'),
+    );
+  }
+}
+
+// ── Pause / Continue button ───────────────────────────────────────────────────
+
+class _PauseButton extends ConsumerStatefulWidget {
+  final AsyncValue<DeviceStatus> statusAsync;
+  const _PauseButton({required this.statusAsync});
+
+  @override
+  ConsumerState<_PauseButton> createState() => _PauseButtonState();
+}
+
+class _PauseButtonState extends ConsumerState<_PauseButton> {
+  bool _loading = false;
+
+  Future<void> _toggle(bool paused) async {
+    setState(() => _loading = true);
+    try {
+      await ref.read(dioProvider).post(paused ? '/nav/resume' : '/nav/pause');
+    } on DioException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
+          backgroundColor: Colors.red,
+        ));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = widget.statusAsync.valueOrNull;
+    final running = status?.navNodesRunning ?? false;
+    if (!running) return const SizedBox.shrink();
+
+    final paused = status?.navPaused ?? false;
+    return FilledButton.icon(
+      onPressed: _loading ? null : () => _toggle(paused),
+      style: FilledButton.styleFrom(
+        backgroundColor: paused
+            ? const Color(0xFFFF9800).withOpacity(0.9)
+            : Colors.black54,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      ),
+      icon: _loading
+          ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+          : Icon(paused ? Icons.play_arrow_rounded : Icons.pause_rounded, size: 16),
+      label: Text(paused ? 'Continue' : 'Pause'),
     );
   }
 }

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -241,6 +241,14 @@ class MapNode(Node):
                 pois_dict[index] = np.array(self.pois[str(key)]["position"])
             self.pois = pois_dict
 
+            if not self.pois:
+                self.poi_index = -1
+                # Signal planning_node to clear target_pose so it stops publishing paths
+                dummy_pose = np.eye(4)
+                self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
+                self.get_logger().info("POIs cleared, navigation cancelled")
+                return
+
             self.poi_index = min(0, len(self.pois) - 1)
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -193,11 +193,12 @@ def generate_trajectory_library_3d(
     num_trajs = n_vx * n_omega
     trajectories = np.empty((num_trajs, num_steps, 7))
     params = np.empty((num_trajs, 2))
-    vx_step = (vx_max - vx_min) / (n_vx - 1) if n_vx > 1 else 0.0
+    # index 0 = single backward sample (vx_min); indices 1..n_vx-1 = forward [0, vx_max]
+    fwd_step = vx_max / (n_vx - 2) if n_vx > 2 else vx_max
     omega_step = (omega_max - omega_min) / (n_omega - 1) if n_omega > 1 else 0.0
     k = 0
     for i_vx in range(n_vx):
-        vx = vx_min + i_vx * vx_step
+        vx = vx_min if i_vx == 0 else (i_vx - 1) * fwd_step
         for i_omega in range(n_omega):
             omega = omega_min + i_omega * omega_step
             p = init_p.copy()

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -593,11 +593,12 @@ class PlanningNode(Node):
             path.header.frame_id = "world"
 
             # Goal-reached: publish empty path so cmd_vel stops.
+            # target_pose is a camera-frame position (POI was recorded as camera pose),
+            # so compare directly against camera position T[:3, 3].
             if self.target_pose is not None:
-                robot_center = self.camera_to_robot_center(T)
-                dist_to_goal = float(np.linalg.norm(robot_center[:2] - self.target_pose[:2]))
+                dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2]))
                 if dist_to_goal < 0.3:
-                    self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.', once=False)
+                    self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
                     self.path_pub.publish(path)
                     return
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -374,12 +374,8 @@ class PlanningNode(Node):
         self.target_pose = None
 
         self.poi_change_sub = self.create_subscription(Odometry, "/mapping/poi_change", self.poi_change_callback, 10)
-        self.poi_changed = False
-        self.poi_change_timestamp_sec = 0.0
 
     def poi_change_callback(self, msg):
-        self.poi_changed = True
-        self.poi_change_timestamp_sec = msg.header.stamp.sec
         self.target_pose = None
 
     def target_pose_callback(self, msg):
@@ -592,9 +588,6 @@ class PlanningNode(Node):
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose, bool(is_backward[i])) for i in range(len(trajectories))]), kind='stable')[:top_k]
             self.last_param = params[top_indices[0]]
 
-            if self.poi_changed and (depth_msg.header.stamp.sec - self.poi_change_timestamp_sec) > 3.0:
-                self.poi_changed = False
-
             # path
             path = Path()
             path.header = depth_msg.header
@@ -607,7 +600,7 @@ class PlanningNode(Node):
                 self.path_pub.publish(path)
                 return
 
-            if self.target_pose is None and not self.poi_changed:
+            if self.target_pose is None:
                 self.path_pub.publish(path)
                 return
 
@@ -619,9 +612,6 @@ class PlanningNode(Node):
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):
                     x,y,z,qx,qy,qz,qw = trajectories[i][j]
-                    if self.poi_changed:
-                        x,y,z,qx,qy,qz,qw = trajectories[i][0]
-                        self.get_logger().info(f"poi changed, using first point, wait {(depth_msg.header.stamp.sec - self.poi_change_timestamp_sec)} seconds")
 
                     pose = PoseStamped()
                     pose.header = depth_msg.header

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -51,9 +51,9 @@ class RobotConfig:
 
 GO2_CONFIG = RobotConfig(
     name='go2', shape='square',
-    length=0.4, width=0.3,
+    length=0.7, width=0.4,
     camera_x=0.35, camera_y=0.0,
-    control_x=0.0, control_y=0.0,
+    control_x=0.35, control_y=0.0,
     safety_radius=0.1,
 )
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -547,36 +547,85 @@ class PlanningNode(Node):
             top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            # Adaptive backward penalty: linearly scales from 10000 (far) to 0 (in contact).
+            # Reverse is generally discouraged, but should be selectable for front-obstacle escape.
             fl_r, rl_r, hw_r = self.robot.footprint_from_control()
             rc = self.camera_to_robot_center(T)
             fwd_r = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
             nr = (fwd_r[0]**2 + fwd_r[1]**2)**0.5
             frx, fry = (fwd_r[0]/nr, fwd_r[1]/nr) if nr > 1e-6 else (1.0, 0.0)
             llx, lly = -fry, frx
-            rc_pts = [
-                (rc[0], rc[1]),
+            Er, Ec = ESDF_map.shape
+
+            front_pts = [
+                (rc[0] + frx*fl_r, rc[1] + fry*fl_r),
                 (rc[0] + frx*fl_r + llx*hw_r, rc[1] + fry*fl_r + lly*hw_r),
                 (rc[0] + frx*fl_r - llx*hw_r, rc[1] + fry*fl_r - lly*hw_r),
-                (rc[0] - frx*rl_r + llx*hw_r, rc[1] - fry*rl_r + lly*hw_r),
-                (rc[0] - frx*rl_r - llx*hw_r, rc[1] - fry*rl_r - lly*hw_r),
             ]
-            Er, Ec = ESDF_map.shape
-            robot_clearance = 999.0
-            for px_, py_ in rc_pts:
+            front_clearance = 999.0
+            for px_, py_ in front_pts:
                 xi_ = int((px_ - self.origin[0]) / self.resolution)
                 yi_ = int((py_ - self.origin[1]) / self.resolution)
                 if 0 <= xi_ < Er and 0 <= yi_ < Ec:
-                    robot_clearance = min(robot_clearance, float(ESDF_map[xi_, yi_]))
-            # Penalty drops to 0 when robot is at safety_radius; full penalty beyond 0.3m.
-            penalty_scale = float(np.clip(robot_clearance / 0.3, 0.0, 1.0))
+                    front_clearance = min(front_clearance, float(ESDF_map[xi_, yi_]))
+
+            front_escape_threshold = self.robot.safety_radius + 0.12
+            front_blocked = front_clearance < front_escape_threshold
+            # Mild reverse discouragement when front is clear.
+            front_penalty_scale = float(np.clip(front_clearance / 0.25, 0.0, 1.0))
+
+            target_behind = False
+            if self.target_pose is not None:
+                to_goal_xy = self.target_pose[:2] - rc[:2]
+                forward_proj = float(to_goal_xy[0] * frx + to_goal_xy[1] * fry)
+                target_behind = forward_proj < -0.15
 
             def cost_function(traj, param, score, target_pose, backward):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
-                backward_penalty = 10000.0 * penalty_scale if backward else 0.0
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + backward_penalty
+                if backward:
+                    backward_penalty = -800.0 if front_blocked else 1800.0 * front_penalty_scale
+                else:
+                    backward_penalty = 0.0
+                # When front is blocked, discourage positive vx so reverse can be chosen.
+                front_block_forward_penalty = 2500.0 * max(0.0, param[0]) if front_blocked and not backward else 0.0
+
+                # If goal is behind robot, prefer rotate-first behavior.
+                rotate_first_penalty = 0.0
+                heading_penalty = 0.0
+                if target_behind and target_pose is not None:
+                    rotate_first_penalty = 4000.0 * abs(param[0])
+
+                    qx, qy, qz, qw = traj[-1, 3], traj[-1, 4], traj[-1, 5], traj[-1, 6]
+                    tf_x = 2.0 * (qx * qz + qw * qy)
+                    tf_y = 2.0 * (qy * qz - qw * qx)
+                    n_tf = (tf_x * tf_x + tf_y * tf_y) ** 0.5
+                    if n_tf > 1e-6:
+                        tf_x /= n_tf
+                        tf_y /= n_tf
+                    else:
+                        tf_x, tf_y = 1.0, 0.0
+                    gx = target_end[0] - traj_end[0]
+                    gy = target_end[1] - traj_end[1]
+                    n_g = (gx * gx + gy * gy) ** 0.5
+                    if n_g > 1e-6:
+                        gx /= n_g
+                        gy /= n_g
+                        cross = tf_x * gy - tf_y * gx
+                        dot = tf_x * gx + tf_y * gy
+                        heading_err = abs(np.arctan2(cross, dot))
+                        heading_penalty = 700.0 * heading_err
+
+                return (
+                    score * 100000
+                    + 100 * dist
+                    + 10 * abs(self.last_param[0] - param[0])
+                    + 10 * abs(self.last_param[1] - param[1])
+                    + backward_penalty
+                    + front_block_forward_penalty
+                    + rotate_first_penalty
+                    + heading_penalty
+                )
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose, bool(is_backward[i])) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -564,8 +564,7 @@ class PlanningNode(Node):
             trajectories, params = generate_trajectory_library_3d(
                 init_p=init_p, init_v=init_v, init_q=init_q
             )
-            # Backward recovery trajectories: fewer samples, fixed slow reverse speed.
-            # Scored together with forward; penalised in cost so forward is always preferred.
+            # Penalised in cost so forward is always preferred when unblocked.
             back_trajs, back_params = generate_trajectory_library_3d(
                 num_samples=5, init_p=init_p, init_v=-v_dir * 0.15, init_q=init_q
             )
@@ -601,9 +600,7 @@ class PlanningNode(Node):
             path.header = depth_msg.header
             path.header.frame_id = "world"
 
-            # Goal-reached: publish empty path so cmd_vel stops.
-            # target_pose is a camera-frame position (POI was recorded as camera pose),
-            # so compare directly against camera position T[:3, 3].
+            # target_pose is camera-frame (POI recorded as camera pose); compare against T[:3, 3] directly.
             if self.target_pose is not None:
                 dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2]))
                 if dist_to_goal < 0.3:
@@ -612,10 +609,9 @@ class PlanningNode(Node):
                     return
 
             if self.target_pose is None and not self.poi_changed:
-                self.path_pub.publish(path)  # empty path — no active nav target
+                self.path_pub.publish(path)
                 return
 
-            # If every trajectory is in collision (forward and backward), stop.
             if all(s == float('inf') for s in scores):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 self.path_pub.publish(path)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -220,7 +220,7 @@ def generate_trajectory_library_3d(
                 if norm_val > 1e-3:
                     acc_body = acc_body / norm_val
                 else:
-                    acc_body = np.array([0.0, 0.0, 0.0])
+                    acc_body = np.array([0.0, 0.0, 1.0])  # body +Z forward; dv<0 gives backward
                 acc_body = acc_body * dv
 
                 acc_world = q @ acc_body

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -184,57 +184,38 @@ def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None)
 
 @njit(cache=True)
 def generate_trajectory_library_3d(
-    num_samples=11, duration=2.0, dt=0.1,
-    acc_std=0.00001, omega_y_std_deg=20.0,
-    init_p=np.zeros(3), init_v=np.zeros(3), init_q=np.array([0, 0, 0, 1])
+    vx_min=-0.2, vx_max=0.5, n_vx=5,
+    omega_min=-0.6, omega_max=0.6, n_omega=11,
+    duration=2.0, dt=0.1,
+    init_p=np.zeros(3), init_q=np.array([0, 0, 0, 1])
 ):
     num_steps = int(duration / dt) + 1
-
-    max_acc = 0.5
-    acc_samples = np.linspace(-max_acc, max_acc, int(num_samples / 2))
-    max_omega = np.pi / 4
-    omega_y_samples = np.linspace(-max_omega, max_omega, num_samples)
-
-    num_samples = len(acc_samples) * len(omega_y_samples)
-
-    trajectories = np.empty((num_samples, num_steps, 7))
-    params = np.empty((num_samples, 2))
-
-    k = -1
-    for i_acc in range(len(acc_samples)):
-        for i_omega in range(len(omega_y_samples)):
-            k += 1
-            dv = acc_samples[i_acc]
-            omega_y = omega_y_samples[i_omega]
+    num_trajs = n_vx * n_omega
+    trajectories = np.empty((num_trajs, num_steps, 7))
+    params = np.empty((num_trajs, 2))
+    vx_step = (vx_max - vx_min) / (n_vx - 1) if n_vx > 1 else 0.0
+    omega_step = (omega_max - omega_min) / (n_omega - 1) if n_omega > 1 else 0.0
+    k = 0
+    for i_vx in range(n_vx):
+        vx = vx_min + i_vx * vx_step
+        for i_omega in range(n_omega):
+            omega = omega_min + i_omega * omega_step
             p = init_p.copy()
-            v_world = init_v.copy()
             q = quat_to_matrix(init_q)
             traj = np.empty((num_steps, 7))
             for i in range(num_steps):
-                dq = rotvec_to_matrix(np.array([0.0, omega_y * dt, 0.0]))
-                v_world = (q @ dq) @ q.T @ v_world
+                v_world = q @ np.array([0.0, 0.0, vx])
+                p = p + v_world * dt
+                dq = rotvec_to_matrix(np.array([0.0, omega * dt, 0.0]))
                 q = q @ dq
-
-                acc_body = q.T @ v_world
-                norm_val = np.linalg.norm(acc_body)
-                if norm_val > 1e-3:
-                    acc_body = acc_body / norm_val
-                else:
-                    acc_body = np.array([0.0, 0.0, 1.0])  # body +Z forward; dv<0 gives backward
-                acc_body = acc_body * dv
-
-                acc_world = q @ acc_body
-                v_world += acc_world * dt
-                v_world = np.clip(v_world, -0.5, 0.5)
-                p += v_world * dt
                 traj[i, :3] = p
                 traj[i, 3:] = matrix_to_quat(q)
-            #hack
             for i in range(num_steps):
                 traj[i, 2] = traj[0, 2]
             trajectories[k] = traj
-            params[k, 0] = dv
-            params[k, 1] = omega_y
+            params[k, 0] = vx
+            params[k, 1] = omega
+            k += 1
     return trajectories, params
 
 @njit(cache=True)
@@ -551,21 +532,10 @@ class PlanningNode(Node):
             self.publish_footprint(T, depth_msg.header.stamp)
 
         with Timer(name='traj gen', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            v_dir = T[:3, :3] @ np.array([0, 0, 1])
-            magnitude = np.clip(self.smoothed_velocity, 0.05, 0.5)
-            init_v = v_dir * float(magnitude)
             init_p = self.camera_to_robot_center(T)
             init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
-            trajectories, params = generate_trajectory_library_3d(
-                init_p=init_p, init_v=init_v, init_q=init_q
-            )
-            # Penalised in cost so forward is always preferred when unblocked.
-            back_trajs, back_params = generate_trajectory_library_3d(
-                num_samples=5, init_p=init_p, init_v=-v_dir * 0.2, init_q=init_q
-            )
-            is_backward = np.array([False] * len(trajectories) + [True] * len(back_trajs))
-            trajectories = np.concatenate([trajectories, back_trajs], axis=0)
-            params = np.concatenate([params, back_params], axis=0)
+            trajectories, params = generate_trajectory_library_3d(init_p=init_p, init_q=init_q)
+            is_backward = params[:, 0] < 0
             self.last_T = T
             self.last_stamp = stamp
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -591,6 +591,16 @@ class PlanningNode(Node):
             path = Path()
             path.header = depth_msg.header
             path.header.frame_id = "world"
+
+            # Goal-reached: publish empty path so cmd_vel stops.
+            if self.target_pose is not None:
+                robot_center = self.camera_to_robot_center(T)
+                dist_to_goal = float(np.linalg.norm(robot_center[:2] - self.target_pose[:2]))
+                if dist_to_goal < 0.3:
+                    self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.', once=False)
+                    self.path_pub.publish(path)
+                    return
+
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):
                     x,y,z,qx,qy,qz,qw = trajectories[i][j]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -190,9 +190,9 @@ def generate_trajectory_library_3d(
 ):
     num_steps = int(duration / dt) + 1
 
-    max_acc = 0.2
+    max_acc = 0.5
     acc_samples = np.linspace(-max_acc, max_acc, int(num_samples / 2))
-    max_omega = np.pi / 8
+    max_omega = np.pi / 4
     omega_y_samples = np.linspace(-max_omega, max_omega, num_samples)
 
     num_samples = len(acc_samples) * len(omega_y_samples)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -424,22 +424,24 @@ class PlanningNode(Node):
         self.footprint_pub.publish(msg)
 
     def _front_obstacle_dist(self, T, obstacle_mask, max_dist=0.5):
-        """Distance to the nearest obstacle in the forward corridor (robot width), up to max_dist."""
+        """Distance from the robot's front face to the nearest obstacle in the forward corridor.
+        Scans start at the front face so the returned value matches physical clearance."""
         center = self.camera_to_robot_center(T)
         fwd = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
         n = (fwd[0] ** 2 + fwd[1] ** 2) ** 0.5
         fx, fy = (fwd[0] / n, fwd[1] / n) if n > 1e-6 else (1.0, 0.0)
         lx, ly = -fy, fx
-        _, _, hw = self.robot.footprint_from_control()
+        fl, _, hw = self.robot.footprint_from_control()
         rows, cols = obstacle_mask.shape
         steps = int(max_dist / self.resolution) + 1
         for step in range(steps):
-            d = step * self.resolution
+            d_from_face = step * self.resolution
+            d_from_center = fl + d_from_face
             for w in (-hw, 0.0, hw):
-                xi = int((center[0] + fx * d + lx * w - self.origin[0]) / self.resolution)
-                yi = int((center[1] + fy * d + ly * w - self.origin[1]) / self.resolution)
+                xi = int((center[0] + fx * d_from_center + lx * w - self.origin[0]) / self.resolution)
+                yi = int((center[1] + fy * d_from_center + ly * w - self.origin[1]) / self.resolution)
                 if 0 <= xi < rows and 0 <= yi < cols and obstacle_mask[xi, yi]:
-                    return d
+                    return d_from_face
         return max_dist + 1.0
 
     def publish_obstacle_mask(self, mask, stamp):

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -12,7 +12,7 @@ from rclpy.time import Time
 from sensor_msgs.msg import PointCloud2, PointCloud
 from geometry_msgs.msg import PoseStamped, Point32
 import sensor_msgs_py.point_cloud2 as pc2
-from std_msgs.msg import Header
+from std_msgs.msg import Header, Float32
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
@@ -373,6 +373,8 @@ class PlanningNode(Node):
         self.create_subscription(Odometry, '/control/target_pose', self.target_pose_callback, 10)
         self.target_pose = None
 
+        self.clearance_pub = self.create_publisher(Float32, '/planning/robot_clearance', 10)
+
         self.poi_change_sub = self.create_subscription(Odometry, "/mapping/poi_change", self.poi_change_callback, 10)
 
     def poi_change_callback(self, msg):
@@ -420,6 +422,26 @@ class PlanningNode(Node):
         msg.header.frame_id = "world"
         msg.points = points
         self.footprint_pub.publish(msg)
+
+    def _robot_clearance(self, T, ESDF_map):
+        """Min ESDF clearance over the robot footprint at the current pose."""
+        center = self.camera_to_robot_center(T)
+        x_w, y_w = center[0], center[1]
+        fwd = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
+        n = (fwd[0] ** 2 + fwd[1] ** 2) ** 0.5
+        fx, fy = (fwd[0] / n, fwd[1] / n) if n > 1e-6 else (1.0, 0.0)
+        lx, ly = -fy, fx
+        fl, rl, hw = self.robot.footprint_from_control()
+        check_xs = (x_w, x_w + fx*fl + lx*hw, x_w + fx*fl - lx*hw, x_w - fx*rl + lx*hw, x_w - fx*rl - lx*hw)
+        check_ys = (y_w, y_w + fy*fl + ly*hw, y_w + fy*fl - ly*hw, y_w - fy*rl + ly*hw, y_w - fy*rl - ly*hw)
+        rows, cols = ESDF_map.shape
+        min_dist = 999.0
+        for k in range(5):
+            xi = int((check_xs[k] - self.origin[0]) / self.resolution)
+            yi = int((check_ys[k] - self.origin[1]) / self.resolution)
+            if 0 <= xi < rows and 0 <= yi < cols:
+                min_dist = min(min_dist, float(ESDF_map[xi, yi]))
+        return min_dist
 
     def publish_obstacle_mask(self, mask, stamp):
         msg = OccupancyGrid()
@@ -543,6 +565,7 @@ class PlanningNode(Node):
                 robot_z=T[2, 3], config=self.obstacle_config,
             )
             ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
+            self.clearance_pub.publish(Float32(data=self._robot_clearance(T, ESDF_map)))
 
         with Timer(name='vis', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             self.publish_3d_occupancy_cloud_with_esdf(self.occupancy_grid, ESDF_map, self.resolution, self.origin)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -373,7 +373,7 @@ class PlanningNode(Node):
         self.create_subscription(Odometry, '/control/target_pose', self.target_pose_callback, 10)
         self.target_pose = None
 
-        self.clearance_pub = self.create_publisher(Float32, '/planning/robot_clearance', 10)
+        self.front_dist_pub = self.create_publisher(Float32, '/planning/front_dist', 10)
 
         self.poi_change_sub = self.create_subscription(Odometry, "/mapping/poi_change", self.poi_change_callback, 10)
 
@@ -423,25 +423,24 @@ class PlanningNode(Node):
         msg.points = points
         self.footprint_pub.publish(msg)
 
-    def _robot_clearance(self, T, ESDF_map):
-        """Min ESDF clearance over the robot footprint at the current pose."""
+    def _front_obstacle_dist(self, T, obstacle_mask, max_dist=0.5):
+        """Distance to the nearest obstacle in the forward corridor (robot width), up to max_dist."""
         center = self.camera_to_robot_center(T)
-        x_w, y_w = center[0], center[1]
         fwd = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
         n = (fwd[0] ** 2 + fwd[1] ** 2) ** 0.5
         fx, fy = (fwd[0] / n, fwd[1] / n) if n > 1e-6 else (1.0, 0.0)
         lx, ly = -fy, fx
-        fl, rl, hw = self.robot.footprint_from_control()
-        check_xs = (x_w, x_w + fx*fl + lx*hw, x_w + fx*fl - lx*hw, x_w - fx*rl + lx*hw, x_w - fx*rl - lx*hw)
-        check_ys = (y_w, y_w + fy*fl + ly*hw, y_w + fy*fl - ly*hw, y_w - fy*rl + ly*hw, y_w - fy*rl - ly*hw)
-        rows, cols = ESDF_map.shape
-        min_dist = 999.0
-        for k in range(5):
-            xi = int((check_xs[k] - self.origin[0]) / self.resolution)
-            yi = int((check_ys[k] - self.origin[1]) / self.resolution)
-            if 0 <= xi < rows and 0 <= yi < cols:
-                min_dist = min(min_dist, float(ESDF_map[xi, yi]))
-        return min_dist
+        _, _, hw = self.robot.footprint_from_control()
+        rows, cols = obstacle_mask.shape
+        steps = int(max_dist / self.resolution) + 1
+        for step in range(steps):
+            d = step * self.resolution
+            for w in (-hw, 0.0, hw):
+                xi = int((center[0] + fx * d + lx * w - self.origin[0]) / self.resolution)
+                yi = int((center[1] + fy * d + ly * w - self.origin[1]) / self.resolution)
+                if 0 <= xi < rows and 0 <= yi < cols and obstacle_mask[xi, yi]:
+                    return d
+        return max_dist + 1.0
 
     def publish_obstacle_mask(self, mask, stamp):
         msg = OccupancyGrid()
@@ -565,7 +564,7 @@ class PlanningNode(Node):
                 robot_z=T[2, 3], config=self.obstacle_config,
             )
             ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
-            self.clearance_pub.publish(Float32(data=self._robot_clearance(T, ESDF_map)))
+            self.front_dist_pub.publish(Float32(data=self._front_obstacle_dist(T, obstacle_mask)))
 
         with Timer(name='vis', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             self.publish_3d_occupancy_cloud_with_esdf(self.occupancy_grid, ESDF_map, self.resolution, self.origin)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -602,15 +602,16 @@ class PlanningNode(Node):
                     self.path_pub.publish(path)
                     return
 
+            if self.target_pose is None and not self.poi_changed:
+                self.path_pub.publish(path)  # empty path — no active nav target
+                return
+
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):
                     x,y,z,qx,qy,qz,qw = trajectories[i][j]
-                    if self.poi_changed or self.target_pose is None:
+                    if self.poi_changed:
                         x,y,z,qx,qy,qz,qw = trajectories[i][0]
-                        if self.poi_changed:
-                            self.get_logger().info(f"poi changed, using first point, wait {(depth_msg.header.stamp.sec - self.poi_change_timestamp_sec)} seconds")
-                        if self.target_pose is None:
-                            self.get_logger().info("target pose is None, using first point")
+                        self.get_logger().info(f"poi changed, using first point, wait {(depth_msg.header.stamp.sec - self.poi_change_timestamp_sec)} seconds")
 
                     pose = PoseStamped()
                     pose.header = depth_msg.header

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -51,7 +51,7 @@ class RobotConfig:
 
 GO2_CONFIG = RobotConfig(
     name='go2', shape='square',
-    length=0.7, width=0.3,
+    length=0.4, width=0.3,
     camera_x=0.35, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.1,
@@ -155,7 +155,7 @@ class ObstacleConfig:
     robot_z_top: float = 0.5
     occ_threshold: float = 0.1
     min_wall_span_m: float = 0.4
-    dilation_cells: int = 3
+    dilation_cells: int = 1
 
 
 def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None):
@@ -559,11 +559,19 @@ class PlanningNode(Node):
             v_dir = T[:3, :3] @ np.array([0, 0, 1])
             magnitude = np.clip(self.smoothed_velocity, 0.05, 0.5)
             init_v = v_dir * float(magnitude)
+            init_p = self.camera_to_robot_center(T)
+            init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
             trajectories, params = generate_trajectory_library_3d(
-                init_p = self.camera_to_robot_center(T),
-                init_v = init_v,
-                init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
+                init_p=init_p, init_v=init_v, init_q=init_q
             )
+            # Backward recovery trajectories: fewer samples, fixed slow reverse speed.
+            # Scored together with forward; penalised in cost so forward is always preferred.
+            back_trajs, back_params = generate_trajectory_library_3d(
+                num_samples=5, init_p=init_p, init_v=-v_dir * 0.15, init_q=init_q
+            )
+            is_backward = np.array([False] * len(trajectories) + [True] * len(back_trajs))
+            trajectories = np.concatenate([trajectories, back_trajs], axis=0)
+            params = np.concatenate([params, back_params], axis=0)
             self.last_T = T
             self.last_stamp = stamp
 
@@ -574,14 +582,15 @@ class PlanningNode(Node):
             top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            def cost_function(traj, param, score, target_pose):
+            def cost_function(traj, param, score, target_pose, backward):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1])
+                backward_penalty = 10000.0 if backward else 0.0
+                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + backward_penalty
 
             top_k = 1
-            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
+            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose, bool(is_backward[i])) for i in range(len(trajectories))]), kind='stable')[:top_k]
             self.last_param = params[top_indices[0]]
 
             if self.poi_changed and (depth_msg.header.stamp.sec - self.poi_change_timestamp_sec) > 3.0:
@@ -606,57 +615,7 @@ class PlanningNode(Node):
                 self.path_pub.publish(path)  # empty path — no active nav target
                 return
 
-            # Obstacle recovery: if robot is within 0.3m of an obstacle, normal planning
-            # cannot escape. Back up if the rear is clear, otherwise stop.
-            robot_pos = T[:3, 3]
-            rx = int((robot_pos[0] - self.origin[0]) / self.resolution)
-            ry = int((robot_pos[1] - self.origin[1]) / self.resolution)
-            if 0 <= rx < ESDF_map.shape[0] and 0 <= ry < ESDF_map.shape[1]:
-                robot_clearance = float(ESDF_map[rx, ry])
-            else:
-                robot_clearance = float('inf')
-
-            if robot_clearance < 0.3:
-                forward = T[:3, :3] @ np.array([0.0, 0.0, 1.0])  # camera +Z = forward
-                back_sample = robot_pos - forward * 0.5
-                bx = int((back_sample[0] - self.origin[0]) / self.resolution)
-                by = int((back_sample[1] - self.origin[1]) / self.resolution)
-                if 0 <= bx < ESDF_map.shape[0] and 0 <= by < ESDF_map.shape[1]:
-                    back_clearance = float(ESDF_map[bx, by])
-                else:
-                    back_clearance = float('inf')
-
-                if back_clearance > 0.3:
-                    # Rear is clear: publish a 2-pose backward path.
-                    # cmd_vel_control will compute negative vx from the backward displacement.
-                    q = odom_msg.pose.pose.orientation
-                    back_target = robot_pos - forward * 0.5
-
-                    def _make_pose(pos):
-                        ps = PoseStamped()
-                        ps.header = depth_msg.header
-                        ps.pose.position.x = float(pos[0])
-                        ps.pose.position.y = float(pos[1])
-                        ps.pose.position.z = float(pos[2])
-                        ps.pose.orientation = q
-                        return ps
-
-                    recovery_path = Path()
-                    recovery_path.header = depth_msg.header
-                    recovery_path.header.frame_id = 'world'
-                    recovery_path.poses = [_make_pose(robot_pos), _make_pose(back_target)]
-                    self.get_logger().info(
-                        f'Recovery: backing up (robot_clearance={robot_clearance:.2f}m, back={back_clearance:.2f}m)'
-                    )
-                    self.path_pub.publish(recovery_path)
-                else:
-                    self.get_logger().info(
-                        f'Recovery: stuck, both sides blocked (robot={robot_clearance:.2f}m, back={back_clearance:.2f}m), stopping'
-                    )
-                    self.path_pub.publish(path)  # empty path
-                return
-
-            # If every trajectory is in collision, stop rather than picking an arbitrary one.
+            # If every trajectory is in collision (forward and backward), stop.
             if all(s == float('inf') for s in scores):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 self.path_pub.publish(path)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -595,7 +595,7 @@ class PlanningNode(Node):
 
             # target_pose is camera-frame (POI recorded as camera pose); compare against T[:3, 3] directly.
             dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2])) if self.target_pose is not None else float('inf')
-            if dist_to_goal < 0.3:
+            if dist_to_goal < 0.5:
                 self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
                 self.path_pub.publish(path)
                 return

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -601,12 +601,11 @@ class PlanningNode(Node):
             path.header.frame_id = "world"
 
             # target_pose is camera-frame (POI recorded as camera pose); compare against T[:3, 3] directly.
-            if self.target_pose is not None:
-                dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2]))
-                if dist_to_goal < 0.3:
-                    self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
-                    self.path_pub.publish(path)
-                    return
+            dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2])) if self.target_pose is not None else float('inf')
+            if dist_to_goal < 0.3:
+                self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
+                self.path_pub.publish(path)
+                return
 
             if self.target_pose is None and not self.poi_changed:
                 self.path_pub.publish(path)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -12,7 +12,7 @@ from rclpy.time import Time
 from sensor_msgs.msg import PointCloud2, PointCloud
 from geometry_msgs.msg import PoseStamped, Point32
 import sensor_msgs_py.point_cloud2 as pc2
-from std_msgs.msg import Header, Float32
+from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
@@ -250,7 +250,7 @@ def score_trajectories_by_ESDF(trajectories, ESDF_map, origin, resolution, safet
         min_dist_for_traj = float('inf')
         closest_step_for_traj = -1
 
-        for i in range(len(traj)):
+        for i in range(1, len(traj)):  # skip step-0 (robot's current position) to avoid score contamination
             x_world, y_world = traj[i, 0], traj[i, 1]
             qx, qy, qz, qw = traj[i, 3], traj[i, 4], traj[i, 5], traj[i, 6]
 
@@ -373,8 +373,6 @@ class PlanningNode(Node):
         self.create_subscription(Odometry, '/control/target_pose', self.target_pose_callback, 10)
         self.target_pose = None
 
-        self.front_dist_pub = self.create_publisher(Float32, '/planning/front_dist', 10)
-
         self.poi_change_sub = self.create_subscription(Odometry, "/mapping/poi_change", self.poi_change_callback, 10)
 
     def poi_change_callback(self, msg):
@@ -422,27 +420,6 @@ class PlanningNode(Node):
         msg.header.frame_id = "world"
         msg.points = points
         self.footprint_pub.publish(msg)
-
-    def _front_obstacle_dist(self, T, obstacle_mask, max_dist=0.5):
-        """Distance from the robot's front face to the nearest obstacle in the forward corridor.
-        Scans start at the front face so the returned value matches physical clearance."""
-        center = self.camera_to_robot_center(T)
-        fwd = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
-        n = (fwd[0] ** 2 + fwd[1] ** 2) ** 0.5
-        fx, fy = (fwd[0] / n, fwd[1] / n) if n > 1e-6 else (1.0, 0.0)
-        lx, ly = -fy, fx
-        fl, _, hw = self.robot.footprint_from_control()
-        rows, cols = obstacle_mask.shape
-        steps = int(max_dist / self.resolution) + 1
-        for step in range(steps):
-            d_from_face = step * self.resolution
-            d_from_center = fl + d_from_face
-            for w in (-hw, 0.0, hw):
-                xi = int((center[0] + fx * d_from_center + lx * w - self.origin[0]) / self.resolution)
-                yi = int((center[1] + fy * d_from_center + ly * w - self.origin[1]) / self.resolution)
-                if 0 <= xi < rows and 0 <= yi < cols and obstacle_mask[xi, yi]:
-                    return d_from_face
-        return max_dist + 1.0
 
     def publish_obstacle_mask(self, mask, stamp):
         msg = OccupancyGrid()
@@ -566,8 +543,6 @@ class PlanningNode(Node):
                 robot_z=T[2, 3], config=self.obstacle_config,
             )
             ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
-            self.front_dist_pub.publish(Float32(data=self._front_obstacle_dist(T, obstacle_mask)))
-
         with Timer(name='vis', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             self.publish_3d_occupancy_cloud_with_esdf(self.occupancy_grid, ESDF_map, self.resolution, self.origin)
             self.publish_height_map(T[:3,3], ESDF_map, depth_msg.header)
@@ -586,7 +561,7 @@ class PlanningNode(Node):
             )
             # Penalised in cost so forward is always preferred when unblocked.
             back_trajs, back_params = generate_trajectory_library_3d(
-                num_samples=5, init_p=init_p, init_v=-v_dir * 0.15, init_q=init_q
+                num_samples=5, init_p=init_p, init_v=-v_dir * 0.2, init_q=init_q
             )
             is_backward = np.array([False] * len(trajectories) + [True] * len(back_trajs))
             trajectories = np.concatenate([trajectories, back_trajs], axis=0)
@@ -601,11 +576,35 @@ class PlanningNode(Node):
             top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
+            # Adaptive backward penalty: linearly scales from 10000 (far) to 0 (in contact).
+            fl_r, rl_r, hw_r = self.robot.footprint_from_control()
+            rc = self.camera_to_robot_center(T)
+            fwd_r = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
+            nr = (fwd_r[0]**2 + fwd_r[1]**2)**0.5
+            frx, fry = (fwd_r[0]/nr, fwd_r[1]/nr) if nr > 1e-6 else (1.0, 0.0)
+            llx, lly = -fry, frx
+            rc_pts = [
+                (rc[0], rc[1]),
+                (rc[0] + frx*fl_r + llx*hw_r, rc[1] + fry*fl_r + lly*hw_r),
+                (rc[0] + frx*fl_r - llx*hw_r, rc[1] + fry*fl_r - lly*hw_r),
+                (rc[0] - frx*rl_r + llx*hw_r, rc[1] - fry*rl_r + lly*hw_r),
+                (rc[0] - frx*rl_r - llx*hw_r, rc[1] - fry*rl_r - lly*hw_r),
+            ]
+            Er, Ec = ESDF_map.shape
+            robot_clearance = 999.0
+            for px_, py_ in rc_pts:
+                xi_ = int((px_ - self.origin[0]) / self.resolution)
+                yi_ = int((py_ - self.origin[1]) / self.resolution)
+                if 0 <= xi_ < Er and 0 <= yi_ < Ec:
+                    robot_clearance = min(robot_clearance, float(ESDF_map[xi_, yi_]))
+            # Penalty drops to 0 when robot is at safety_radius; full penalty beyond 0.3m.
+            penalty_scale = float(np.clip(robot_clearance / 0.3, 0.0, 1.0))
+
             def cost_function(traj, param, score, target_pose, backward):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
-                backward_penalty = 10000.0 if backward else 0.0
+                backward_penalty = 10000.0 * penalty_scale if backward else 0.0
                 return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + backward_penalty
 
             top_k = 1

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -606,6 +606,62 @@ class PlanningNode(Node):
                 self.path_pub.publish(path)  # empty path — no active nav target
                 return
 
+            # Obstacle recovery: if robot is within 0.3m of an obstacle, normal planning
+            # cannot escape. Back up if the rear is clear, otherwise stop.
+            robot_pos = T[:3, 3]
+            rx = int((robot_pos[0] - self.origin[0]) / self.resolution)
+            ry = int((robot_pos[1] - self.origin[1]) / self.resolution)
+            if 0 <= rx < ESDF_map.shape[0] and 0 <= ry < ESDF_map.shape[1]:
+                robot_clearance = float(ESDF_map[rx, ry])
+            else:
+                robot_clearance = float('inf')
+
+            if robot_clearance < 0.3:
+                forward = T[:3, :3] @ np.array([0.0, 0.0, 1.0])  # camera +Z = forward
+                back_sample = robot_pos - forward * 0.5
+                bx = int((back_sample[0] - self.origin[0]) / self.resolution)
+                by = int((back_sample[1] - self.origin[1]) / self.resolution)
+                if 0 <= bx < ESDF_map.shape[0] and 0 <= by < ESDF_map.shape[1]:
+                    back_clearance = float(ESDF_map[bx, by])
+                else:
+                    back_clearance = float('inf')
+
+                if back_clearance > 0.3:
+                    # Rear is clear: publish a 2-pose backward path.
+                    # cmd_vel_control will compute negative vx from the backward displacement.
+                    q = odom_msg.pose.pose.orientation
+                    back_target = robot_pos - forward * 0.5
+
+                    def _make_pose(pos):
+                        ps = PoseStamped()
+                        ps.header = depth_msg.header
+                        ps.pose.position.x = float(pos[0])
+                        ps.pose.position.y = float(pos[1])
+                        ps.pose.position.z = float(pos[2])
+                        ps.pose.orientation = q
+                        return ps
+
+                    recovery_path = Path()
+                    recovery_path.header = depth_msg.header
+                    recovery_path.header.frame_id = 'world'
+                    recovery_path.poses = [_make_pose(robot_pos), _make_pose(back_target)]
+                    self.get_logger().info(
+                        f'Recovery: backing up (robot_clearance={robot_clearance:.2f}m, back={back_clearance:.2f}m)'
+                    )
+                    self.path_pub.publish(recovery_path)
+                else:
+                    self.get_logger().info(
+                        f'Recovery: stuck, both sides blocked (robot={robot_clearance:.2f}m, back={back_clearance:.2f}m), stopping'
+                    )
+                    self.path_pub.publish(path)  # empty path
+                return
+
+            # If every trajectory is in collision, stop rather than picking an arbitrary one.
+            if all(s == float('inf') for s in scores):
+                self.get_logger().info('All trajectories in collision, stopping path.')
+                self.path_pub.publish(path)
+                return
+
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):
                     x,y,z,qx,qy,qz,qw = trajectories[i][j]

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -3,7 +3,7 @@ from rclpy.node import Node
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Path
 from nav_msgs.msg import Odometry
-from std_msgs.msg import Bool, Float32
+from std_msgs.msg import Bool
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from scipy.spatial.transform import Rotation as R
 import numpy as np
@@ -56,19 +56,10 @@ class CmdVelControlNode(Node):
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
         self._paused = False
-        # Forced-backward reflex: reverse when forward obstacle is within this distance.
-        self.front_clear_dist = 0.30
-        self.front_dist = 999.0
-        self.last_front_time = None
-        self.create_subscription(Float32, '/planning/front_dist', self._on_front_dist, 10)
         _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
         self.create_subscription(Bool, '/nav/paused', self._on_paused, _latched_qos)
         self.cmd_timer = self.create_timer(1.0 / self.cmd_rate_hz, self.cmd_timer_callback)
         
-    def _on_front_dist(self, msg: Float32):
-        self.front_dist = msg.data
-        self.last_front_time = time.monotonic()
-
     def _on_paused(self, msg: Bool):
         self._paused = msg.data
         if not self._paused:
@@ -119,15 +110,6 @@ class CmdVelControlNode(Node):
             out.linear.x = self.min_effective_linear_speed
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
-
-        front_age = float('inf') if self.last_front_time is None else (now - self.last_front_time)
-        if front_age < 0.5 and self.front_dist < self.front_clear_dist:
-            out = Twist()
-            out.linear.x = -self.fixed_reverse_speed
-            self.logger.warn(f"Forced backward: front obstacle at {self.front_dist:.2f}m")
-            self.cmd_pub.publish(out)
-            self.prev_cmd = out
-            return
 
         self.cmd_pub.publish(out)
         self.prev_cmd = out

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -87,11 +87,14 @@ class CmdVelControlNode(Node):
         out.linear.x = self._clamp_step(target_cmd.linear.x, self.prev_cmd.linear.x, max_dv)
         out.angular.z = self._clamp_step(target_cmd.angular.z, self.prev_cmd.angular.z, max_dw)
         out.linear.y = 0.0
-        # Dead-band: < 0.05 → 0; small positive → snap to min effective speed.
+        # Dead-band: < 0.05 → 0.
+        # Snap to min effective speed only when starting from standstill
+        # (prev_cmd near zero) — avoids locking robot at 0.2 while decelerating.
         if abs(out.linear.x) < 0.05:
             out.linear.x = 0.0
         elif 0 < out.linear.x < self.min_effective_linear_speed:
-            out.linear.x = self.min_effective_linear_speed
+            if self.prev_cmd.linear.x < 0.05:
+                out.linear.x = self.min_effective_linear_speed
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
 

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -87,17 +87,13 @@ class CmdVelControlNode(Node):
         out.linear.x = self._clamp_step(target_cmd.linear.x, self.prev_cmd.linear.x, max_dv)
         out.angular.z = self._clamp_step(target_cmd.angular.z, self.prev_cmd.angular.z, max_dw)
         out.linear.y = 0.0
-        # Dead-band: suppress noise below engage threshold.
-        if abs(out.linear.x) < 0.1:
+        # Dead-band: < 0.05 → 0; 0.05~0.2 → snap to min effective speed.
+        if abs(out.linear.x) < 0.05:
             out.linear.x = 0.0
+        elif abs(out.linear.x) < self.min_effective_linear_speed:
+            out.linear.x = float(np.sign(out.linear.x) * self.min_effective_linear_speed)
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
-        # Keep a minimum forward speed when planner requests motion and path is fresh.
-        elif (
-            age <= stale_slow_s
-            and abs(out.linear.x) < self.min_effective_linear_speed
-        ):
-            out.linear.x = float(np.sign(out.linear.x) * self.min_effective_linear_speed)
 
         self.cmd_pub.publish(out)
         self.prev_cmd = out

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -3,7 +3,7 @@ from rclpy.node import Node
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Path
 from nav_msgs.msg import Odometry
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, Float32
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from scipy.spatial.transform import Rotation as R
 import numpy as np
@@ -56,10 +56,21 @@ class CmdVelControlNode(Node):
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
         self._paused = False
+        # Forced-backward reflex: override path when physically too close to obstacle.
+        self.force_reverse_enter = 0.10  # m — start forcing backward below this
+        self.force_reverse_exit  = 0.30  # m — stop forcing backward once clearance reaches this
+        self._force_reversing = False
+        self.robot_clearance = 999.0
+        self.last_clearance_time = None
+        self.create_subscription(Float32, '/planning/robot_clearance', self._on_clearance, 10)
         _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
         self.create_subscription(Bool, '/nav/paused', self._on_paused, _latched_qos)
         self.cmd_timer = self.create_timer(1.0 / self.cmd_rate_hz, self.cmd_timer_callback)
         
+    def _on_clearance(self, msg: Float32):
+        self.robot_clearance = msg.data
+        self.last_clearance_time = time.monotonic()
+
     def _on_paused(self, msg: Bool):
         self._paused = msg.data
         if not self._paused:
@@ -110,6 +121,22 @@ class CmdVelControlNode(Node):
             out.linear.x = self.min_effective_linear_speed
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
+
+        clearance_age = float('inf') if self.last_clearance_time is None else (now - self.last_clearance_time)
+        if clearance_age < 0.5:
+            if self.robot_clearance < self.force_reverse_enter:
+                self._force_reversing = True
+            elif self.robot_clearance >= self.force_reverse_exit:
+                self._force_reversing = False
+        else:
+            self._force_reversing = False
+        if self._force_reversing:
+            out = Twist()
+            out.linear.x = -self.fixed_reverse_speed
+            self.logger.warn(f"Forced backward: clearance={self.robot_clearance:.3f}m")
+            self.cmd_pub.publish(out)
+            self.prev_cmd = out
+            return
 
         self.cmd_pub.publish(out)
         self.prev_cmd = out

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -90,9 +90,8 @@ class CmdVelControlNode(Node):
         # Snap to min effective speed only when starting from standstill — avoids locking at min speed while decelerating.
         if abs(out.linear.x) < 0.05:
             out.linear.x = 0.0
-        elif 0 < out.linear.x < self.min_effective_linear_speed:
-            if self.prev_cmd.linear.x < 0.05:
-                out.linear.x = self.min_effective_linear_speed
+        elif 0 < out.linear.x < self.min_effective_linear_speed and self.prev_cmd.linear.x < 0.05:
+            out.linear.x = self.min_effective_linear_speed
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
 

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -87,11 +87,11 @@ class CmdVelControlNode(Node):
         out.linear.x = self._clamp_step(target_cmd.linear.x, self.prev_cmd.linear.x, max_dv)
         out.angular.z = self._clamp_step(target_cmd.angular.z, self.prev_cmd.angular.z, max_dw)
         out.linear.y = 0.0
-        # Dead-band: < 0.05 → 0; 0.05~0.2 → snap to min effective speed.
+        # Dead-band: < 0.05 → 0; small positive → snap to min effective speed.
         if abs(out.linear.x) < 0.05:
             out.linear.x = 0.0
-        elif abs(out.linear.x) < self.min_effective_linear_speed:
-            out.linear.x = float(np.sign(out.linear.x) * self.min_effective_linear_speed)
+        elif 0 < out.linear.x < self.min_effective_linear_speed:
+            out.linear.x = self.min_effective_linear_speed
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
 

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -87,9 +87,7 @@ class CmdVelControlNode(Node):
         out.linear.x = self._clamp_step(target_cmd.linear.x, self.prev_cmd.linear.x, max_dv)
         out.angular.z = self._clamp_step(target_cmd.angular.z, self.prev_cmd.angular.z, max_dw)
         out.linear.y = 0.0
-        # Dead-band: < 0.05 → 0.
-        # Snap to min effective speed only when starting from standstill
-        # (prev_cmd near zero) — avoids locking robot at 0.2 while decelerating.
+        # Snap to min effective speed only when starting from standstill — avoids locking at min speed while decelerating.
         if abs(out.linear.x) < 0.05:
             out.linear.x = 0.0
         elif 0 < out.linear.x < self.min_effective_linear_speed:

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -49,7 +49,7 @@ class CmdVelControlNode(Node):
         # Static-friction compensation: very small vx often cannot move the robot.
         self.min_effective_linear_speed = 0.2
         self.linear_engage_threshold = 0.04
-        self.fixed_reverse_speed = 0.1
+        self.fixed_reverse_speed = 0.2
 
         self.latest_cmd = Twist()
         self.prev_cmd = Twist()

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -135,7 +135,7 @@ class CmdVelControlNode(Node):
         r = R.from_matrix(T_robot_2_to_1[:3, :3])
         angular_velocity_vec = r.as_rotvec() / dt
 
-        vx = np.clip(linear_velocity_vec[0], -0.1, 0.3)
+        vx = np.clip(linear_velocity_vec[0], -0.1, 0.5)
         if vx < 0.0:
             vx = -self.fixed_reverse_speed
         vy = 0.0

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -87,13 +87,17 @@ class CmdVelControlNode(Node):
         out.linear.x = self._clamp_step(target_cmd.linear.x, self.prev_cmd.linear.x, max_dv)
         out.angular.z = self._clamp_step(target_cmd.angular.z, self.prev_cmd.angular.z, max_dw)
         out.linear.y = 0.0
+        # Dead-band: suppress noise below engage threshold.
+        if abs(out.linear.x) < 0.1:
+            out.linear.x = 0.0
+        if abs(out.angular.z) < 0.05:
+            out.angular.z = 0.0
         # Keep a minimum forward speed when planner requests motion and path is fresh.
-        if (
+        elif (
             age <= stale_slow_s
-            and abs(target_cmd.linear.x) >= self.linear_engage_threshold
             and abs(out.linear.x) < self.min_effective_linear_speed
         ):
-            out.linear.x = float(np.sign(target_cmd.linear.x) * self.min_effective_linear_speed)
+            out.linear.x = float(np.sign(out.linear.x) * self.min_effective_linear_speed)
 
         self.cmd_pub.publish(out)
         self.prev_cmd = out

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -56,20 +56,18 @@ class CmdVelControlNode(Node):
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
         self._paused = False
-        # Forced-backward reflex: override path when physically too close to obstacle.
-        self.force_reverse_enter = 0.10  # m — start forcing backward below this
-        self.force_reverse_exit  = 0.30  # m — stop forcing backward once clearance reaches this
-        self._force_reversing = False
-        self.robot_clearance = 999.0
-        self.last_clearance_time = None
-        self.create_subscription(Float32, '/planning/robot_clearance', self._on_clearance, 10)
+        # Forced-backward reflex: reverse when forward obstacle is within this distance.
+        self.front_clear_dist = 0.30
+        self.front_dist = 999.0
+        self.last_front_time = None
+        self.create_subscription(Float32, '/planning/front_dist', self._on_front_dist, 10)
         _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
         self.create_subscription(Bool, '/nav/paused', self._on_paused, _latched_qos)
         self.cmd_timer = self.create_timer(1.0 / self.cmd_rate_hz, self.cmd_timer_callback)
         
-    def _on_clearance(self, msg: Float32):
-        self.robot_clearance = msg.data
-        self.last_clearance_time = time.monotonic()
+    def _on_front_dist(self, msg: Float32):
+        self.front_dist = msg.data
+        self.last_front_time = time.monotonic()
 
     def _on_paused(self, msg: Bool):
         self._paused = msg.data
@@ -122,18 +120,11 @@ class CmdVelControlNode(Node):
         if abs(out.angular.z) < 0.05:
             out.angular.z = 0.0
 
-        clearance_age = float('inf') if self.last_clearance_time is None else (now - self.last_clearance_time)
-        if clearance_age < 0.5:
-            if self.robot_clearance < self.force_reverse_enter:
-                self._force_reversing = True
-            elif self.robot_clearance >= self.force_reverse_exit:
-                self._force_reversing = False
-        else:
-            self._force_reversing = False
-        if self._force_reversing:
+        front_age = float('inf') if self.last_front_time is None else (now - self.last_front_time)
+        if front_age < 0.5 and self.front_dist < self.front_clear_dist:
             out = Twist()
             out.linear.x = -self.fixed_reverse_speed
-            self.logger.warn(f"Forced backward: clearance={self.robot_clearance:.3f}m")
+            self.logger.warn(f"Forced backward: front obstacle at {self.front_dist:.2f}m")
             self.cmd_pub.publish(out)
             self.prev_cmd = out
             return

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -3,6 +3,8 @@ from rclpy.node import Node
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Path
 from nav_msgs.msg import Odometry
+from std_msgs.msg import Bool
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from scipy.spatial.transform import Rotation as R
 import numpy as np
 import logging
@@ -53,8 +55,17 @@ class CmdVelControlNode(Node):
         self.prev_cmd = Twist()
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
+        self._paused = False
+        _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.create_subscription(Bool, '/nav/paused', self._on_paused, _latched_qos)
         self.cmd_timer = self.create_timer(1.0 / self.cmd_rate_hz, self.cmd_timer_callback)
         
+    def _on_paused(self, msg: Bool):
+        self._paused = msg.data
+        if not self._paused:
+            # Reset prev_cmd so resume starts from zero cleanly
+            self.prev_cmd = Twist()
+
     def pose_callback(self, msg):
         self.pose = msg
 
@@ -65,6 +76,11 @@ class CmdVelControlNode(Node):
         now = time.monotonic()
         dt = max(1e-3, now - self.last_cmd_pub_time)
         self.last_cmd_pub_time = now
+
+        if self._paused:
+            self.cmd_pub.publish(Twist())
+            self.prev_cmd = Twist()
+            return
 
         # Stale-path protection: slow down, then stop if planner has not refreshed.
         age = float('inf') if self.last_path_update_time is None else (now - self.last_path_update_time)


### PR DESCRIPTION
  - **POI nav UI** (`operate_tab.dart`): Replace per-POI "Go" buttons with checkbox-based                                                                                            
    multi-select and a single "Nav" button. Navigates to the first checked POI.
    Multi-waypoint sequential nav is not yet implemented.                                                                                                                            
                  
  - **Backward recovery** (`planning_node.py`): Generate 5 backward trajectories alongside                                                                                           
    the forward library and score them jointly. A 10 000-point penalty ensures reverse is
    only chosen when all forward paths are blocked（junlin used to do before）.                                                                                                                                  
                                                                                                                                                                                     
  - **Planning robustness** (`planning_node.py`):                                                                                                                                    
    - Tighter Go2 footprint (length 0.7 → 0.4 m) and reduced map dilation (3 → 1 cell).                                                                                              
    - Goal-reached check: compare camera position to `target_pose`; publish empty path and                                                                                           
      stop when within 0.3 m.                                                                                                                                                        
    - Publish empty path immediately when `target_pose` is `None` (no active nav target).                                                                                            
    - All-collision stop: if every trajectory (forward + backward) scores `inf`, halt.                                                                                               
                                                                                                                                                                                     
  - **cmd_vel fixes** (`cmd_vel_control.py`):                                                                                                                                        
    - Hard dead-band: suppress linear and angular commands below 0.05 m/s / rad/s.                                                                                                   
    - Snap to `min_effective_linear_speed` only when starting from standstill, not during                                                                                            
      deceleration.                                                                                                                                                                  
    - Raise max linear velocity cap 0.3 → 0.5 m/s.                                                                                                                                   
                                                                                                                                                                                     
  - **Mapping percent bridge** (`node_manager.py`): In looper mode, spawn a subprocess on
    domain 231 that forwards `/mapping/percent` to the backend via pipe, so the UI progress                                                                                          
    bar works correctly during map build.


https://github.com/user-attachments/assets/78f2952e-8df5-42d3-839c-67b64e73f334

