### PR TITLE
chore(deps): update unitree-sdk2py source and lockfile pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,13 +196,6 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 # To use lekiwi instead, replace --extra unitree with --extra lekiwi.
 RUN /root/.local/bin/uv sync --python /opt/venv/bin/python --extra unitree
 
-# unitree_sdk2_python does not ship b2 in the installed package; copy it manually
-RUN git clone https://github.com/unitreerobotics/unitree_sdk2_python.git /tmp/unitree_sdk2_python \
-    && cd /tmp/unitree_sdk2_python \
-    && git checkout 404fe44d76f705c002c97e773276f2a8fefb57e4 \
-    && cp -r unitree_sdk2py/b2 /opt/venv/lib/python3.10/site-packages/unitree_sdk2py/ \
-    && rm -rf /tmp/unitree_sdk2_python
-
 # Write entrypoint.sh (model build prompt only)
 RUN cat > /usr/local/bin/entrypoint.sh <<'EOF'
 #!/usr/bin/env bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ lekiwi =[
     "lerobot[lekiwi]==0.3.3",
 ]
 unitree = [
-    "unitree-sdk2py @ git+https://github.com/unitreerobotics/unitree_sdk2_python.git@404fe44d76f705c002c97e773276f2a8fefb57e4",
+    "unitree-sdk2py @ git+https://github.com/junlinp/unitree_sdk2_python.git@800103eab7e045336b1c40186cda5023dbd05821",
 ]
 3dgs = [
     "torch>=2.4,<2.11",

--- a/tinynav/core/imu_propagator_node.py
+++ b/tinynav/core/imu_propagator_node.py
@@ -2,7 +2,6 @@ import logging
 
 import numpy as np
 import rclpy
-from message_filters import ApproximateTimeSynchronizer, Subscriber
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy
@@ -19,29 +18,43 @@ def integrate(odom_prev, imu, gravity_world=np.array([0.0, 0.0, -9.80])):
     translation_prev = pose_prev[:3, 3]
 
     t1, imu_msg = imu
-    gyro = np.array([
-        imu_msg.angular_velocity.x,
-        imu_msg.angular_velocity.y,
-        imu_msg.angular_velocity.z,
-    ], dtype=float)
-    accel = np.array([
-        imu_msg.linear_acceleration.x,
-        imu_msg.linear_acceleration.y,
-        imu_msg.linear_acceleration.z,
-    ], dtype=float)
+    gyro = np.array(
+        [
+            imu_msg.angular_velocity.x,
+            imu_msg.angular_velocity.y,
+            imu_msg.angular_velocity.z,
+        ],
+        dtype=float,
+    )
+    accel = np.array(
+        [
+            imu_msg.linear_acceleration.x,
+            imu_msg.linear_acceleration.y,
+            imu_msg.linear_acceleration.z,
+        ],
+        dtype=float,
+    )
 
     dt = t1 - t0
     delta_rotation = R.from_rotvec(gyro * dt).as_matrix()
     rotation_new = rotation_prev @ delta_rotation
     accel_world = rotation_prev @ accel + gravity_world
     velocity_new = velocity_prev + accel_world * dt
-    translation_new = translation_prev + velocity_prev * dt + 0.5 * accel_world * dt * dt
+    translation_new = (
+        translation_prev + velocity_prev * dt + 0.5 * accel_world * dt * dt
+    )
 
     pose_new = np.eye(4)
     pose_new[:3, :3] = rotation_new
     pose_new[:3, 3] = translation_new
 
-    odom_new = np2msg(pose_new, imu_msg.header.stamp, odom_msg.header.frame_id, odom_msg.child_frame_id, velocity_new)
+    odom_new = np2msg(
+        pose_new,
+        imu_msg.header.stamp,
+        odom_msg.header.frame_id,
+        odom_msg.child_frame_id,
+        velocity_new,
+    )
     odom_new.twist.twist.angular.x = gyro[0]
     odom_new.twist.twist.angular.y = gyro[1]
     odom_new.twist.twist.angular.z = gyro[2]
@@ -53,8 +66,12 @@ class ImuPropagatorNode(Node):
         super().__init__("imu_propagator_node")
 
         qos_profile = QoSProfile(reliability=ReliabilityPolicy.BEST_EFFORT, depth=1000)
-        self.imu_sub = self.create_subscription(Imu, "/camera/camera/imu", self.imu_callback, qos_profile)
-        self.odom_sub = self.create_subscription(Odometry, "/slam/odometry", self.odom_callback, qos_profile)
+        self.imu_sub = self.create_subscription(
+            Imu, "/camera/camera/imu", self.imu_callback, qos_profile
+        )
+        self.odom_sub = self.create_subscription(
+            Odometry, "/slam/odometry", self.odom_callback, qos_profile
+        )
         self.odom_pub = self.create_publisher(Odometry, "/slam/odometry_100hz", 50)
 
         self.imu_buffer = []
@@ -85,7 +102,9 @@ class ImuPropagatorNode(Node):
             return
 
         for i in range(start_idx, 0):
-            self.odom_100hz_buffer.append(integrate(self.odom_100hz_buffer[-1], self.imu_buffer[i]))
+            self.odom_100hz_buffer.append(
+                integrate(self.odom_100hz_buffer[-1], self.imu_buffer[i])
+            )
             if len(self.odom_100hz_buffer) > 1000:
                 self.odom_100hz_buffer.pop(0)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.12, <3.11"
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'darwin'",
@@ -4035,7 +4035,7 @@ requires-dist = [
     { name = "tabulate" },
     { name = "torch", marker = "extra == '3dgs'", specifier = ">=2.4,<2.11" },
     { name = "tyro" },
-    { name = "unitree-sdk2py", marker = "extra == 'unitree'", git = "https://github.com/unitreerobotics/unitree_sdk2_python.git?rev=404fe44d76f705c002c97e773276f2a8fefb57e4" },
+    { name = "unitree-sdk2py", marker = "extra == 'unitree'", git = "https://github.com/junlinp/unitree_sdk2_python.git?rev=800103eab7e045336b1c40186cda5023dbd05821" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
     { name = "viser" },
 ]
@@ -4331,7 +4331,7 @@ wheels = [
 [[package]]
 name = "unitree-sdk2py"
 version = "1.0.1"
-source = { git = "https://github.com/unitreerobotics/unitree_sdk2_python.git?rev=404fe44d76f705c002c97e773276f2a8fefb57e4#404fe44d76f705c002c97e773276f2a8fefb57e4" }
+source = { git = "https://github.com/junlinp/unitree_sdk2_python.git?rev=800103eab7e045336b1c40186cda5023dbd05821#800103eab7e045336b1c40186cda5023dbd05821" }
 dependencies = [
     { name = "cyclonedds" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- switch unitree-sdk2py source to junlinp/unitree_sdk2_python
- pin dependency to commit 800103eab7e045336b1c40186cda5023dbd05821
- update uv.lock accordingly

## Validation
- installed unitree extra in devcontainer
- verified unitree_sdk2py exposes g1 and b2

## Type
- chore(deps)
