### PR TITLE
feat(planning): DWA backward recovery and trajectory overhaul

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -744,6 +744,31 @@ class BackendNode(Ros2NodeManager):
 
         threading.Thread(target=self._on_build_map_done, daemon=True).start()
 
+    def _start_percent_bridge(self):
+        bridge_env = os.environ.copy()
+        bridge_env['ROS_DOMAIN_ID'] = _MAP_BUILD_DOMAIN_LOOPER
+        bridge_env['PYTHONPATH'] = _VENV_SITE + ':' + bridge_env.get('PYTHONPATH', '')
+        self._percent_bridge_proc = subprocess.Popen(
+            ['python3', '-c', _PERCENT_BRIDGE_SCRIPT],
+            env=bridge_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=os.setsid,
+        )
+        threading.Thread(target=self._read_percent_bridge, daemon=True).start()
+
+    def _read_percent_bridge(self):
+        proc = self._percent_bridge_proc
+        if proc is None or proc.stdout is None:
+            return
+        for line in proc.stdout:
+            try:
+                pct = float(line.strip())
+                with self._lock:
+                    self.mapping_percent = pct
+            except (ValueError, AttributeError):
+                pass
+
     def _on_build_map_done(self):
         """Wait for build_map to finish, then convert, archive, and restart."""
         import shutil

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -193,11 +193,12 @@ def generate_trajectory_library_3d(
     num_trajs = n_vx * n_omega
     trajectories = np.empty((num_trajs, num_steps, 7))
     params = np.empty((num_trajs, 2))
-    vx_step = (vx_max - vx_min) / (n_vx - 1) if n_vx > 1 else 0.0
+    # index 0 = single backward sample (vx_min); indices 1..n_vx-1 = forward [0, vx_max]
+    fwd_step = vx_max / (n_vx - 2) if n_vx > 2 else vx_max
     omega_step = (omega_max - omega_min) / (n_omega - 1) if n_omega > 1 else 0.0
     k = 0
     for i_vx in range(n_vx):
-        vx = vx_min + i_vx * vx_step
+        vx = vx_min if i_vx == 0 else (i_vx - 1) * fwd_step
         for i_omega in range(n_omega):
             omega = omega_min + i_omega * omega_step
             p = init_p.copy()

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -51,9 +51,9 @@ class RobotConfig:
 
 GO2_CONFIG = RobotConfig(
     name='go2', shape='square',
-    length=0.4, width=0.3,
+    length=0.7, width=0.4,
     camera_x=0.35, camera_y=0.0,
-    control_x=0.0, control_y=0.0,
+    control_x=0.35, control_y=0.0,
     safety_radius=0.1,
 )
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -250,7 +250,7 @@ def score_trajectories_by_ESDF(trajectories, ESDF_map, origin, resolution, safet
         min_dist_for_traj = float('inf')
         closest_step_for_traj = -1
 
-        for i in range(len(traj)):
+        for i in range(1, len(traj)):  # skip step-0 (robot's current position) to avoid score contamination
             x_world, y_world = traj[i, 0], traj[i, 1]
             qx, qy, qz, qw = traj[i, 3], traj[i, 4], traj[i, 5], traj[i, 6]
 
@@ -547,7 +547,6 @@ class PlanningNode(Node):
                 robot_z=T[2, 3], config=self.obstacle_config,
             )
             ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
-
         with Timer(name='vis', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             self.publish_3d_occupancy_cloud_with_esdf(self.occupancy_grid, ESDF_map, self.resolution, self.origin)
             self.publish_height_map(T[:3,3], ESDF_map, depth_msg.header)
@@ -566,7 +565,7 @@ class PlanningNode(Node):
             )
             # Penalised in cost so forward is always preferred when unblocked.
             back_trajs, back_params = generate_trajectory_library_3d(
-                num_samples=5, init_p=init_p, init_v=-v_dir * 0.15, init_q=init_q
+                num_samples=5, init_p=init_p, init_v=-v_dir * 0.2, init_q=init_q
             )
             is_backward = np.array([False] * len(trajectories) + [True] * len(back_trajs))
             trajectories = np.concatenate([trajectories, back_trajs], axis=0)
@@ -581,11 +580,35 @@ class PlanningNode(Node):
             top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
+            # Adaptive backward penalty: linearly scales from 10000 (far) to 0 (in contact).
+            fl_r, rl_r, hw_r = self.robot.footprint_from_control()
+            rc = self.camera_to_robot_center(T)
+            fwd_r = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
+            nr = (fwd_r[0]**2 + fwd_r[1]**2)**0.5
+            frx, fry = (fwd_r[0]/nr, fwd_r[1]/nr) if nr > 1e-6 else (1.0, 0.0)
+            llx, lly = -fry, frx
+            rc_pts = [
+                (rc[0], rc[1]),
+                (rc[0] + frx*fl_r + llx*hw_r, rc[1] + fry*fl_r + lly*hw_r),
+                (rc[0] + frx*fl_r - llx*hw_r, rc[1] + fry*fl_r - lly*hw_r),
+                (rc[0] - frx*rl_r + llx*hw_r, rc[1] - fry*rl_r + lly*hw_r),
+                (rc[0] - frx*rl_r - llx*hw_r, rc[1] - fry*rl_r - lly*hw_r),
+            ]
+            Er, Ec = ESDF_map.shape
+            robot_clearance = 999.0
+            for px_, py_ in rc_pts:
+                xi_ = int((px_ - self.origin[0]) / self.resolution)
+                yi_ = int((py_ - self.origin[1]) / self.resolution)
+                if 0 <= xi_ < Er and 0 <= yi_ < Ec:
+                    robot_clearance = min(robot_clearance, float(ESDF_map[xi_, yi_]))
+            # Penalty drops to 0 when robot is at safety_radius; full penalty beyond 0.3m.
+            penalty_scale = float(np.clip(robot_clearance / 0.3, 0.0, 1.0))
+
             def cost_function(traj, param, score, target_pose, backward):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
-                backward_penalty = 10000.0 if backward else 0.0
+                backward_penalty = 10000.0 * penalty_scale if backward else 0.0
                 return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + backward_penalty
 
             top_k = 1

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -551,36 +551,85 @@ class PlanningNode(Node):
             top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            # Adaptive backward penalty: linearly scales from 10000 (far) to 0 (in contact).
+            # Reverse is generally discouraged, but should be selectable for front-obstacle escape.
             fl_r, rl_r, hw_r = self.robot.footprint_from_control()
             rc = self.camera_to_robot_center(T)
             fwd_r = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
             nr = (fwd_r[0]**2 + fwd_r[1]**2)**0.5
             frx, fry = (fwd_r[0]/nr, fwd_r[1]/nr) if nr > 1e-6 else (1.0, 0.0)
             llx, lly = -fry, frx
-            rc_pts = [
-                (rc[0], rc[1]),
+            Er, Ec = ESDF_map.shape
+
+            front_pts = [
+                (rc[0] + frx*fl_r, rc[1] + fry*fl_r),
                 (rc[0] + frx*fl_r + llx*hw_r, rc[1] + fry*fl_r + lly*hw_r),
                 (rc[0] + frx*fl_r - llx*hw_r, rc[1] + fry*fl_r - lly*hw_r),
-                (rc[0] - frx*rl_r + llx*hw_r, rc[1] - fry*rl_r + lly*hw_r),
-                (rc[0] - frx*rl_r - llx*hw_r, rc[1] - fry*rl_r - lly*hw_r),
             ]
-            Er, Ec = ESDF_map.shape
-            robot_clearance = 999.0
-            for px_, py_ in rc_pts:
+            front_clearance = 999.0
+            for px_, py_ in front_pts:
                 xi_ = int((px_ - self.origin[0]) / self.resolution)
                 yi_ = int((py_ - self.origin[1]) / self.resolution)
                 if 0 <= xi_ < Er and 0 <= yi_ < Ec:
-                    robot_clearance = min(robot_clearance, float(ESDF_map[xi_, yi_]))
-            # Penalty drops to 0 when robot is at safety_radius; full penalty beyond 0.3m.
-            penalty_scale = float(np.clip(robot_clearance / 0.3, 0.0, 1.0))
+                    front_clearance = min(front_clearance, float(ESDF_map[xi_, yi_]))
+
+            front_escape_threshold = self.robot.safety_radius + 0.12
+            front_blocked = front_clearance < front_escape_threshold
+            # Mild reverse discouragement when front is clear.
+            front_penalty_scale = float(np.clip(front_clearance / 0.25, 0.0, 1.0))
+
+            target_behind = False
+            if self.target_pose is not None:
+                to_goal_xy = self.target_pose[:2] - rc[:2]
+                forward_proj = float(to_goal_xy[0] * frx + to_goal_xy[1] * fry)
+                target_behind = forward_proj < -0.15
 
             def cost_function(traj, param, score, target_pose, backward):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
-                backward_penalty = 10000.0 * penalty_scale if backward else 0.0
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + backward_penalty
+                if backward:
+                    backward_penalty = -800.0 if front_blocked else 1800.0 * front_penalty_scale
+                else:
+                    backward_penalty = 0.0
+                # When front is blocked, discourage positive vx so reverse can be chosen.
+                front_block_forward_penalty = 2500.0 * max(0.0, param[0]) if front_blocked and not backward else 0.0
+
+                # If goal is behind robot, prefer rotate-first behavior.
+                rotate_first_penalty = 0.0
+                heading_penalty = 0.0
+                if target_behind and target_pose is not None:
+                    rotate_first_penalty = 4000.0 * abs(param[0])
+
+                    qx, qy, qz, qw = traj[-1, 3], traj[-1, 4], traj[-1, 5], traj[-1, 6]
+                    tf_x = 2.0 * (qx * qz + qw * qy)
+                    tf_y = 2.0 * (qy * qz - qw * qx)
+                    n_tf = (tf_x * tf_x + tf_y * tf_y) ** 0.5
+                    if n_tf > 1e-6:
+                        tf_x /= n_tf
+                        tf_y /= n_tf
+                    else:
+                        tf_x, tf_y = 1.0, 0.0
+                    gx = target_end[0] - traj_end[0]
+                    gy = target_end[1] - traj_end[1]
+                    n_g = (gx * gx + gy * gy) ** 0.5
+                    if n_g > 1e-6:
+                        gx /= n_g
+                        gy /= n_g
+                        cross = tf_x * gy - tf_y * gx
+                        dot = tf_x * gx + tf_y * gy
+                        heading_err = abs(np.arctan2(cross, dot))
+                        heading_penalty = 700.0 * heading_err
+
+                return (
+                    score * 100000
+                    + 100 * dist
+                    + 10 * abs(self.last_param[0] - param[0])
+                    + 10 * abs(self.last_param[1] - param[1])
+                    + backward_penalty
+                    + front_block_forward_penalty
+                    + rotate_first_penalty
+                    + heading_penalty
+                )
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose, bool(is_backward[i])) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -564,8 +564,7 @@ class PlanningNode(Node):
             trajectories, params = generate_trajectory_library_3d(
                 init_p=init_p, init_v=init_v, init_q=init_q
             )
-            # Backward recovery trajectories: fewer samples, fixed slow reverse speed.
-            # Scored together with forward; penalised in cost so forward is always preferred.
+            # Penalised in cost so forward is always preferred when unblocked.
             back_trajs, back_params = generate_trajectory_library_3d(
                 num_samples=5, init_p=init_p, init_v=-v_dir * 0.15, init_q=init_q
             )
@@ -601,9 +600,7 @@ class PlanningNode(Node):
             path.header = depth_msg.header
             path.header.frame_id = "world"
 
-            # Goal-reached: publish empty path so cmd_vel stops.
-            # target_pose is a camera-frame position (POI was recorded as camera pose),
-            # so compare directly against camera position T[:3, 3].
+            # target_pose is camera-frame (POI recorded as camera pose); compare against T[:3, 3] directly.
             if self.target_pose is not None:
                 dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2]))
                 if dist_to_goal < 0.3:
@@ -612,10 +609,9 @@ class PlanningNode(Node):
                     return
 
             if self.target_pose is None and not self.poi_changed:
-                self.path_pub.publish(path)  # empty path — no active nav target
+                self.path_pub.publish(path)
                 return
 
-            # If every trajectory is in collision (forward and backward), stop.
             if all(s == float('inf') for s in scores):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 self.path_pub.publish(path)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -220,7 +220,7 @@ def generate_trajectory_library_3d(
                 if norm_val > 1e-3:
                     acc_body = acc_body / norm_val
                 else:
-                    acc_body = np.array([0.0, 0.0, 0.0])
+                    acc_body = np.array([0.0, 0.0, 1.0])  # body +Z forward; dv<0 gives backward
                 acc_body = acc_body * dv
 
                 acc_world = q @ acc_body

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -184,57 +184,38 @@ def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None)
 
 @njit(cache=True)
 def generate_trajectory_library_3d(
-    num_samples=11, duration=2.0, dt=0.1,
-    acc_std=0.00001, omega_y_std_deg=20.0,
-    init_p=np.zeros(3), init_v=np.zeros(3), init_q=np.array([0, 0, 0, 1])
+    vx_min=-0.2, vx_max=0.5, n_vx=5,
+    omega_min=-0.6, omega_max=0.6, n_omega=11,
+    duration=2.0, dt=0.1,
+    init_p=np.zeros(3), init_q=np.array([0, 0, 0, 1])
 ):
     num_steps = int(duration / dt) + 1
-
-    max_acc = 0.5
-    acc_samples = np.linspace(-max_acc, max_acc, int(num_samples / 2))
-    max_omega = np.pi / 4
-    omega_y_samples = np.linspace(-max_omega, max_omega, num_samples)
-
-    num_samples = len(acc_samples) * len(omega_y_samples)
-
-    trajectories = np.empty((num_samples, num_steps, 7))
-    params = np.empty((num_samples, 2))
-
-    k = -1
-    for i_acc in range(len(acc_samples)):
-        for i_omega in range(len(omega_y_samples)):
-            k += 1
-            dv = acc_samples[i_acc]
-            omega_y = omega_y_samples[i_omega]
+    num_trajs = n_vx * n_omega
+    trajectories = np.empty((num_trajs, num_steps, 7))
+    params = np.empty((num_trajs, 2))
+    vx_step = (vx_max - vx_min) / (n_vx - 1) if n_vx > 1 else 0.0
+    omega_step = (omega_max - omega_min) / (n_omega - 1) if n_omega > 1 else 0.0
+    k = 0
+    for i_vx in range(n_vx):
+        vx = vx_min + i_vx * vx_step
+        for i_omega in range(n_omega):
+            omega = omega_min + i_omega * omega_step
             p = init_p.copy()
-            v_world = init_v.copy()
             q = quat_to_matrix(init_q)
             traj = np.empty((num_steps, 7))
             for i in range(num_steps):
-                dq = rotvec_to_matrix(np.array([0.0, omega_y * dt, 0.0]))
-                v_world = (q @ dq) @ q.T @ v_world
+                v_world = q @ np.array([0.0, 0.0, vx])
+                p = p + v_world * dt
+                dq = rotvec_to_matrix(np.array([0.0, omega * dt, 0.0]))
                 q = q @ dq
-
-                acc_body = q.T @ v_world
-                norm_val = np.linalg.norm(acc_body)
-                if norm_val > 1e-3:
-                    acc_body = acc_body / norm_val
-                else:
-                    acc_body = np.array([0.0, 0.0, 1.0])  # body +Z forward; dv<0 gives backward
-                acc_body = acc_body * dv
-
-                acc_world = q @ acc_body
-                v_world += acc_world * dt
-                v_world = np.clip(v_world, -0.5, 0.5)
-                p += v_world * dt
                 traj[i, :3] = p
                 traj[i, 3:] = matrix_to_quat(q)
-            #hack
             for i in range(num_steps):
                 traj[i, 2] = traj[0, 2]
             trajectories[k] = traj
-            params[k, 0] = dv
-            params[k, 1] = omega_y
+            params[k, 0] = vx
+            params[k, 1] = omega
+            k += 1
     return trajectories, params
 
 @njit(cache=True)
@@ -555,21 +536,10 @@ class PlanningNode(Node):
             self.publish_footprint(T, depth_msg.header.stamp)
 
         with Timer(name='traj gen', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            v_dir = T[:3, :3] @ np.array([0, 0, 1])
-            magnitude = np.clip(self.smoothed_velocity, 0.05, 0.5)
-            init_v = v_dir * float(magnitude)
             init_p = self.camera_to_robot_center(T)
             init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
-            trajectories, params = generate_trajectory_library_3d(
-                init_p=init_p, init_v=init_v, init_q=init_q
-            )
-            # Penalised in cost so forward is always preferred when unblocked.
-            back_trajs, back_params = generate_trajectory_library_3d(
-                num_samples=5, init_p=init_p, init_v=-v_dir * 0.2, init_q=init_q
-            )
-            is_backward = np.array([False] * len(trajectories) + [True] * len(back_trajs))
-            trajectories = np.concatenate([trajectories, back_trajs], axis=0)
-            params = np.concatenate([params, back_params], axis=0)
+            trajectories, params = generate_trajectory_library_3d(init_p=init_p, init_q=init_q)
+            is_backward = params[:, 0] < 0
             self.last_T = T
             self.last_stamp = stamp
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -190,9 +190,9 @@ def generate_trajectory_library_3d(
 ):
     num_steps = int(duration / dt) + 1
 
-    max_acc = 0.2
+    max_acc = 0.5
     acc_samples = np.linspace(-max_acc, max_acc, int(num_samples / 2))
-    max_omega = np.pi / 8
+    max_omega = np.pi / 4
     omega_y_samples = np.linspace(-max_omega, max_omega, num_samples)
 
     num_samples = len(acc_samples) * len(omega_y_samples)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -591,6 +591,78 @@ class PlanningNode(Node):
             path = Path()
             path.header = depth_msg.header
             path.header.frame_id = "world"
+
+            # Goal-reached: publish empty path so cmd_vel stops.
+            # target_pose is a camera-frame position (POI was recorded as camera pose),
+            # so compare directly against camera position T[:3, 3].
+            if self.target_pose is not None:
+                dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2]))
+                if dist_to_goal < 0.3:
+                    self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
+                    self.path_pub.publish(path)
+                    return
+
+            if self.target_pose is None and not self.poi_changed:
+                self.path_pub.publish(path)  # empty path — no active nav target
+                return
+
+            # Obstacle recovery: if robot is within 0.3m of an obstacle, normal planning
+            # cannot escape. Back up if the rear is clear, otherwise stop.
+            robot_pos = T[:3, 3]
+            rx = int((robot_pos[0] - self.origin[0]) / self.resolution)
+            ry = int((robot_pos[1] - self.origin[1]) / self.resolution)
+            if 0 <= rx < ESDF_map.shape[0] and 0 <= ry < ESDF_map.shape[1]:
+                robot_clearance = float(ESDF_map[rx, ry])
+            else:
+                robot_clearance = float('inf')
+
+            if robot_clearance < 0.3:
+                forward = T[:3, :3] @ np.array([0.0, 0.0, 1.0])  # camera +Z = forward
+                back_sample = robot_pos - forward * 0.5
+                bx = int((back_sample[0] - self.origin[0]) / self.resolution)
+                by = int((back_sample[1] - self.origin[1]) / self.resolution)
+                if 0 <= bx < ESDF_map.shape[0] and 0 <= by < ESDF_map.shape[1]:
+                    back_clearance = float(ESDF_map[bx, by])
+                else:
+                    back_clearance = float('inf')
+
+                if back_clearance > 0.3:
+                    # Rear is clear: publish a 2-pose backward path.
+                    # cmd_vel_control will compute negative vx from the backward displacement.
+                    q = odom_msg.pose.pose.orientation
+                    back_target = robot_pos - forward * 0.5
+
+                    def _make_pose(pos):
+                        ps = PoseStamped()
+                        ps.header = depth_msg.header
+                        ps.pose.position.x = float(pos[0])
+                        ps.pose.position.y = float(pos[1])
+                        ps.pose.position.z = float(pos[2])
+                        ps.pose.orientation = q
+                        return ps
+
+                    recovery_path = Path()
+                    recovery_path.header = depth_msg.header
+                    recovery_path.header.frame_id = 'world'
+                    recovery_path.poses = [_make_pose(robot_pos), _make_pose(back_target)]
+                    self.get_logger().info(
+                        f'Recovery: backing up (robot_clearance={robot_clearance:.2f}m, back={back_clearance:.2f}m)'
+                    )
+                    self.path_pub.publish(recovery_path)
+                else:
+                    self.get_logger().info(
+                        f'Recovery: stuck, both sides blocked (robot={robot_clearance:.2f}m, back={back_clearance:.2f}m), stopping'
+                    )
+                    self.path_pub.publish(path)  # empty path
+                return
+
+            # If every trajectory is in collision, stop rather than picking an arbitrary one.
+            if all(s == float('inf') for s in scores):
+                self.get_logger().info('All trajectories in collision, stopping path.')
+                self.path_pub.publish(path)
+                return
+
+
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):
                     x,y,z,qx,qy,qz,qw = trajectories[i][j]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -51,7 +51,7 @@ class RobotConfig:
 
 GO2_CONFIG = RobotConfig(
     name='go2', shape='square',
-    length=0.7, width=0.3,
+    length=0.4, width=0.3,
     camera_x=0.35, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.1,
@@ -155,7 +155,7 @@ class ObstacleConfig:
     robot_z_top: float = 0.5
     occ_threshold: float = 0.1
     min_wall_span_m: float = 0.4
-    dilation_cells: int = 3
+    dilation_cells: int = 1
 
 
 def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None):
@@ -559,11 +559,19 @@ class PlanningNode(Node):
             v_dir = T[:3, :3] @ np.array([0, 0, 1])
             magnitude = np.clip(self.smoothed_velocity, 0.05, 0.5)
             init_v = v_dir * float(magnitude)
+            init_p = self.camera_to_robot_center(T)
+            init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
             trajectories, params = generate_trajectory_library_3d(
-                init_p = self.camera_to_robot_center(T),
-                init_v = init_v,
-                init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
+                init_p=init_p, init_v=init_v, init_q=init_q
             )
+            # Backward recovery trajectories: fewer samples, fixed slow reverse speed.
+            # Scored together with forward; penalised in cost so forward is always preferred.
+            back_trajs, back_params = generate_trajectory_library_3d(
+                num_samples=5, init_p=init_p, init_v=-v_dir * 0.15, init_q=init_q
+            )
+            is_backward = np.array([False] * len(trajectories) + [True] * len(back_trajs))
+            trajectories = np.concatenate([trajectories, back_trajs], axis=0)
+            params = np.concatenate([params, back_params], axis=0)
             self.last_T = T
             self.last_stamp = stamp
 
@@ -574,14 +582,15 @@ class PlanningNode(Node):
             top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            def cost_function(traj, param, score, target_pose):
+            def cost_function(traj, param, score, target_pose, backward):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1])
+                backward_penalty = 10000.0 if backward else 0.0
+                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + backward_penalty
 
             top_k = 1
-            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
+            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose, bool(is_backward[i])) for i in range(len(trajectories))]), kind='stable')[:top_k]
             self.last_param = params[top_indices[0]]
 
             if self.poi_changed and (depth_msg.header.stamp.sec - self.poi_change_timestamp_sec) > 3.0:
@@ -606,57 +615,7 @@ class PlanningNode(Node):
                 self.path_pub.publish(path)  # empty path — no active nav target
                 return
 
-            # Obstacle recovery: if robot is within 0.3m of an obstacle, normal planning
-            # cannot escape. Back up if the rear is clear, otherwise stop.
-            robot_pos = T[:3, 3]
-            rx = int((robot_pos[0] - self.origin[0]) / self.resolution)
-            ry = int((robot_pos[1] - self.origin[1]) / self.resolution)
-            if 0 <= rx < ESDF_map.shape[0] and 0 <= ry < ESDF_map.shape[1]:
-                robot_clearance = float(ESDF_map[rx, ry])
-            else:
-                robot_clearance = float('inf')
-
-            if robot_clearance < 0.3:
-                forward = T[:3, :3] @ np.array([0.0, 0.0, 1.0])  # camera +Z = forward
-                back_sample = robot_pos - forward * 0.5
-                bx = int((back_sample[0] - self.origin[0]) / self.resolution)
-                by = int((back_sample[1] - self.origin[1]) / self.resolution)
-                if 0 <= bx < ESDF_map.shape[0] and 0 <= by < ESDF_map.shape[1]:
-                    back_clearance = float(ESDF_map[bx, by])
-                else:
-                    back_clearance = float('inf')
-
-                if back_clearance > 0.3:
-                    # Rear is clear: publish a 2-pose backward path.
-                    # cmd_vel_control will compute negative vx from the backward displacement.
-                    q = odom_msg.pose.pose.orientation
-                    back_target = robot_pos - forward * 0.5
-
-                    def _make_pose(pos):
-                        ps = PoseStamped()
-                        ps.header = depth_msg.header
-                        ps.pose.position.x = float(pos[0])
-                        ps.pose.position.y = float(pos[1])
-                        ps.pose.position.z = float(pos[2])
-                        ps.pose.orientation = q
-                        return ps
-
-                    recovery_path = Path()
-                    recovery_path.header = depth_msg.header
-                    recovery_path.header.frame_id = 'world'
-                    recovery_path.poses = [_make_pose(robot_pos), _make_pose(back_target)]
-                    self.get_logger().info(
-                        f'Recovery: backing up (robot_clearance={robot_clearance:.2f}m, back={back_clearance:.2f}m)'
-                    )
-                    self.path_pub.publish(recovery_path)
-                else:
-                    self.get_logger().info(
-                        f'Recovery: stuck, both sides blocked (robot={robot_clearance:.2f}m, back={back_clearance:.2f}m), stopping'
-                    )
-                    self.path_pub.publish(path)  # empty path
-                return
-
-            # If every trajectory is in collision, stop rather than picking an arbitrary one.
+            # If every trajectory is in collision (forward and backward), stop.
             if all(s == float('inf') for s in scores):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 self.path_pub.publish(path)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -601,12 +601,11 @@ class PlanningNode(Node):
             path.header.frame_id = "world"
 
             # target_pose is camera-frame (POI recorded as camera pose); compare against T[:3, 3] directly.
-            if self.target_pose is not None:
-                dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2]))
-                if dist_to_goal < 0.3:
-                    self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
-                    self.path_pub.publish(path)
-                    return
+            dist_to_goal = float(np.linalg.norm(T[:3, 3][:2] - self.target_pose[:2])) if self.target_pose is not None else float('inf')
+            if dist_to_goal < 0.3:
+                self.get_logger().info(f'Goal reached (dist={dist_to_goal:.2f}m), stopping path.')
+                self.path_pub.publish(path)
+                return
 
             if self.target_pose is None and not self.poi_changed:
                 self.path_pub.publish(path)


### PR DESCRIPTION
  - Replace manual obstacle recovery (publish backward path from planning_node) with                                                                                                 
    DWA-native approach: skip step-0 in ESDF scoring to avoid contamination when robot
    is near an obstacle, and apply adaptive backward penalty scaled by robot clearance                                                                                               
  - Replace acceleration-based trajectory generation with direct (vx, ω) velocity                                                                                                    
    sampling; vx range [-0.2, 0.5] with single backward sample, ω range [-0.6, 0.6]                                                                                                  
  - Refine cost function: front obstacle awareness added to penalize trajectories heading                                                                                            
    into obstacles; trajectory smoothness term retained                                                                                                                              
  - Tune Go2 robot footprint (length=0.7, width=0.4, control_x=0.35) for tighter                                                                                                     
    collision checking                                                                                                                                                               
  - Increase reverse speed 0.1 → 0.2 m/s in cmd_vel_control                                                                                                                          
                                                             