### PR TITLE
build: add --no-web-resources-cdn for offline Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -251,7 +251,7 @@ RUN flutter config --enable-web \
     && flutter precache --web \
     && cd /tinynav/app/frontend \
     && flutter pub get \
-    && flutter build web --release --suppress-analytics
+    && flutter build web --release --suppress-analytics --no-web-resources-cdn
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
## Why

By default, `flutter build web` fetches CanvasKit and other resources from a CDN at build time, making the Docker build dependent on internet access.

## What

Add the `--no-web-resources-cdn` flag to the `flutter build web` command in the Dockerfile.

## How it works

The Dockerfile already runs `flutter precache --web`, which caches CanvasKit and related resources locally. With `--no-web-resources-cdn`:

- **At build time**: Uses the local cache directly instead of fetching from CDN → Docker build no longer requires internet access
- **At runtime**: The output is self-contained with CanvasKit bundled → suitable for offline / air-gapped environments

## Changes

```diff
-    && flutter build web --release --suppress-analytics
+    && flutter build web --release --suppress-analytics --no-web-resources-cdn
```

One-line change, no functional difference for online deployments.