### PR TITLE
refactor(build_map): migrate image storage to VideoDB and decord-backed pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,6 +196,17 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 # To use lekiwi instead, replace --extra unitree with --extra lekiwi.
 RUN /root/.local/bin/uv sync --python /opt/venv/bin/python --extra unitree
 
+# build decord from source
+RUN git clone --recursive https://github.com/dmlc/decord.git /tmp/decord \
+    && cd /tmp/decord \
+    && mkdir -p build \
+    && cd build \
+    && cmake .. -DUSE_CUDA=0 -DCMAKE_BUILD_TYPE=Release \
+    && make -j"$(nproc)" \
+    && cd ../python \
+    && /opt/venv/bin/python setup.py install \
+    && rm -rf /tmp/decord
+
 # unitree_sdk2_python does not ship b2 in the installed package; copy it manually
 RUN git clone https://github.com/unitreerobotics/unitree_sdk2_python.git /tmp/unitree_sdk2_python \
     && cd /tmp/unitree_sdk2_python \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pillow>=10.0.0",
     "httpx>=0.27.0",
-    "decord",
 ]
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pillow>=10.0.0",
     "httpx>=0.27.0",
+    "decord",
 ]
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "scipy",
     "matplotlib",
     "opencv-python",
+    "av",
     "codetiming",
     "numba==0.61.2",
     "fufpy",

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -25,6 +25,9 @@ from tinynav.core.planning_node import run_raycasting_loopy
 import logging
 import asyncio
 import shelve
+import base64
+import zlib
+import av
 from tqdm import tqdm
 import einops
 from tf2_msgs.msg import TFMessage
@@ -246,6 +249,19 @@ class OdomPoseRecorder:
 class TinyNavDB():
     def __init__(self, map_save_path:str, is_scratch:bool = True):
         self.map_save_path = map_save_path
+        self.is_scratch = is_scratch
+        self.meta_prefix = "TinyNav:"
+        self.infra1_mp4_path = f"{map_save_path}/infra1_images.mp4"
+        self.rgb_mp4_path = f"{map_save_path}/rgb_images.mp4"
+        self.infra1_ts_to_idx = {}
+        self.rgb_ts_to_idx = {}
+        self.infra1_frame_count = 0
+        self.rgb_frame_count = 0
+        self._infra1_stream = None
+        self._rgb_stream = None
+        self._infra1_container = None
+        self._rgb_container = None
+
         if is_scratch:
             if os.path.exists(f"{map_save_path}/features.db"):
                 os.remove(f"{map_save_path}/features.db")
@@ -257,17 +273,100 @@ class TinyNavDB():
                 os.remove(f"{map_save_path}/rgb_images.db")
             if os.path.exists(f"{map_save_path}/embeddings.db"):
                 os.remove(f"{map_save_path}/embeddings.db")
+            if os.path.exists(self.infra1_mp4_path):
+                os.remove(self.infra1_mp4_path)
+            if os.path.exists(self.rgb_mp4_path):
+                os.remove(self.rgb_mp4_path)
+
+            self._init_mp4_writers()
+
         self.features = IntKeyShelf(f"{map_save_path}/features")
         self.embeddings = IntKeyShelf(f"{map_save_path}/embeddings")
-        self.infra1_images = IntKeyShelf(f"{map_save_path}/infra1_images")
         self.depths = IntKeyShelf(f"{map_save_path}/depths")
-        self.rgb_images = IntKeyShelf(f"{map_save_path}/rgb_images")
+        if not is_scratch:
+            self.infra1_ts_to_idx = self._load_ts_index_from_metadata(self.infra1_mp4_path)
+            self.rgb_ts_to_idx = self._load_ts_index_from_metadata(self.rgb_mp4_path)
+
+    def _init_mp4_writers(self):
+        self._infra1_container = av.open(self.infra1_mp4_path, mode="w")
+        self._rgb_container = av.open(self.rgb_mp4_path, mode="w")
+
+    def _ensure_writer_stream(self, image: np.ndarray, is_rgb: bool):
+        h, w = image.shape[:2]
+        container = self._rgb_container if is_rgb else self._infra1_container
+        stream = self._rgb_stream if is_rgb else self._infra1_stream
+        if stream is not None:
+            return stream
+        stream = container.add_stream("libx264", rate=13)
+        stream.width = int(w)
+        stream.height = int(h)
+        stream.pix_fmt = "yuv420p"
+        stream.options = {"preset": "veryfast", "crf": "18", "tune": "zerolatency", "bf": "0"}
+        if is_rgb:
+            self._rgb_stream = stream
+        else:
+            self._infra1_stream = stream
+        return stream
+
+    def _append_rgb_image_mp4(self, key: int, image: np.ndarray):
+        if not self.is_scratch:
+            return
+        frame_np = np.asarray(image)
+        if frame_np.ndim == 2:
+            frame_np = cv2.cvtColor(frame_np, cv2.COLOR_GRAY2BGR)
+        frame = av.VideoFrame.from_ndarray(frame_np, format="bgr24")
+        stream = self._ensure_writer_stream(frame_np, is_rgb=True)
+        frame.pts = self.rgb_frame_count
+        self.rgb_ts_to_idx[int(key)] = int(self.rgb_frame_count)
+        self.rgb_frame_count += 1
+        for pkt in stream.encode(frame):
+            self._rgb_container.mux(pkt)
+
+    def _append_infra1_image_mp4(self, key: int, image: np.ndarray):
+        if not self.is_scratch:
+            return
+        frame_np = np.asarray(image)
+        if frame_np.ndim == 3:
+            frame_np = cv2.cvtColor(frame_np, cv2.COLOR_BGR2GRAY)
+        frame = av.VideoFrame.from_ndarray(frame_np, format="gray")
+        stream = self._ensure_writer_stream(frame_np, is_rgb=False)
+        frame.pts = self.infra1_frame_count
+        self.infra1_ts_to_idx[int(key)] = int(self.infra1_frame_count)
+        self.infra1_frame_count += 1
+        for pkt in stream.encode(frame):
+            self._infra1_container.mux(pkt)
+
+    def _write_ts_index_to_metadata(self, container, mapping: dict):
+        payload = json.dumps({str(k): int(v) for k, v in mapping.items()}, separators=(",", ":"))
+        payload = base64.b64encode(zlib.compress(payload.encode("utf-8"), level=9)).decode("ascii")
+        container.metadata["comment"] = self.meta_prefix + payload
+
+    def _load_ts_index_from_metadata(self, mp4_path: str) -> dict:
+        if not os.path.exists(mp4_path):
+            return {}
+        with av.open(mp4_path, mode="r") as c:
+            comment = c.metadata.get("comment", "")
+        if not comment.startswith(self.meta_prefix):
+            return {}
+        payload = comment[len(self.meta_prefix):]
+        data = json.loads(zlib.decompress(base64.b64decode(payload)).decode("utf-8"))
+        return {int(k): int(v) for k, v in data.items()}
+
+    def _decode_frame_by_index(self, mp4_path: str, frame_idx: int, as_gray: bool):
+        if frame_idx < 0 or not os.path.exists(mp4_path):
+            return None
+        with av.open(mp4_path, mode="r") as c:
+            stream = c.streams.video[0]
+            for i, frame in enumerate(c.decode(stream)):
+                if i == frame_idx:
+                    return frame.to_ndarray(format="gray" if as_gray else "bgr24")
+        return None
 
     def set_entry(self, key:int,   depth:np.ndarray = None, embedding:np.ndarray = None, features:dict = None,  infra1_image:np.ndarray = None, rgb_image:np.ndarray = None):
         if infra1_image is not None:
-            self.infra1_images[key] = infra1_image
+            self._append_infra1_image_mp4(key, infra1_image)
         if rgb_image is not None:
-            self.rgb_images[key] = rgb_image
+            self._append_rgb_image_mp4(key, rgb_image)
         if depth is not None:
             self.depths[key] = depth
         if embedding is not None:
@@ -276,7 +375,16 @@ class TinyNavDB():
             self.features[key] = features
 
     def get_depth_embedding_features_images(self, key:int):
-        return self.depths[key], self.embeddings[key], self.features[key], self.rgb_images[key], self.infra1_images[key]
+        rgb_image = None
+        infra1_image = None
+        key_int = int(key)
+        if key_int in self.rgb_ts_to_idx:
+            idx = self.rgb_ts_to_idx[key_int]
+            rgb_image = self._decode_frame_by_index(self.rgb_mp4_path, idx, as_gray=False)
+        if key_int in self.infra1_ts_to_idx:
+            idx = self.infra1_ts_to_idx[key_int]
+            infra1_image = self._decode_frame_by_index(self.infra1_mp4_path, idx, as_gray=True)
+        return self.depths[key], self.embeddings[key], self.features[key], rgb_image, infra1_image
 
     def get_embedding(self, key:int):
         return self.embeddings[key]
@@ -284,9 +392,20 @@ class TinyNavDB():
     def close(self):
         self.features.close()
         self.embeddings.close()
-        self.infra1_images.close()
         self.depths.close()
-        self.rgb_images.close()
+        if self.is_scratch:
+            if self._infra1_stream is not None:
+                for pkt in self._infra1_stream.encode(None):
+                    self._infra1_container.mux(pkt)
+            if self._rgb_stream is not None:
+                for pkt in self._rgb_stream.encode(None):
+                    self._rgb_container.mux(pkt)
+            if self._infra1_container is not None:
+                self._write_ts_index_to_metadata(self._infra1_container, self.infra1_ts_to_idx)
+                self._infra1_container.close()
+            if self._rgb_container is not None:
+                self._write_ts_index_to_metadata(self._rgb_container, self.rgb_ts_to_idx)
+                self._rgb_container.close()
 
 class BagPlayer(Node):
     def __init__(self, bag_uri: str, storage_id: str = "sqlite3", serialization_format: str = "cdr",

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -298,7 +298,7 @@ class TinyNavDB():
         stream = self._rgb_stream if is_rgb else self._infra1_stream
         if stream is not None:
             return stream
-        stream = container.add_stream("libx264", rate=13)
+        stream = container.add_stream("libx264", rate=30)
         stream.width = int(w)
         stream.height = int(h)
         stream.pix_fmt = "yuv420p"

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -374,16 +374,17 @@ class TinyNavDB():
         if features is not None:
             self.features[key] = features
 
-    def get_depth_embedding_features_images(self, key:int):
+    def get_depth_embedding_features_images(self, key:int, load_images: bool = False):
         rgb_image = None
         infra1_image = None
         key_int = int(key)
-        if key_int in self.rgb_ts_to_idx:
-            idx = self.rgb_ts_to_idx[key_int]
-            rgb_image = self._decode_frame_by_index(self.rgb_mp4_path, idx, as_gray=False)
-        if key_int in self.infra1_ts_to_idx:
-            idx = self.infra1_ts_to_idx[key_int]
-            infra1_image = self._decode_frame_by_index(self.infra1_mp4_path, idx, as_gray=True)
+        if load_images:
+            if key_int in self.rgb_ts_to_idx:
+                idx = self.rgb_ts_to_idx[key_int]
+                rgb_image = self._decode_frame_by_index(self.rgb_mp4_path, idx, as_gray=False)
+            if key_int in self.infra1_ts_to_idx:
+                idx = self.infra1_ts_to_idx[key_int]
+                infra1_image = self._decode_frame_by_index(self.infra1_mp4_path, idx, as_gray=True)
         return self.depths[key], self.embeddings[key], self.features[key], rgb_image, infra1_image
 
     def get_embedding(self, key:int):

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -26,9 +26,8 @@ import logging
 import asyncio
 import shelve
 import json
-import base64
-import zlib
 import av
+import time
 from tqdm import tqdm
 import einops
 from tf2_msgs.msg import TFMessage
@@ -247,127 +246,168 @@ class OdomPoseRecorder:
         self.poses.clear()
 
 
-class TinyNavDB():
-    def __init__(self, map_save_path:str, is_scratch:bool = True):
-        self.map_save_path = map_save_path
-        self.is_scratch = is_scratch
-        self.meta_prefix = "TinyNav:"
-        self.infra1_mp4_path = f"{map_save_path}/infra1_images.mp4"
-        self.rgb_mp4_path = f"{map_save_path}/rgb_images.mp4"
-        self.infra1_ts_to_idx = {}
-        self.rgb_ts_to_idx = {}
-        self.infra1_frame_count = 0
-        self.rgb_frame_count = 0
-        self._infra1_stream = None
-        self._rgb_stream = None
-        self._infra1_container = None
-        self._rgb_container = None
+class VideoDB:
+    def __init__(
+        self,
+        dir_path: str,
+        mode: str,
+        fps: int = 30,
+    ):
+        if mode not in {"read", "write"}:
+            raise ValueError(f"Invalid mode: {mode}")
+        self.dir_path = dir_path
+        self.video_path = os.path.join(dir_path, "video.mp4")
+        self.meta_path = os.path.join(dir_path, "meta.json")
+        self.mode = mode
+        self.fps = fps
+        self.ts_to_idx = {}
+        self.frame_count = 0
+        self._stream = None
+        self._container = None
+        self.is_gray = None
+        self.write_count = 0
+        self.write_total_s = 0.0
+        self.read_count = 0
+        self.read_total_s = 0.0
 
-        if is_scratch:
-            if os.path.exists(f"{map_save_path}/features.db"):
-                os.remove(f"{map_save_path}/features.db")
-            if os.path.exists(f"{map_save_path}/infra1_images.db"):
-                os.remove(f"{map_save_path}/infra1_images.db")
-            if os.path.exists(f"{map_save_path}/depths.db"):
-                os.remove(f"{map_save_path}/depths.db")
-            if os.path.exists(f"{map_save_path}/rgb_images.db"):
-                os.remove(f"{map_save_path}/rgb_images.db")
-            if os.path.exists(f"{map_save_path}/embeddings.db"):
-                os.remove(f"{map_save_path}/embeddings.db")
-            if os.path.exists(self.infra1_mp4_path):
-                os.remove(self.infra1_mp4_path)
-            if os.path.exists(self.rgb_mp4_path):
-                os.remove(self.rgb_mp4_path)
+        if self.mode == "write":
+            os.makedirs(self.dir_path, exist_ok=True)
+            if os.path.exists(self.video_path):
+                os.remove(self.video_path)
+            if os.path.exists(self.meta_path):
+                os.remove(self.meta_path)
+            self._container = av.open(self.video_path, mode="w")
+        else:
+            self.ts_to_idx = self._load_meta()
 
-            self._init_mp4_writers()
-
-        self.features = IntKeyShelf(f"{map_save_path}/features")
-        self.embeddings = IntKeyShelf(f"{map_save_path}/embeddings")
-        self.depths = IntKeyShelf(f"{map_save_path}/depths")
-        if not is_scratch:
-            self.infra1_ts_to_idx = self._load_ts_index_from_metadata(self.infra1_mp4_path)
-            self.rgb_ts_to_idx = self._load_ts_index_from_metadata(self.rgb_mp4_path)
-
-    def _init_mp4_writers(self):
-        self._infra1_container = av.open(self.infra1_mp4_path, mode="w")
-        self._rgb_container = av.open(self.rgb_mp4_path, mode="w")
-
-    def _ensure_writer_stream(self, image: np.ndarray, is_rgb: bool):
+    def _ensure_writer_stream(self, image: np.ndarray):
         h, w = image.shape[:2]
-        container = self._rgb_container if is_rgb else self._infra1_container
-        stream = self._rgb_stream if is_rgb else self._infra1_stream
+        container = self._container
+        stream = self._stream
         if stream is not None:
             return stream
-        stream = container.add_stream("libx264", rate=30)
+        stream = container.add_stream("libx264", rate=self.fps)
         stream.width = int(w)
         stream.height = int(h)
         stream.pix_fmt = "yuv420p"
         stream.options = {"preset": "veryfast", "crf": "18", "tune": "zerolatency", "bf": "0"}
-        if is_rgb:
-            self._rgb_stream = stream
-        else:
-            self._infra1_stream = stream
+        self._stream = stream
         return stream
 
-    def _append_rgb_image_mp4(self, key: int, image: np.ndarray):
-        if not self.is_scratch:
-            return
+    def write(self, timestamp: int, image: np.ndarray):
+        if self.mode != "write":
+            raise RuntimeError("VideoDB write() requires mode='write'")
+        t0 = time.perf_counter()
         frame_np = np.asarray(image)
-        if frame_np.ndim == 2:
-            frame_np = cv2.cvtColor(frame_np, cv2.COLOR_GRAY2BGR)
-        frame = av.VideoFrame.from_ndarray(frame_np, format="bgr24")
-        stream = self._ensure_writer_stream(frame_np, is_rgb=True)
-        frame.pts = self.rgb_frame_count
-        self.rgb_ts_to_idx[int(key)] = int(self.rgb_frame_count)
-        self.rgb_frame_count += 1
-        for pkt in stream.encode(frame):
-            self._rgb_container.mux(pkt)
-
-    def _append_infra1_image_mp4(self, key: int, image: np.ndarray):
-        if not self.is_scratch:
-            return
-        frame_np = np.asarray(image)
-        if frame_np.ndim == 3:
+        curr_is_gray = frame_np.ndim == 2
+        if self.is_gray is None:
+            self.is_gray = curr_is_gray
+        elif self.is_gray and frame_np.ndim == 3:
             frame_np = cv2.cvtColor(frame_np, cv2.COLOR_BGR2GRAY)
-        frame = av.VideoFrame.from_ndarray(frame_np, format="gray")
-        stream = self._ensure_writer_stream(frame_np, is_rgb=False)
-        frame.pts = self.infra1_frame_count
-        self.infra1_ts_to_idx[int(key)] = int(self.infra1_frame_count)
-        self.infra1_frame_count += 1
+        elif not self.is_gray and frame_np.ndim == 2:
+            frame_np = cv2.cvtColor(frame_np, cv2.COLOR_GRAY2BGR)
+        frame_format = "gray" if self.is_gray else "bgr24"
+        frame = av.VideoFrame.from_ndarray(frame_np, format=frame_format)
+        stream = self._ensure_writer_stream(frame_np)
+        frame.pts = self.frame_count
+        self.ts_to_idx[int(timestamp)] = int(self.frame_count)
+        self.frame_count += 1
         for pkt in stream.encode(frame):
-            self._infra1_container.mux(pkt)
+            self._container.mux(pkt)
+        self.write_count += 1
+        self.write_total_s += time.perf_counter() - t0
 
-    def _write_ts_index_to_metadata(self, container, mapping: dict):
-        payload = json.dumps({str(k): int(v) for k, v in mapping.items()}, separators=(",", ":"))
-        payload = base64.b64encode(zlib.compress(payload.encode("utf-8"), level=9)).decode("ascii")
-        container.metadata["comment"] = self.meta_prefix + payload
+    def _write_meta(self):
+        payload = {
+            "ts_to_idx": {str(k): int(v) for k, v in self.ts_to_idx.items()},
+            "is_gray": bool(self.is_gray) if self.is_gray is not None else False,
+        }
+        with open(self.meta_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, separators=(",", ":"))
 
-    def _load_ts_index_from_metadata(self, mp4_path: str) -> dict:
-        if not os.path.exists(mp4_path):
+    def _load_meta(self) -> dict:
+        if not os.path.exists(self.meta_path):
             return {}
-        with av.open(mp4_path, mode="r") as c:
-            comment = c.metadata.get("comment", "")
-        if not comment.startswith(self.meta_prefix):
+        with open(self.meta_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "ts_to_idx" not in data:
             return {}
-        payload = comment[len(self.meta_prefix):]
-        data = json.loads(zlib.decompress(base64.b64decode(payload)).decode("utf-8"))
-        return {int(k): int(v) for k, v in data.items()}
+        self.is_gray = bool(data.get("is_gray", False))
+        ts_to_idx = data["ts_to_idx"]
+        return {int(k): int(v) for k, v in ts_to_idx.items()}
 
-    def _decode_frame_by_index(self, mp4_path: str, frame_idx: int, as_gray: bool):
-        if frame_idx < 0 or not os.path.exists(mp4_path):
+    def _decode_frame_by_index(self, frame_idx: int):
+        if frame_idx < 0 or not os.path.exists(self.video_path):
             return None
-        with av.open(mp4_path, mode="r") as c:
+        with av.open(self.video_path, mode="r") as c:
             stream = c.streams.video[0]
             for i, frame in enumerate(c.decode(stream)):
                 if i == frame_idx:
-                    return frame.to_ndarray(format="gray" if as_gray else "bgr24")
+                    return frame.to_ndarray(format="gray" if self.is_gray else "bgr24")
         return None
+
+    def read(self, timestamp: int):
+        if self.mode != "read":
+            raise RuntimeError("VideoDB read() requires mode='read'")
+        t0 = time.perf_counter()
+        key = int(timestamp)
+        if key not in self.ts_to_idx:
+            self.read_count += 1
+            self.read_total_s += time.perf_counter() - t0
+            return None
+        image = self._decode_frame_by_index(self.ts_to_idx[key])
+        self.read_count += 1
+        self.read_total_s += time.perf_counter() - t0
+        return image
+
+    def close(self):
+        if self.mode == "write":
+            if self._stream is not None:
+                for pkt in self._stream.encode(None):
+                    self._container.mux(pkt)
+            if self._container is not None:
+                self._container.close()
+            self._write_meta()
+        write_avg_ms = (self.write_total_s / self.write_count * 1000.0) if self.write_count > 0 else 0.0
+        read_avg_ms = (self.read_total_s / self.read_count * 1000.0) if self.read_count > 0 else 0.0
+        print(
+            f"[VideoDB] dir={self.dir_path} mode={self.mode} "
+            f"write_count={self.write_count} write_avg_ms={write_avg_ms:.3f} "
+            f"read_count={self.read_count} read_avg_ms={read_avg_ms:.3f}"
+        )
+
+
+class TinyNavDB():
+    def __init__(self, map_save_path:str, is_scratch:bool = True):
+        self.map_save_path = map_save_path
+        self.is_scratch = is_scratch
+        mode = "write" if is_scratch else "read"
+        self.infra1_video_db = VideoDB(
+            dir_path=f"{map_save_path}/infra1_images_db",
+            mode=mode,
+            fps=30,
+        )
+        self.rgb_video_db = VideoDB(
+            dir_path=f"{map_save_path}/rgb_images_db",
+            mode=mode,
+            fps=30,
+        )
+        if is_scratch:
+            if os.path.exists(f"{map_save_path}/features.db"):
+                os.remove(f"{map_save_path}/features.db")
+            if os.path.exists(f"{map_save_path}/depths.db"):
+                os.remove(f"{map_save_path}/depths.db")
+            if os.path.exists(f"{map_save_path}/embeddings.db"):
+                os.remove(f"{map_save_path}/embeddings.db")
+        self.features = IntKeyShelf(f"{map_save_path}/features")
+        self.embeddings = IntKeyShelf(f"{map_save_path}/embeddings")
+        self.depths = IntKeyShelf(f"{map_save_path}/depths")
 
     def set_entry(self, key:int,   depth:np.ndarray = None, embedding:np.ndarray = None, features:dict = None,  infra1_image:np.ndarray = None, rgb_image:np.ndarray = None):
         if infra1_image is not None:
-            self._append_infra1_image_mp4(key, infra1_image)
+            self.infra1_video_db.write(key, infra1_image)
         if rgb_image is not None:
-            self._append_rgb_image_mp4(key, rgb_image)
+            self.rgb_video_db.write(key, rgb_image)
         if depth is not None:
             self.depths[key] = depth
         if embedding is not None:
@@ -377,22 +417,15 @@ class TinyNavDB():
 
     def get_depth_embedding_features_images(self, key:int):
         key_int = int(key)
-
         def rgb_loader():
             if self.is_scratch:
                 return None
-            if key_int not in self.rgb_ts_to_idx:
-                return None
-            idx = self.rgb_ts_to_idx[key_int]
-            return self._decode_frame_by_index(self.rgb_mp4_path, idx, as_gray=False)
+            return self.rgb_video_db.read(key_int)
 
         def infra1_loader():
             if self.is_scratch:
                 return None
-            if key_int not in self.infra1_ts_to_idx:
-                return None
-            idx = self.infra1_ts_to_idx[key_int]
-            return self._decode_frame_by_index(self.infra1_mp4_path, idx, as_gray=True)
+            return self.infra1_video_db.read(key_int)
 
         return self.depths[key], self.embeddings[key], self.features[key], rgb_loader, infra1_loader
 
@@ -403,19 +436,8 @@ class TinyNavDB():
         self.features.close()
         self.embeddings.close()
         self.depths.close()
-        if self.is_scratch:
-            if self._infra1_stream is not None:
-                for pkt in self._infra1_stream.encode(None):
-                    self._infra1_container.mux(pkt)
-            if self._rgb_stream is not None:
-                for pkt in self._rgb_stream.encode(None):
-                    self._rgb_container.mux(pkt)
-            if self._infra1_container is not None:
-                self._write_ts_index_to_metadata(self._infra1_container, self.infra1_ts_to_idx)
-                self._infra1_container.close()
-            if self._rgb_container is not None:
-                self._write_ts_index_to_metadata(self._rgb_container, self.rgb_ts_to_idx)
-                self._rgb_container.close()
+        self.infra1_video_db.close()
+        self.rgb_video_db.close()
 
 class BagPlayer(Node):
     def __init__(self, bag_uri: str, storage_id: str = "sqlite3", serialization_format: str = "cdr",

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -25,13 +25,11 @@ from tinynav.core.planning_node import run_raycasting_loopy
 import logging
 import asyncio
 import shelve
-import json
-import av
-import time
 from tqdm import tqdm
 import einops
 from tf2_msgs.msg import TFMessage
 from typing import Dict
+from tool.video_db import VideoDB
 
 from tf2_ros import TransformBroadcaster
 from geometry_msgs.msg import TransformStamped,Point
@@ -244,138 +242,6 @@ class OdomPoseRecorder:
 
     def clear(self) -> None:
         self.poses.clear()
-
-
-class VideoDB:
-    def __init__(
-        self,
-        dir_path: str,
-        mode: str,
-        fps: int = 30,
-    ):
-        if mode not in {"read", "write"}:
-            raise ValueError(f"Invalid mode: {mode}")
-        self.dir_path = dir_path
-        self.video_path = os.path.join(dir_path, "video.mp4")
-        self.meta_path = os.path.join(dir_path, "meta.json")
-        self.mode = mode
-        self.fps = fps
-        self.ts_to_idx = {}
-        self.frame_count = 0
-        self._stream = None
-        self._container = None
-        self.is_gray = None
-        self.write_count = 0
-        self.write_total_s = 0.0
-        self.read_count = 0
-        self.read_total_s = 0.0
-
-        if self.mode == "write":
-            os.makedirs(self.dir_path, exist_ok=True)
-            if os.path.exists(self.video_path):
-                os.remove(self.video_path)
-            if os.path.exists(self.meta_path):
-                os.remove(self.meta_path)
-            self._container = av.open(self.video_path, mode="w")
-        else:
-            self.ts_to_idx = self._load_meta()
-
-    def _ensure_writer_stream(self, image: np.ndarray):
-        h, w = image.shape[:2]
-        container = self._container
-        stream = self._stream
-        if stream is not None:
-            return stream
-        stream = container.add_stream("libx264", rate=self.fps)
-        stream.width = int(w)
-        stream.height = int(h)
-        stream.pix_fmt = "yuv420p"
-        stream.options = {"preset": "veryfast", "crf": "18", "tune": "zerolatency", "bf": "0"}
-        self._stream = stream
-        return stream
-
-    def write(self, timestamp: int, image: np.ndarray):
-        if self.mode != "write":
-            raise RuntimeError("VideoDB write() requires mode='write'")
-        t0 = time.perf_counter()
-        frame_np = np.asarray(image)
-        curr_is_gray = frame_np.ndim == 2
-        if self.is_gray is None:
-            self.is_gray = curr_is_gray
-        elif self.is_gray != curr_is_gray:
-            raise ValueError(
-                f"Inconsistent image ndim for {self.dir_path}: expected "
-                f"{'gray(2D)' if self.is_gray else 'color(3D)'}, got ndim={frame_np.ndim}"
-            )
-        frame_format = "gray" if self.is_gray else "bgr24"
-        frame = av.VideoFrame.from_ndarray(frame_np, format=frame_format)
-        stream = self._ensure_writer_stream(frame_np)
-        frame.pts = self.frame_count
-        self.ts_to_idx[int(timestamp)] = int(self.frame_count)
-        self.frame_count += 1
-        for pkt in stream.encode(frame):
-            self._container.mux(pkt)
-        self.write_count += 1
-        self.write_total_s += time.perf_counter() - t0
-
-    def _write_meta(self):
-        payload = {
-            "ts_to_idx": {str(k): int(v) for k, v in self.ts_to_idx.items()},
-            "is_gray": bool(self.is_gray) if self.is_gray is not None else False,
-        }
-        with open(self.meta_path, "w", encoding="utf-8") as f:
-            json.dump(payload, f, separators=(",", ":"))
-
-    def _load_meta(self) -> dict:
-        if not os.path.exists(self.meta_path):
-            return {}
-        with open(self.meta_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        if not isinstance(data, dict) or "ts_to_idx" not in data:
-            return {}
-        self.is_gray = bool(data.get("is_gray", False))
-        ts_to_idx = data["ts_to_idx"]
-        return {int(k): int(v) for k, v in ts_to_idx.items()}
-
-    def _decode_frame_by_index(self, frame_idx: int):
-        if frame_idx < 0 or not os.path.exists(self.video_path):
-            return None
-        with av.open(self.video_path, mode="r") as c:
-            stream = c.streams.video[0]
-            for i, frame in enumerate(c.decode(stream)):
-                if i == frame_idx:
-                    return frame.to_ndarray(format="gray" if self.is_gray else "bgr24")
-        return None
-
-    def read(self, timestamp: int):
-        if self.mode != "read":
-            raise RuntimeError("VideoDB read() requires mode='read'")
-        t0 = time.perf_counter()
-        key = int(timestamp)
-        if key not in self.ts_to_idx:
-            self.read_count += 1
-            self.read_total_s += time.perf_counter() - t0
-            return None
-        image = self._decode_frame_by_index(self.ts_to_idx[key])
-        self.read_count += 1
-        self.read_total_s += time.perf_counter() - t0
-        return image
-
-    def close(self):
-        if self.mode == "write":
-            if self._stream is not None:
-                for pkt in self._stream.encode(None):
-                    self._container.mux(pkt)
-            if self._container is not None:
-                self._container.close()
-            self._write_meta()
-        write_avg_ms = (self.write_total_s / self.write_count * 1000.0) if self.write_count > 0 else 0.0
-        read_avg_ms = (self.read_total_s / self.read_count * 1000.0) if self.read_count > 0 else 0.0
-        print(
-            f"[VideoDB] dir={self.dir_path} mode={self.mode} "
-            f"write_count={self.write_count} write_avg_ms={write_avg_ms:.3f} "
-            f"read_count={self.read_count} read_avg_ms={read_avg_ms:.3f}"
-        )
 
 
 class TinyNavDB():

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -302,10 +302,11 @@ class VideoDB:
         curr_is_gray = frame_np.ndim == 2
         if self.is_gray is None:
             self.is_gray = curr_is_gray
-        elif self.is_gray and frame_np.ndim == 3:
-            frame_np = cv2.cvtColor(frame_np, cv2.COLOR_BGR2GRAY)
-        elif not self.is_gray and frame_np.ndim == 2:
-            frame_np = cv2.cvtColor(frame_np, cv2.COLOR_GRAY2BGR)
+        elif self.is_gray != curr_is_gray:
+            raise ValueError(
+                f"Inconsistent image ndim for {self.dir_path}: expected "
+                f"{'gray(2D)' if self.is_gray else 'color(3D)'}, got ndim={frame_np.ndim}"
+            )
         frame_format = "gray" if self.is_gray else "bgr24"
         frame = av.VideoFrame.from_ndarray(frame_np, format=frame_format)
         stream = self._ensure_writer_stream(frame_np)

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -25,6 +25,7 @@ from tinynav.core.planning_node import run_raycasting_loopy
 import logging
 import asyncio
 import shelve
+import json
 import base64
 import zlib
 import av
@@ -374,18 +375,26 @@ class TinyNavDB():
         if features is not None:
             self.features[key] = features
 
-    def get_depth_embedding_features_images(self, key:int, load_images: bool = False):
-        rgb_image = None
-        infra1_image = None
+    def get_depth_embedding_features_images(self, key:int):
         key_int = int(key)
-        if load_images:
-            if key_int in self.rgb_ts_to_idx:
-                idx = self.rgb_ts_to_idx[key_int]
-                rgb_image = self._decode_frame_by_index(self.rgb_mp4_path, idx, as_gray=False)
-            if key_int in self.infra1_ts_to_idx:
-                idx = self.infra1_ts_to_idx[key_int]
-                infra1_image = self._decode_frame_by_index(self.infra1_mp4_path, idx, as_gray=True)
-        return self.depths[key], self.embeddings[key], self.features[key], rgb_image, infra1_image
+
+        def rgb_loader():
+            if self.is_scratch:
+                return None
+            if key_int not in self.rgb_ts_to_idx:
+                return None
+            idx = self.rgb_ts_to_idx[key_int]
+            return self._decode_frame_by_index(self.rgb_mp4_path, idx, as_gray=False)
+
+        def infra1_loader():
+            if self.is_scratch:
+                return None
+            if key_int not in self.infra1_ts_to_idx:
+                return None
+            idx = self.infra1_ts_to_idx[key_int]
+            return self._decode_frame_by_index(self.infra1_mp4_path, idx, as_gray=True)
+
+        return self.depths[key], self.embeddings[key], self.features[key], rgb_loader, infra1_loader
 
     def get_embedding(self, key:int):
         return self.embeddings[key]

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -907,13 +907,13 @@ class BuildMapNode(Node):
             return
             
         transforms = []        
-        for time, pose_in_world in self.pose_graph_used_pose.items():
+        for timestamp, pose_in_world in self.pose_graph_used_pose.items():
             transform = TransformStamped()
             
             # Set header
             transform.header.stamp = self.get_clock().now().to_msg()
             transform.header.frame_id = 'world'
-            transform.child_frame_id = 'camera_' + str(time)
+            transform.child_frame_id = 'camera_' + str(timestamp)
             
             # Set position
             t = pose_in_world[:3, 3]

--- a/tinynav/core/imu_propagator_node.py
+++ b/tinynav/core/imu_propagator_node.py
@@ -60,27 +60,12 @@ class ImuPropagatorNode(Node):
         self.imu_buffer = []
         self.odom_10hz_buffer = []
         self.odom_100hz_buffer = []
-        self.imu_log_counter = 0
 
     def imu_callback(self, imu_msg: Imu):
         if len(self.odom_100hz_buffer) == 0:
             return
 
         timestamp = self._stamp_to_sec(imu_msg.header.stamp)
-        self.imu_log_counter += 1
-        if self.imu_log_counter % 20 == 0:
-            self.get_logger().info(
-                "imu t=%.6f gyro=(%.4f, %.4f, %.4f) accel=(%.4f, %.4f, %.4f)"
-                % (
-                    timestamp,
-                    imu_msg.angular_velocity.x,
-                    imu_msg.angular_velocity.y,
-                    imu_msg.angular_velocity.z,
-                    imu_msg.linear_acceleration.x,
-                    imu_msg.linear_acceleration.y,
-                    imu_msg.linear_acceleration.z,
-                )
-            )
         self.imu_buffer.append((timestamp, imu_msg))
         if len(self.imu_buffer) > 2000:
             self.imu_buffer.pop(0)

--- a/tinynav/core/imu_propagator_node.py
+++ b/tinynav/core/imu_propagator_node.py
@@ -60,13 +60,27 @@ class ImuPropagatorNode(Node):
         self.imu_buffer = []
         self.odom_10hz_buffer = []
         self.odom_100hz_buffer = []
+        self.imu_log_counter = 0
 
     def imu_callback(self, imu_msg: Imu):
         if len(self.odom_100hz_buffer) == 0:
             return
 
         timestamp = self._stamp_to_sec(imu_msg.header.stamp)
-        print("imu: ", timestamp)
+        self.imu_log_counter += 1
+        if self.imu_log_counter % 20 == 0:
+            self.get_logger().info(
+                "imu t=%.6f gyro=(%.4f, %.4f, %.4f) accel=(%.4f, %.4f, %.4f)"
+                % (
+                    timestamp,
+                    imu_msg.angular_velocity.x,
+                    imu_msg.angular_velocity.y,
+                    imu_msg.angular_velocity.z,
+                    imu_msg.linear_acceleration.x,
+                    imu_msg.linear_acceleration.y,
+                    imu_msg.linear_acceleration.z,
+                )
+            )
         self.imu_buffer.append((timestamp, imu_msg))
         if len(self.imu_buffer) > 2000:
             self.imu_buffer.pop(0)

--- a/tool/convert_to_nerf_format.py
+++ b/tool/convert_to_nerf_format.py
@@ -84,16 +84,14 @@ def export_rgb_images(
     image_size = None
     rgb_db_dir = map_dir / "rgb_images_db"
     rgb_video_db = VideoDB(dir_path=str(rgb_db_dir), mode="read")
-    try:
-        for timestamp in tqdm(timestamps, desc="Exporting RGB images", unit="img"):
-            rgb_image = rgb_video_db.read(timestamp)
-            if rgb_image is None:
-                raise KeyError(f"Missing rgb image timestamp {timestamp} in {rgb_db_dir / 'meta.json'}")
-            if image_size is None:
-                image_size = rgb_image.shape[:2]
-            cv2.imwrite(str(images_dir / f"image_{timestamp}.png"), rgb_image)
-    finally:
-        rgb_video_db.close()
+    for timestamp in tqdm(timestamps, desc="Exporting RGB images", unit="img"):
+        rgb_image = rgb_video_db.read(timestamp)
+        if rgb_image is None:
+            raise KeyError(f"Missing rgb image timestamp {timestamp} in {rgb_db_dir / 'meta.json'}")
+        if image_size is None:
+            image_size = rgb_image.shape[:2]
+        cv2.imwrite(str(images_dir / f"image_{timestamp}.png"), rgb_image)
+    rgb_video_db.close()
 
     if image_size is None:
         raise RuntimeError("No RGB images exported; poses may be empty")

--- a/tool/convert_to_nerf_format.py
+++ b/tool/convert_to_nerf_format.py
@@ -13,8 +13,8 @@ from typing import Dict, Tuple
 
 import cv2
 import numpy as np
-import shelve
 from tqdm import tqdm
+from tool.video_db import VideoDB
 
 
 def convert_nerf_format(
@@ -82,15 +82,18 @@ def export_rgb_images(
 ) -> Tuple[int, int]:
     images_dir.mkdir(parents=True, exist_ok=True)
     image_size = None
-    with shelve.open(str(map_dir / "rgb_images")) as rgb_db:
+    rgb_db_dir = map_dir / "rgb_images_db"
+    rgb_video_db = VideoDB(dir_path=str(rgb_db_dir), mode="read")
+    try:
         for timestamp in tqdm(timestamps, desc="Exporting RGB images", unit="img"):
-            key = str(timestamp)
-            if key not in rgb_db:
-                raise KeyError(f"Missing rgb image for timestamp {timestamp} in {map_dir / 'rgb_images'}")
-            rgb_image = rgb_db[key]
+            rgb_image = rgb_video_db.read(timestamp)
+            if rgb_image is None:
+                raise KeyError(f"Missing rgb image timestamp {timestamp} in {rgb_db_dir / 'meta.json'}")
             if image_size is None:
                 image_size = rgb_image.shape[:2]
             cv2.imwrite(str(images_dir / f"image_{timestamp}.png"), rgb_image)
+    finally:
+        rgb_video_db.close()
 
     if image_size is None:
         raise RuntimeError("No RGB images exported; poses may be empty")
@@ -153,7 +156,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--reuse-existing-images",
         action="store_true",
-        help="Do not export from rgb_images shelve; reuse existing image_*.png files",
+        help="Do not export from rgb_images_db/video.mp4; reuse existing image_*.png files",
     )
     return parser.parse_args()
 

--- a/tool/video_db.py
+++ b/tool/video_db.py
@@ -1,0 +1,167 @@
+import json
+import os
+import time
+
+import av
+import numpy as np
+
+
+class VideoDB:
+    def __init__(
+        self,
+        dir_path: str,
+        mode: str,
+        fps: int = 30,
+    ):
+        if mode not in {"read", "write"}:
+            raise ValueError(f"Invalid mode: {mode}")
+        self.dir_path = dir_path
+        self.video_path = os.path.join(dir_path, "video.mp4")
+        self.meta_path = os.path.join(dir_path, "meta.json")
+        self.mode = mode
+        self.fps = fps
+        self.ts_to_idx = {}
+        self.frame_count = 0
+        self._stream = None
+        self._container = None
+        self.is_gray = None
+        self.write_count = 0
+        self.write_total_s = 0.0
+        self.read_count = 0
+        self.read_total_s = 0.0
+
+        if self.mode == "write":
+            os.makedirs(self.dir_path, exist_ok=True)
+            if os.path.exists(self.video_path):
+                os.remove(self.video_path)
+            if os.path.exists(self.meta_path):
+                os.remove(self.meta_path)
+            self._container = av.open(self.video_path, mode="w")
+        else:
+            self.ts_to_idx = self._load_meta()
+
+    def _ensure_writer_stream(self, image: np.ndarray):
+        h, w = image.shape[:2]
+        stream = self._stream
+        if stream is not None:
+            return stream
+        stream = self._container.add_stream("libx264", rate=self.fps)
+        stream.width = int(w)
+        stream.height = int(h)
+        stream.pix_fmt = "yuv420p"
+        stream.options = {"preset": "veryfast", "crf": "18", "tune": "zerolatency", "bf": "0"}
+        self._stream = stream
+        return stream
+
+    def write(self, timestamp: int, image: np.ndarray):
+        if self.mode != "write":
+            raise RuntimeError("VideoDB write() requires mode='write'")
+        t0 = time.perf_counter()
+        frame_np = np.asarray(image)
+        curr_is_gray = frame_np.ndim == 2
+        if self.is_gray is None:
+            self.is_gray = curr_is_gray
+        elif self.is_gray != curr_is_gray:
+            raise ValueError(
+                f"Inconsistent image ndim for {self.dir_path}: expected "
+                f"{'gray(2D)' if self.is_gray else 'color(3D)'}, got ndim={frame_np.ndim}"
+            )
+        frame_format = "gray" if self.is_gray else "bgr24"
+        frame = av.VideoFrame.from_ndarray(frame_np, format=frame_format)
+        stream = self._ensure_writer_stream(frame_np)
+        frame.pts = self.frame_count
+        self.ts_to_idx[int(timestamp)] = int(self.frame_count)
+        self.frame_count += 1
+        for pkt in stream.encode(frame):
+            self._container.mux(pkt)
+        self.write_count += 1
+        self.write_total_s += time.perf_counter() - t0
+
+    def _write_meta(self):
+        payload = {
+            "ts_to_idx": {str(k): int(v) for k, v in self.ts_to_idx.items()},
+            "is_gray": bool(self.is_gray) if self.is_gray is not None else False,
+        }
+        with open(self.meta_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, separators=(",", ":"))
+
+    def _load_meta(self) -> dict:
+        if not os.path.exists(self.meta_path):
+            return {}
+        with open(self.meta_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "ts_to_idx" not in data:
+            return {}
+        self.is_gray = bool(data.get("is_gray", False))
+        ts_to_idx = data["ts_to_idx"]
+        return {int(k): int(v) for k, v in ts_to_idx.items()}
+
+    def _decode_frame_by_index_linear(self, frame_idx: int):
+        if frame_idx < 0 or not os.path.exists(self.video_path):
+            return None
+        with av.open(self.video_path, mode="r") as c:
+            stream = c.streams.video[0]
+            for i, frame in enumerate(c.decode(stream)):
+                if i == frame_idx:
+                    return frame.to_ndarray(format="gray" if self.is_gray else "bgr24")
+        return None
+
+    def _decode_frame_by_index(self, frame_idx: int):
+        if frame_idx < 0 or not os.path.exists(self.video_path):
+            return None
+        # Near-random access: seek to a nearby keyframe, then decode forward.
+        target_us = int((frame_idx / max(self.fps, 1)) * 1_000_000)
+        decode_format = "gray" if self.is_gray else "bgr24"
+        try:
+            with av.open(self.video_path, mode="r") as c:
+                stream = c.streams.video[0]
+                c.seek(target_us, stream=stream, any_frame=False, backward=True)
+                best_frame = None
+                best_err = None
+                for frame in c.decode(stream):
+                    if frame.pts is None or stream.time_base is None:
+                        continue
+                    sec = float(frame.pts * stream.time_base)
+                    est_idx = int(round(sec * self.fps))
+                    err = abs(est_idx - frame_idx)
+                    if best_err is None or err < best_err:
+                        best_err = err
+                        best_frame = frame
+                    if est_idx >= frame_idx:
+                        return frame.to_ndarray(format=decode_format)
+                if best_frame is not None:
+                    return best_frame.to_ndarray(format=decode_format)
+        except Exception:
+            pass
+        # Fallback for robustness.
+        return self._decode_frame_by_index_linear(frame_idx)
+
+    def read(self, timestamp: int):
+        if self.mode != "read":
+            raise RuntimeError("VideoDB read() requires mode='read'")
+        t0 = time.perf_counter()
+        key = int(timestamp)
+        if key not in self.ts_to_idx:
+            self.read_count += 1
+            self.read_total_s += time.perf_counter() - t0
+            return None
+        image = self._decode_frame_by_index(self.ts_to_idx[key])
+        self.read_count += 1
+        self.read_total_s += time.perf_counter() - t0
+        return image
+
+    def close(self):
+        if self.mode == "write":
+            if self._stream is not None:
+                for pkt in self._stream.encode(None):
+                    self._container.mux(pkt)
+            if self._container is not None:
+                self._container.close()
+            self._write_meta()
+        write_avg_ms = (self.write_total_s / self.write_count * 1000.0) if self.write_count > 0 else 0.0
+        read_avg_ms = (self.read_total_s / self.read_count * 1000.0) if self.read_count > 0 else 0.0
+        print(
+            f"[VideoDB] dir={self.dir_path} mode={self.mode} "
+            f"write_count={self.write_count} write_avg_ms={write_avg_ms:.3f} "
+            f"read_count={self.read_count} read_avg_ms={read_avg_ms:.3f}"
+        )

--- a/tool/video_db.py
+++ b/tool/video_db.py
@@ -4,6 +4,7 @@ import time
 
 import av
 import numpy as np
+import decord
 
 
 class VideoDB:
@@ -40,12 +41,6 @@ class VideoDB:
             self._container = av.open(self.video_path, mode="w")
         else:
             self.ts_to_idx = self._load_meta()
-            try:
-                import decord
-            except ImportError as e:
-                raise ImportError(
-                    "decord is required for VideoDB.read(). Install decord first."
-                ) from e
             if os.path.exists(self.video_path):
                 self._video_reader = decord.VideoReader(self.video_path)
 

--- a/tool/video_db.py
+++ b/tool/video_db.py
@@ -24,6 +24,7 @@ class VideoDB:
         self.frame_count = 0
         self._stream = None
         self._container = None
+        self._video_reader = None
         self.is_gray = None
         self.write_count = 0
         self.write_total_s = 0.0
@@ -39,6 +40,14 @@ class VideoDB:
             self._container = av.open(self.video_path, mode="w")
         else:
             self.ts_to_idx = self._load_meta()
+            try:
+                import decord
+            except ImportError as e:
+                raise ImportError(
+                    "decord is required for VideoDB.read(). Install decord first."
+                ) from e
+            if os.path.exists(self.video_path):
+                self._video_reader = decord.VideoReader(self.video_path)
 
     def _ensure_writer_stream(self, image: np.ndarray):
         h, w = image.shape[:2]
@@ -96,45 +105,22 @@ class VideoDB:
         ts_to_idx = data["ts_to_idx"]
         return {int(k): int(v) for k, v in ts_to_idx.items()}
 
-    def _decode_frame_by_index_linear(self, frame_idx: int):
-        if frame_idx < 0 or not os.path.exists(self.video_path):
-            return None
-        with av.open(self.video_path, mode="r") as c:
-            stream = c.streams.video[0]
-            for i, frame in enumerate(c.decode(stream)):
-                if i == frame_idx:
-                    return frame.to_ndarray(format="gray" if self.is_gray else "bgr24")
-        return None
-
     def _decode_frame_by_index(self, frame_idx: int):
         if frame_idx < 0 or not os.path.exists(self.video_path):
             return None
-        # Near-random access: seek to a nearby keyframe, then decode forward.
-        target_us = int((frame_idx / max(self.fps, 1)) * 1_000_000)
-        decode_format = "gray" if self.is_gray else "bgr24"
-        try:
-            with av.open(self.video_path, mode="r") as c:
-                stream = c.streams.video[0]
-                c.seek(target_us, stream=stream, any_frame=False, backward=True)
-                best_frame = None
-                best_err = None
-                for frame in c.decode(stream):
-                    if frame.pts is None or stream.time_base is None:
-                        continue
-                    sec = float(frame.pts * stream.time_base)
-                    est_idx = int(round(sec * self.fps))
-                    err = abs(est_idx - frame_idx)
-                    if best_err is None or err < best_err:
-                        best_err = err
-                        best_frame = frame
-                    if est_idx >= frame_idx:
-                        return frame.to_ndarray(format=decode_format)
-                if best_frame is not None:
-                    return best_frame.to_ndarray(format=decode_format)
-        except Exception:
-            pass
-        # Fallback for robustness.
-        return self._decode_frame_by_index_linear(frame_idx)
+        if self._video_reader is None:
+            return None
+        if frame_idx >= len(self._video_reader):
+            return None
+        frame = self._video_reader[frame_idx].asnumpy()
+        if self.is_gray:
+            if frame.ndim == 3:
+                frame = frame[..., 0]
+            return frame
+        # decord returns RGB; convert to BGR to keep OpenCV-style behavior.
+        if frame.ndim == 3:
+            return frame[..., ::-1]
+        return frame
 
     def read(self, timestamp: int):
         if self.mode != "read":

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.12, <3.11"
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'darwin'",
@@ -3958,6 +3958,7 @@ version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "async-lru" },
+    { name = "av" },
     { name = "codetiming" },
     { name = "cuda-python", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.6.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
@@ -4007,6 +4008,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "async-lru" },
+    { name = "av" },
     { name = "codetiming" },
     { name = "cuda-python", marker = "platform_machine == 'aarch64'", specifier = "==12.6.0" },
     { name = "cuda-python", marker = "platform_machine == 'x86_64'", specifier = "==12.2.0" },


### PR DESCRIPTION
## Summary
- fix missing json import used by build_map_node metadata serialization
- return lazy image loaders from TinyNavDB image accessor path
- update imu_propagator_node logging behavior in callback path

## Type
- fix(core)
