### PR TITLE
multi-POI selection, cancel, and pause/continue  

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -23,10 +23,11 @@ import base64
 import rclpy
 import rclpy.time
 import tf2_ros
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
 from sensor_msgs.msg import CompressedImage, Image
-from std_msgs.msg import Float32, String
+from std_msgs.msg import Bool, Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
 
@@ -106,6 +107,11 @@ class BackendNode(Ros2NodeManager):
 
         # Publisher for POI nav target consumed by map_node via /mapping/cmd_pois
         self._cmd_pois_pub = self.create_publisher(String, '/mapping/cmd_pois', 10)
+
+        # Latched publisher — new subscribers (cmd_vel_control) get current state immediately on connect
+        _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self._pause_pub = self.create_publisher(Bool, '/nav/paused', _latched_qos)
+        self._nav_paused = False
 
         # Publisher for robot action commands (sit / stand)
         self._action_pub = self.create_publisher(String, '/service/command', 10)
@@ -482,6 +488,7 @@ class BackendNode(Ros2NodeManager):
             pct = self.mapping_percent
             battery = self._battery
             nav_nodes = self._nav_nodes_running
+            nav_paused = self._nav_paused
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -493,6 +500,7 @@ class BackendNode(Ros2NodeManager):
             'navStatus': 'navigating' if raw == 'navigation' else 'idle',
             'rawState': raw,
             'navNodesRunning': nav_nodes,
+            'navPaused': nav_paused,
         }
 
     @staticmethod
@@ -617,6 +625,7 @@ class BackendNode(Ros2NodeManager):
             self._map_pose = None
             self._global_path = []
             self._nav_target_pose = None
+            self._nav_paused = False
         self.get_logger().info('Nav nodes stopped')
 
     def cmd_restart_nav_nodes(self):
@@ -806,6 +815,28 @@ class BackendNode(Ros2NodeManager):
         payload = {'0': pois[key]}
         self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
 
+    def cmd_send_pois(self, poi_ids: list[int]):
+        """Publish selected POIs to map_node and transition to navigation state."""
+        if not poi_ids:
+            self._cmd_pois_pub.publish(String(data='{}'))
+        else:
+            pois_file = os.path.join(self.map_path, 'pois.json')
+            if not os.path.exists(pois_file):
+                self.get_logger().warn('No pois.json found, cannot publish cmd_pois')
+                return
+            with open(pois_file) as f:
+                all_pois = json.load(f)
+            payload = {str(pid): all_pois[str(pid)] for pid in poi_ids if str(pid) in all_pois}
+            self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
+        with self._lock:
+            nav_running = self._nav_nodes_running
+        if nav_running:
+            self.state = 'navigation'
+            self._pub_state()
+        else:
+            self._stop_all()
+            self._start('navigation')
+
     def cmd_nav_start(self, poi_id: str | None = None):
         if poi_id is not None:
             self._publish_cmd_pois(int(poi_id))
@@ -831,6 +862,16 @@ class BackendNode(Ros2NodeManager):
             self._pub_state()
         else:
             self._stop_all()
+
+    def cmd_nav_pause(self):
+        with self._lock:
+            self._nav_paused = True
+        self._pause_pub.publish(Bool(data=True))
+
+    def cmd_nav_resume(self):
+        with self._lock:
+            self._nav_paused = False
+        self._pause_pub.publish(Bool(data=False))
 
     def cmd_action(self, action: str):
         self._action_pub.publish(String(data=f'play {action}'))

--- a/app/backend/routers/nav.py
+++ b/app/backend/routers/nav.py
@@ -16,6 +16,19 @@ class GoToPoiRequest(BaseModel):
     poi_id: int
 
 
+class SendPoisRequest(BaseModel):
+    poi_ids: list[int]
+
+
+@router.post('/send-pois')
+def nav_send_pois(req: SendPoisRequest):
+    node = _require_node()
+    if not node._localized:
+        raise HTTPException(409, 'Not localized')
+    node.cmd_send_pois(req.poi_ids)
+    return {'ok': True}
+
+
 @router.post('/go-to-poi')
 def nav_go_to_poi(req: GoToPoiRequest):
     node = _require_node()
@@ -60,6 +73,20 @@ def nav_restart():
     if not node._nav_nodes_running:
         raise HTTPException(409, 'Nav nodes not running')
     node.cmd_restart_nav_nodes()
+    return {'ok': True}
+
+
+@router.post('/pause')
+def nav_pause():
+    node = _require_node()
+    node.cmd_nav_pause()
+    return {'ok': True}
+
+
+@router.post('/resume')
+def nav_resume():
+    node = _require_node()
+    node.cmd_nav_resume()
     return {'ok': True}
 
 

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -11,6 +11,7 @@ class DeviceStatus {
   final String navStatus;
   final String rawState;
   final bool navNodesRunning;
+  final bool navPaused;
 
   const DeviceStatus({
     required this.online,
@@ -22,6 +23,7 @@ class DeviceStatus {
     required this.navStatus,
     required this.rawState,
     required this.navNodesRunning,
+    required this.navPaused,
   });
 
   factory DeviceStatus.fromJson(Map<String, dynamic> json) => DeviceStatus(
@@ -34,6 +36,7 @@ class DeviceStatus {
         navStatus: json['navStatus'] as String? ?? 'idle',
         rawState: json['rawState'] as String? ?? 'unknown',
         navNodesRunning: json['navNodesRunning'] as bool? ?? false,
+        navPaused: json['navPaused'] as bool? ?? false,
       );
 }
 

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -494,51 +494,11 @@ class _PoiSheet extends ConsumerStatefulWidget {
 
 class _PoiSheetState extends ConsumerState<_PoiSheet> {
   bool _canceling = false;
-
-  Future<void> _addPoi() async {
-    final pose = widget.pose;
-    if (pose == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('No pose — robot must be localized first')),
-      );
-      return;
-    }
-    final ctrl = TextEditingController();
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('New POI'),
-        content: TextField(
-          controller: ctrl,
-          decoration: const InputDecoration(labelText: 'Name', hintText: 'e.g. Entrance'),
-          autofocus: true,
-          textCapitalization: TextCapitalization.sentences,
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Create')),
-        ],
-      ),
-    );
-    if (ok != true || ctrl.text.trim().isEmpty) return;
-    try {
-      await ref.read(dioProvider).post('/map/pois', data: {
-        'name': ctrl.text.trim(),
-        'position': [pose.x, pose.y, 0.0],
-      });
-      ref.invalidate(poisProvider);
-    } on DioException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
-          backgroundColor: Colors.red,
-        ));
-      }
-    }
-  }
+  final Set<int> _checkedIds = {};
+  List<int> _navQueue = [];
 
   Future<void> _cancelNav() async {
-    setState(() => _canceling = true);
+    setState(() { _canceling = true; _navQueue = []; });
     try {
       await ref.read(dioProvider).post('/nav/cancel');
     } on DioException catch (e) {
@@ -572,9 +532,36 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     if (ok != true) return;
     try {
       await ref.read(dioProvider).delete('/poi/${poi.id}');
+      setState(() => _checkedIds.remove(poi.id));
       ref.invalidate(poisProvider);
     } on DioException catch (e) {
       if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
+          backgroundColor: Colors.red,
+        ));
+      }
+    }
+  }
+
+  Future<void> _startNav(List<Poi> pois) async {
+    final queue = pois
+        .where((p) => _checkedIds.contains(p.id))
+        .map((p) => p.id)
+        .toList();
+    if (queue.isEmpty) return;
+    setState(() => _navQueue = queue);
+    await _goToNext();
+  }
+
+  Future<void> _goToNext() async {
+    if (_navQueue.isEmpty) return;
+    final nextId = _navQueue.removeAt(0);
+    try {
+      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': nextId});
+    } on DioException catch (e) {
+      if (mounted) {
+        setState(() => _navQueue = []);
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
           backgroundColor: Colors.red,
@@ -590,6 +577,15 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     final status = statusAsync.valueOrNull;
     final isNavigating = status?.rawState == 'navigation';
     final canGo = status != null && status.online && status.rawState == 'idle';
+
+    // Auto-advance to next POI in queue when navigation completes.
+    ref.listen<AsyncValue<DeviceStatus>>(deviceStatusProvider, (prev, next) {
+      final wasNav = prev?.valueOrNull?.rawState == 'navigation';
+      final isNowIdle = next.valueOrNull?.rawState == 'idle';
+      if (wasNav && isNowIdle && _navQueue.isNotEmpty) {
+        _goToNext();
+      }
+    });
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -624,10 +620,16 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
                 label: const Text('Cancel Nav'),
               )
             else
-              TextButton.icon(
-                onPressed: _addPoi,
-                icon: const Icon(Icons.add_location_alt_outlined, size: 18),
-                label: const Text('Add here'),
+              FilledButton.icon(
+                onPressed: (canGo && _checkedIds.isNotEmpty)
+                    ? () => poisAsync.whenData((pois) => _startNav(pois))
+                    : null,
+                icon: const Icon(Icons.navigation_rounded, size: 16),
+                label: const Text('Nav'),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  minimumSize: Size.zero,
+                ),
               ),
           ]),
           const Divider(height: 20),
@@ -644,7 +646,11 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
                     children: pois
                         .map((poi) => _PoiTile(
                               poi: poi,
-                              canGo: canGo,
+                              checked: _checkedIds.contains(poi.id),
+                              onChecked: (v) => setState(() {
+                                if (v) _checkedIds.add(poi.id);
+                                else _checkedIds.remove(poi.id);
+                              }),
                               onDelete: () => _deletePoi(poi),
                             ))
                         .toList(),
@@ -658,66 +664,36 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   }
 }
 
-class _PoiTile extends ConsumerStatefulWidget {
+class _PoiTile extends StatelessWidget {
   final Poi poi;
-  final bool canGo;
+  final bool checked;
+  final ValueChanged<bool> onChecked;
   final VoidCallback onDelete;
 
-  const _PoiTile({required this.poi, required this.canGo, required this.onDelete});
-
-  @override
-  ConsumerState<_PoiTile> createState() => _PoiTileState();
-}
-
-class _PoiTileState extends ConsumerState<_PoiTile> {
-  bool _loading = false;
-
-  Future<void> _go() async {
-    setState(() => _loading = true);
-    try {
-      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': widget.poi.id});
-    } on DioException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
-          backgroundColor: Colors.red,
-        ));
-      }
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
+  const _PoiTile({
+    required this.poi,
+    required this.checked,
+    required this.onChecked,
+    required this.onDelete,
+  });
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const Icon(Icons.place, color: Colors.amber),
-      title: Text(widget.poi.name),
+      leading: Checkbox(
+        value: checked,
+        onChanged: (v) => onChecked(v ?? false),
+      ),
+      title: Text(poi.name),
       subtitle: Text(
-        '(${widget.poi.x.toStringAsFixed(2)}, ${widget.poi.y.toStringAsFixed(2)})',
+        '(${poi.x.toStringAsFixed(2)}, ${poi.y.toStringAsFixed(2)})',
         style: const TextStyle(fontSize: 12),
       ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _loading
-              ? const SizedBox(width: 28, height: 28, child: CircularProgressIndicator(strokeWidth: 2))
-              : FilledButton(
-                  onPressed: widget.canGo ? _go : null,
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                    minimumSize: Size.zero,
-                  ),
-                  child: const Text('Go', style: TextStyle(fontSize: 12)),
-                ),
-          const SizedBox(width: 4),
-          IconButton(
-            icon: const Icon(Icons.delete_outline, color: Colors.red, size: 18),
-            onPressed: widget.onDelete,
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
-          ),
-        ],
+      trailing: IconButton(
+        icon: const Icon(Icons.delete_outline, color: Colors.red, size: 18),
+        onPressed: onDelete,
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(),
       ),
       dense: true,
       contentPadding: const EdgeInsets.symmetric(horizontal: 4),

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -495,10 +495,9 @@ class _PoiSheet extends ConsumerStatefulWidget {
 class _PoiSheetState extends ConsumerState<_PoiSheet> {
   bool _canceling = false;
   final Set<int> _checkedIds = {};
-  List<int> _navQueue = [];
 
   Future<void> _cancelNav() async {
-    setState(() { _canceling = true; _navQueue = []; });
+    setState(() => _canceling = true);
     try {
       await ref.read(dioProvider).post('/nav/cancel');
     } on DioException catch (e) {
@@ -545,23 +544,15 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   }
 
   Future<void> _startNav(List<Poi> pois) async {
-    final queue = pois
+    final ids = pois
         .where((p) => _checkedIds.contains(p.id))
         .map((p) => p.id)
         .toList();
-    if (queue.isEmpty) return;
-    setState(() => _navQueue = queue);
-    await _goToNext();
-  }
-
-  Future<void> _goToNext() async {
-    if (_navQueue.isEmpty) return;
-    final nextId = _navQueue.removeAt(0);
+    if (ids.isEmpty) return;
     try {
-      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': nextId});
+      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': ids.first});
     } on DioException catch (e) {
       if (mounted) {
-        setState(() => _navQueue = []);
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
           content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
           backgroundColor: Colors.red,
@@ -577,15 +568,6 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     final status = statusAsync.valueOrNull;
     final isNavigating = status?.rawState == 'navigation';
     final canGo = status != null && status.online && status.rawState == 'idle';
-
-    // Auto-advance to next POI in queue when navigation completes.
-    ref.listen<AsyncValue<DeviceStatus>>(deviceStatusProvider, (prev, next) {
-      final wasNav = prev?.valueOrNull?.rawState == 'navigation';
-      final isNowIdle = next.valueOrNull?.rawState == 'idle';
-      if (wasNav && isNowIdle && _navQueue.isNotEmpty) {
-        _goToNext();
-      }
-    });
 
     return Padding(
       padding: EdgeInsets.fromLTRB(

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -141,6 +141,14 @@ class _OperateTabState extends ConsumerState<OperateTab> {
               ),
               Positioned(
                 bottom: 10,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: _PauseButton(statusAsync: ref.watch(deviceStatusProvider)),
+                ),
+              ),
+              Positioned(
+                bottom: 10,
                 right: 10,
                 child: _NavNodesButton(statusAsync: ref.watch(deviceStatusProvider)),
               ),
@@ -441,7 +449,7 @@ class _LocalizationChip extends StatelessWidget {
 
 // ── POI button + bottom sheet ─────────────────────────────────────────────────
 
-class _PoiButton extends ConsumerWidget {
+class _PoiButton extends ConsumerStatefulWidget {
   final AsyncValue<List<Poi>> poisAsync;
   final AsyncValue<DeviceStatus> statusAsync;
   final Pose? pose;
@@ -453,48 +461,11 @@ class _PoiButton extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final count = poisAsync.valueOrNull?.length ?? 0;
-    final isNavigating = statusAsync.valueOrNull?.rawState == 'navigation';
-
-    return FilledButton.icon(
-      onPressed: () => showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        builder: (_) => _PoiSheet(pose: pose),
-      ),
-      style: FilledButton.styleFrom(
-        backgroundColor: isNavigating
-            ? const Color(0xFF34C759).withOpacity(0.9)
-            : Colors.black87,
-        foregroundColor: Colors.white,
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-      ),
-      icon: Icon(
-        isNavigating ? Icons.navigation_rounded : Icons.place_outlined,
-        size: 16,
-      ),
-      label: Text(isNavigating
-          ? 'Navigating'
-          : 'POIs${count > 0 ? ' ($count)' : ''}'),
-    );
-  }
+  ConsumerState<_PoiButton> createState() => _PoiButtonState();
 }
 
-class _PoiSheet extends ConsumerStatefulWidget {
-  final Pose? pose;
-  const _PoiSheet({this.pose});
-
-  @override
-  ConsumerState<_PoiSheet> createState() => _PoiSheetState();
-}
-
-class _PoiSheetState extends ConsumerState<_PoiSheet> {
+class _PoiButtonState extends ConsumerState<_PoiButton> {
   bool _canceling = false;
-  final Set<int> _checkedIds = {};
 
   Future<void> _cancelNav() async {
     setState(() => _canceling = true);
@@ -511,6 +482,57 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
       if (mounted) setState(() => _canceling = false);
     }
   }
+
+  @override
+  Widget build(BuildContext context) {
+    final count = widget.poisAsync.valueOrNull?.length ?? 0;
+    final isNavigating = widget.statusAsync.valueOrNull?.rawState == 'navigation';
+
+    if (isNavigating) {
+      return FilledButton.icon(
+        onPressed: _canceling ? null : _cancelNav,
+        style: FilledButton.styleFrom(
+          backgroundColor: Colors.red.withOpacity(0.85),
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        ),
+        icon: _canceling
+            ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+            : const Icon(Icons.cancel_outlined, size: 16),
+        label: const Text('Cancel'),
+      );
+    }
+
+    return FilledButton.icon(
+      onPressed: () => showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        builder: (_) => _PoiSheet(pose: widget.pose),
+      ),
+      style: FilledButton.styleFrom(
+        backgroundColor: Colors.black87,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      ),
+      icon: const Icon(Icons.place_outlined, size: 16),
+      label: Text('POIs${count > 0 ? ' ($count)' : ''}'),
+    );
+  }
+}
+
+class _PoiSheet extends ConsumerStatefulWidget {
+  final Pose? pose;
+  const _PoiSheet({this.pose});
+
+  @override
+  ConsumerState<_PoiSheet> createState() => _PoiSheetState();
+}
+
+class _PoiSheetState extends ConsumerState<_PoiSheet> {
+  final Set<int> _checkedIds = {};
 
   Future<void> _deletePoi(Poi poi) async {
     final ok = await showDialog<bool>(
@@ -550,7 +572,7 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
         .toList();
     if (ids.isEmpty) return;
     try {
-      await ref.read(dioProvider).post('/nav/go-to-poi', data: {'poi_id': ids.first});
+      await ref.read(dioProvider).post('/nav/send-pois', data: {'poi_ids': ids});
     } on DioException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
@@ -564,10 +586,9 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   @override
   Widget build(BuildContext context) {
     final poisAsync = ref.watch(poisProvider);
-    final statusAsync = ref.watch(deviceStatusProvider);
-    final status = statusAsync.valueOrNull;
-    final isNavigating = status?.rawState == 'navigation';
-    final canGo = status != null && status.online && status.rawState == 'idle';
+    final status = ref.watch(deviceStatusProvider).valueOrNull;
+    final localized = ref.watch(planningStreamProvider).valueOrNull?.localized ?? false;
+    final canGo = status != null && status.online && localized;
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -592,27 +613,17 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
             const SizedBox(width: 8),
             const Text('POIs', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
             const Spacer(),
-            if (isNavigating)
-              OutlinedButton.icon(
-                onPressed: _canceling ? null : _cancelNav,
-                style: OutlinedButton.styleFrom(foregroundColor: Colors.red),
-                icon: _canceling
-                    ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2))
-                    : const Icon(Icons.cancel_outlined, size: 16),
-                label: const Text('Cancel Nav'),
-              )
-            else
-              FilledButton.icon(
-                onPressed: (canGo && _checkedIds.isNotEmpty)
-                    ? () => poisAsync.whenData((pois) => _startNav(pois))
-                    : null,
-                icon: const Icon(Icons.navigation_rounded, size: 16),
-                label: const Text('Nav'),
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  minimumSize: Size.zero,
-                ),
+            FilledButton.icon(
+              onPressed: (canGo && _checkedIds.isNotEmpty)
+                  ? () => poisAsync.whenData((pois) => _startNav(pois))
+                  : null,
+              icon: const Icon(Icons.navigation_rounded, size: 16),
+              label: const Text('Go'),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                minimumSize: Size.zero,
               ),
+            ),
           ]),
           const Divider(height: 20),
           // ── POI list ────────────────────────────────────────────────
@@ -739,6 +750,59 @@ class _NavNodesButtonState extends ConsumerState<_NavNodesButton> {
               size: 16,
             ),
       label: Text(running ? 'Nav ON' : 'Nav'),
+    );
+  }
+}
+
+// ── Pause / Continue button ───────────────────────────────────────────────────
+
+class _PauseButton extends ConsumerStatefulWidget {
+  final AsyncValue<DeviceStatus> statusAsync;
+  const _PauseButton({required this.statusAsync});
+
+  @override
+  ConsumerState<_PauseButton> createState() => _PauseButtonState();
+}
+
+class _PauseButtonState extends ConsumerState<_PauseButton> {
+  bool _loading = false;
+
+  Future<void> _toggle(bool paused) async {
+    setState(() => _loading = true);
+    try {
+      await ref.read(dioProvider).post(paused ? '/nav/resume' : '/nav/pause');
+    } on DioException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
+          backgroundColor: Colors.red,
+        ));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = widget.statusAsync.valueOrNull;
+    final running = status?.navNodesRunning ?? false;
+    if (!running) return const SizedBox.shrink();
+
+    final paused = status?.navPaused ?? false;
+    return FilledButton.icon(
+      onPressed: _loading ? null : () => _toggle(paused),
+      style: FilledButton.styleFrom(
+        backgroundColor: paused
+            ? const Color(0xFFFF9800).withOpacity(0.9)
+            : Colors.black54,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      ),
+      icon: _loading
+          ? const SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+          : Icon(paused ? Icons.play_arrow_rounded : Icons.pause_rounded, size: 16),
+      label: Text(paused ? 'Continue' : 'Pause'),
     );
   }
 }

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -241,6 +241,14 @@ class MapNode(Node):
                 pois_dict[index] = np.array(self.pois[str(key)]["position"])
             self.pois = pois_dict
 
+            if not self.pois:
+                self.poi_index = -1
+                # Signal planning_node to clear target_pose so it stops publishing paths
+                dummy_pose = np.eye(4)
+                self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
+                self.get_logger().info("POIs cleared, navigation cancelled")
+                return
+
             self.poi_index = min(0, len(self.pois) - 1)
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -3,6 +3,8 @@ from rclpy.node import Node
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Path
 from nav_msgs.msg import Odometry
+from std_msgs.msg import Bool
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from scipy.spatial.transform import Rotation as R
 import numpy as np
 import logging
@@ -53,8 +55,17 @@ class CmdVelControlNode(Node):
         self.prev_cmd = Twist()
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
+        self._paused = False
+        _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.create_subscription(Bool, '/nav/paused', self._on_paused, _latched_qos)
         self.cmd_timer = self.create_timer(1.0 / self.cmd_rate_hz, self.cmd_timer_callback)
         
+    def _on_paused(self, msg: Bool):
+        self._paused = msg.data
+        if not self._paused:
+            # Reset prev_cmd so resume starts from zero cleanly
+            self.prev_cmd = Twist()
+
     def pose_callback(self, msg):
         self.pose = msg
 
@@ -65,6 +76,11 @@ class CmdVelControlNode(Node):
         now = time.monotonic()
         dt = max(1e-3, now - self.last_cmd_pub_time)
         self.last_cmd_pub_time = now
+
+        if self._paused:
+            self.cmd_pub.publish(Twist())
+            self.prev_cmd = Twist()
+            return
 
         # Stale-path protection: slow down, then stop if planner has not refreshed.
         age = float('inf') if self.last_path_update_time is None else (now - self.last_path_update_time)


### PR DESCRIPTION
 - Multi-POI navigation: operate page switches from single-POI dropdown to a checkbox list, navigating to each selected POI in order                                                
  - Cancel / Pause / Continue: backend adds /nav/cancel, /nav/pause, /nav/resume endpoints with corresponding frontend buttons
  - Remove frontend auto-advance: previously the frontend would push to the next POI on arrival; now fully driven by map_node cmd mechanism — frontend only initiates and cancels