### PR TITLE
  feat(nav): per-POI navigation progress with dynamic ETA 

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -145,8 +145,11 @@ class BackendNode(Ros2NodeManager):
         self._map_node_proc: subprocess.Popen | None = None
         self._cmd_vel_proc: subprocess.Popen | None = None
 
+        self._nav_progress: dict | None = None
+
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
+        self.create_subscription(String, '/mapping/nav_progress', self._on_nav_progress, 10)
         self._detect_and_init_sensor()
         self._start_unitree_if_configured()
 
@@ -162,6 +165,14 @@ class BackendNode(Ros2NodeManager):
         if msg.data and self.state == 'navigation':
             self.state = 'idle'
             self._pub_state()
+
+    def _on_nav_progress(self, msg: String):
+        try:
+            data = json.loads(msg.data)
+            with self._lock:
+                self._nav_progress = data
+        except json.JSONDecodeError:
+            pass
 
     def _on_mapping_percent(self, msg: Float32):
         with self._lock:
@@ -501,6 +512,7 @@ class BackendNode(Ros2NodeManager):
             battery = self._battery
             nav_nodes = self._nav_nodes_running
             nav_paused = self._nav_paused
+            nav_progress = self._nav_progress
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -513,6 +525,7 @@ class BackendNode(Ros2NodeManager):
             'rawState': raw,
             'navNodesRunning': nav_nodes,
             'navPaused': nav_paused,
+            'navProgress': nav_progress,
         }
 
     @staticmethod

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -146,6 +146,7 @@ class BackendNode(Ros2NodeManager):
         self._cmd_vel_proc: subprocess.Popen | None = None
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
+        self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
         self._detect_and_init_sensor()
         self._start_unitree_if_configured()
 
@@ -156,6 +157,11 @@ class BackendNode(Ros2NodeManager):
     def _on_battery(self, msg: Float32):
         with self._lock:
             self._battery = float(msg.data)
+
+    def _on_nav_done(self, msg: Bool):
+        if msg.data and self.state == 'navigation':
+            self.state = 'idle'
+            self._pub_state()
 
     def _on_mapping_percent(self, msg: Float32):
         with self._lock:

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -146,6 +146,7 @@ class BackendNode(Ros2NodeManager):
         self._cmd_vel_proc: subprocess.Popen | None = None
 
         self._nav_progress: dict | None = None
+        self.nav_progress_callbacks: list = []
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
@@ -171,6 +172,8 @@ class BackendNode(Ros2NodeManager):
             data = json.loads(msg.data)
             with self._lock:
                 self._nav_progress = data
+            for cb in self.nav_progress_callbacks:
+                cb(data)
         except json.JSONDecodeError:
             pass
 
@@ -512,7 +515,6 @@ class BackendNode(Ros2NodeManager):
             battery = self._battery
             nav_nodes = self._nav_nodes_running
             nav_paused = self._nav_paused
-            nav_progress = self._nav_progress
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -525,7 +527,6 @@ class BackendNode(Ros2NodeManager):
             'rawState': raw,
             'navNodesRunning': nav_nodes,
             'navPaused': nav_paused,
-            'navProgress': nav_progress,
         }
 
     @staticmethod

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -26,7 +26,7 @@ import tf2_ros
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
-from sensor_msgs.msg import CompressedImage, Image, PointCloud
+from sensor_msgs.msg import CompressedImage, Image
 from std_msgs.msg import Bool, Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
@@ -85,7 +85,6 @@ class BackendNode(Ros2NodeManager):
         self._global_path: list = []
         self._grid_info: dict | None = None
         self._nav_target_pose: dict | None = None
-        self._footprint: list = []
 
         self.create_subscription(Float32, '/mapping/percent', self._on_mapping_percent, 10)
         self.create_subscription(Odometry, '/slam/odometry', self._on_slam_odom, 10)
@@ -102,7 +101,6 @@ class BackendNode(Ros2NodeManager):
             OccupancyGrid, '/planning/obstacle_mask', self._on_obstacle_mask, 1
         )
         self.create_subscription(Path, '/planning/trajectory_path', self._on_trajectory_path, 1)
-        self.create_subscription(PointCloud, '/planning/footprint', self._on_footprint, 1)
         self.create_subscription(Path, '/mapping/global_plan', self._on_global_plan, 1)
         self.create_subscription(
             Odometry, '/control/target_pose', self._on_nav_target_pose, 1
@@ -259,11 +257,6 @@ class BackendNode(Ros2NodeManager):
         ]
         with self._lock:
             self._global_path = pts
-
-    def _on_footprint(self, msg: PointCloud):
-        pts = [{'x': float(p.x), 'y': float(p.y)} for p in msg.points]
-        with self._lock:
-            self._footprint = pts
 
     # ------------------------------------------------------------------ #
     # Helpers                                                              #
@@ -452,7 +445,6 @@ class BackendNode(Ros2NodeManager):
                 'esdf_image': base64.b64encode(self._esdf_bytes).decode() if self._esdf_bytes else None,
                 'obstacle_image': base64.b64encode(self._obstacle_bytes).decode() if self._obstacle_bytes else None,
                 'trajectory': list(self._trajectory),
-                'footprint': list(self._footprint),
                 'global_path': None,  # filled after TF transform (odom frame)
                 'map_global_path': path_snapshot,
                 'grid_info': self._grid_info,

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -192,7 +192,9 @@ class BackendNode(Ros2NodeManager):
                 pass
 
     def _on_relocalization(self, msg: Odometry):
+        pose = self._odom_to_dict(msg, source='map')
         with self._lock:
+            self._map_pose = pose
             self._localized = True
 
     def _on_nav_target_pose(self, msg: Odometry):

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -26,7 +26,7 @@ import tf2_ros
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
-from sensor_msgs.msg import CompressedImage, Image
+from sensor_msgs.msg import CompressedImage, Image, PointCloud
 from std_msgs.msg import Bool, Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
@@ -85,6 +85,7 @@ class BackendNode(Ros2NodeManager):
         self._global_path: list = []
         self._grid_info: dict | None = None
         self._nav_target_pose: dict | None = None
+        self._footprint: list = []
 
         self.create_subscription(Float32, '/mapping/percent', self._on_mapping_percent, 10)
         self.create_subscription(Odometry, '/slam/odometry', self._on_slam_odom, 10)
@@ -101,6 +102,7 @@ class BackendNode(Ros2NodeManager):
             OccupancyGrid, '/planning/obstacle_mask', self._on_obstacle_mask, 1
         )
         self.create_subscription(Path, '/planning/trajectory_path', self._on_trajectory_path, 1)
+        self.create_subscription(PointCloud, '/planning/footprint', self._on_footprint, 1)
         self.create_subscription(Path, '/mapping/global_plan', self._on_global_plan, 1)
         self.create_subscription(
             Odometry, '/control/target_pose', self._on_nav_target_pose, 1
@@ -257,6 +259,11 @@ class BackendNode(Ros2NodeManager):
         ]
         with self._lock:
             self._global_path = pts
+
+    def _on_footprint(self, msg: PointCloud):
+        pts = [{'x': float(p.x), 'y': float(p.y)} for p in msg.points]
+        with self._lock:
+            self._footprint = pts
 
     # ------------------------------------------------------------------ #
     # Helpers                                                              #
@@ -445,6 +452,7 @@ class BackendNode(Ros2NodeManager):
                 'esdf_image': base64.b64encode(self._esdf_bytes).decode() if self._esdf_bytes else None,
                 'obstacle_image': base64.b64encode(self._obstacle_bytes).decode() if self._obstacle_bytes else None,
                 'trajectory': list(self._trajectory),
+                'footprint': list(self._footprint),
                 'global_path': None,  # filled after TF transform (odom frame)
                 'map_global_path': path_snapshot,
                 'grid_info': self._grid_info,

--- a/app/backend/ws.py
+++ b/app/backend/ws.py
@@ -86,6 +86,38 @@ async def ws_pose(ws: WebSocket):
 
 
 # --------------------------------------------------------------------------- #
+# /ws/nav-progress  — pushed on every /mapping/nav_progress message          #
+# --------------------------------------------------------------------------- #
+
+@router.websocket('/ws/nav-progress')
+async def ws_nav_progress(ws: WebSocket):
+    await ws.accept()
+    queue: asyncio.Queue = asyncio.Queue(maxsize=10)
+    loop = asyncio.get_event_loop()
+
+    def _on_progress(data: dict):
+        loop.call_soon_threadsafe(lambda: _safe_put(queue, data))
+
+    node = runner.node
+    if node is None:
+        await ws.close(code=1013)
+        return
+
+    node.nav_progress_callbacks.append(_on_progress)
+    try:
+        while True:
+            data = await queue.get()
+            await ws.send_text(json.dumps(data))
+    except WebSocketDisconnect:
+        pass
+    finally:
+        try:
+            node.nav_progress_callbacks.remove(_on_progress)
+        except ValueError:
+            pass
+
+
+# --------------------------------------------------------------------------- #
 # /ws/map-update  — polls for occupancy_grid.npy mtime changes               #
 # --------------------------------------------------------------------------- #
 

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -1,6 +1,30 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+class NavProgress {
+  final int poiIndex;
+  final double percent;
+  final double pathRemainingM;
+  final double pathTotalM;
+  final double estimatedRemainingS;
+
+  const NavProgress({
+    required this.poiIndex,
+    required this.percent,
+    required this.pathRemainingM,
+    required this.pathTotalM,
+    required this.estimatedRemainingS,
+  });
+
+  factory NavProgress.fromJson(Map<String, dynamic> json) => NavProgress(
+        poiIndex: json['poi_index'] as int? ?? 0,
+        percent: (json['percent'] as num?)?.toDouble() ?? 0.0,
+        pathRemainingM: (json['path_remaining_m'] as num?)?.toDouble() ?? 0.0,
+        pathTotalM: (json['path_total_m'] as num?)?.toDouble() ?? 0.0,
+        estimatedRemainingS: (json['estimated_remaining_s'] as num?)?.toDouble() ?? -1.0,
+      );
+}
+
 class DeviceStatus {
   final bool online;
   final double? battery;
@@ -12,6 +36,7 @@ class DeviceStatus {
   final String rawState;
   final bool navNodesRunning;
   final bool navPaused;
+  final NavProgress? navProgress;
 
   const DeviceStatus({
     required this.online,
@@ -24,6 +49,7 @@ class DeviceStatus {
     required this.rawState,
     required this.navNodesRunning,
     required this.navPaused,
+    this.navProgress,
   });
 
   factory DeviceStatus.fromJson(Map<String, dynamic> json) => DeviceStatus(
@@ -37,6 +63,9 @@ class DeviceStatus {
         rawState: json['rawState'] as String? ?? 'unknown',
         navNodesRunning: json['navNodesRunning'] as bool? ?? false,
         navPaused: json['navPaused'] as bool? ?? false,
+        navProgress: json['navProgress'] != null
+            ? NavProgress.fromJson(json['navProgress'] as Map<String, dynamic>)
+            : null,
       );
 }
 

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -153,6 +153,7 @@ class PlanningState {
   final Uint8List? esdfImage;
   final Uint8List? obstacleImage;
   final List<TrajPoint> trajectory;
+  final List<TrajPoint> footprint;
   final List<TrajPoint> globalPath;
   final List<TrajPoint> mapGlobalPath;
   final GridInfo? gridInfo;
@@ -166,6 +167,7 @@ class PlanningState {
     this.esdfImage,
     this.obstacleImage,
     required this.trajectory,
+    this.footprint = const [],
     required this.globalPath,
     this.mapGlobalPath = const [],
     this.gridInfo,
@@ -197,6 +199,7 @@ class PlanningState {
       esdfImage: decodeImg(j['esdf_image'] as String?),
       obstacleImage: decodeImg(j['obstacle_image'] as String?),
       trajectory: parsePath('trajectory'),
+      footprint: parsePath('footprint'),
       globalPath: parsePath('global_path'),
       mapGlobalPath: parsePath('map_global_path'),
       gridInfo: j['grid_info'] != null

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -36,7 +36,6 @@ class DeviceStatus {
   final String rawState;
   final bool navNodesRunning;
   final bool navPaused;
-  final NavProgress? navProgress;
 
   const DeviceStatus({
     required this.online,
@@ -49,7 +48,6 @@ class DeviceStatus {
     required this.rawState,
     required this.navNodesRunning,
     required this.navPaused,
-    this.navProgress,
   });
 
   factory DeviceStatus.fromJson(Map<String, dynamic> json) => DeviceStatus(
@@ -63,9 +61,6 @@ class DeviceStatus {
         rawState: json['rawState'] as String? ?? 'unknown',
         navNodesRunning: json['navNodesRunning'] as bool? ?? false,
         navPaused: json['navPaused'] as bool? ?? false,
-        navProgress: json['navProgress'] != null
-            ? NavProgress.fromJson(json['navProgress'] as Map<String, dynamic>)
-            : null,
       );
 }
 

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -153,7 +153,6 @@ class PlanningState {
   final Uint8List? esdfImage;
   final Uint8List? obstacleImage;
   final List<TrajPoint> trajectory;
-  final List<TrajPoint> footprint;
   final List<TrajPoint> globalPath;
   final List<TrajPoint> mapGlobalPath;
   final GridInfo? gridInfo;
@@ -167,7 +166,6 @@ class PlanningState {
     this.esdfImage,
     this.obstacleImage,
     required this.trajectory,
-    this.footprint = const [],
     required this.globalPath,
     this.mapGlobalPath = const [],
     this.gridInfo,
@@ -199,7 +197,6 @@ class PlanningState {
       esdfImage: decodeImg(j['esdf_image'] as String?),
       obstacleImage: decodeImg(j['obstacle_image'] as String?),
       trajectory: parsePath('trajectory'),
-      footprint: parsePath('footprint'),
       globalPath: parsePath('global_path'),
       mapGlobalPath: parsePath('map_global_path'),
       gridInfo: j['grid_info'] != null

--- a/app/frontend/lib/core/providers.dart
+++ b/app/frontend/lib/core/providers.dart
@@ -41,6 +41,19 @@ final deviceStatusProvider = StreamProvider<DeviceStatus>((ref) {
   );
 });
 
+/// Streams NavProgress from WS /ws/nav-progress (pushed on every ROS message).
+final navProgressStreamProvider = StreamProvider<NavProgress>((ref) {
+  final ip = ref.watch(deviceIpProvider);
+  if (ip == null) return const Stream.empty();
+
+  final channel = WebSocketChannel.connect(Uri.parse('ws://$ip:8000/ws/nav-progress'));
+  ref.onDispose(() => channel.sink.close());
+
+  return channel.stream.map(
+    (data) => NavProgress.fromJson(jsonDecode(data as String) as Map<String, dynamic>),
+  );
+});
+
 /// Streams robot Pose from WS /ws/pose (pushed on every odometry message).
 final poseStreamProvider = StreamProvider<Pose>((ref) {
   final ip = ref.watch(deviceIpProvider);

--- a/app/frontend/lib/core/providers.dart
+++ b/app/frontend/lib/core/providers.dart
@@ -98,6 +98,9 @@ final imageTopicsProvider = FutureProvider.autoDispose<List<String>>((ref) async
 /// Currently selected bag name for map building (null = use last verified).
 final selectedBagProvider = StateProvider<String?>((ref) => null);
 
+/// POIs currently being navigated (set when Go is pressed, cleared when nav done).
+final activeNavPoisProvider = StateProvider<List<Poi>>((ref) => const []);
+
 /// Currently selected preview topic (null = preview closed).
 final selectedPreviewTopicProvider = StateProvider<String?>((ref) => null);
 

--- a/app/frontend/lib/pages/nav_tab.dart
+++ b/app/frontend/lib/pages/nav_tab.dart
@@ -120,7 +120,7 @@ class _NavStatusCardState extends ConsumerState<_NavStatusCard> {
   Widget build(BuildContext context) {
     final s = widget.status;
     final isNavigating = s.rawState == 'navigation';
-    final np = isNavigating ? s.navProgress : null;
+    final np = isNavigating ? ref.watch(navProgressStreamProvider).valueOrNull : null;
     final showCompletion = _showCompletion;
 
     String subtitle;

--- a/app/frontend/lib/pages/nav_tab.dart
+++ b/app/frontend/lib/pages/nav_tab.dart
@@ -182,12 +182,14 @@ class _NavStatusCardState extends ConsumerState<_NavStatusCard> {
           ]),
           if (active) ...[
             const SizedBox(height: 10),
-            LinearProgressIndicator(
-              value: progressValue,
-              color: progressColor,
-              backgroundColor: progressColor.withOpacity(0.15),
-              minHeight: 6,
+            ClipRRect(
               borderRadius: BorderRadius.circular(3),
+              child: LinearProgressIndicator(
+                value: progressValue,
+                color: progressColor,
+                backgroundColor: progressColor.withOpacity(0.15),
+                minHeight: 6,
+              ),
             ),
             const SizedBox(height: 4),
             Align(

--- a/app/frontend/lib/pages/nav_tab.dart
+++ b/app/frontend/lib/pages/nav_tab.dart
@@ -83,6 +83,20 @@ class _NavStatusCard extends ConsumerStatefulWidget {
 
 class _NavStatusCardState extends ConsumerState<_NavStatusCard> {
   bool _canceling = false;
+  bool _showCompletion = false;
+
+  @override
+  void didUpdateWidget(_NavStatusCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasNavigating = oldWidget.status.rawState == 'navigation';
+    final isNavigating = widget.status.rawState == 'navigation';
+    if (wasNavigating && !isNavigating) {
+      setState(() => _showCompletion = true);
+      Future.delayed(const Duration(milliseconds: 1200), () {
+        if (mounted) setState(() => _showCompletion = false);
+      });
+    }
+  }
 
   Future<void> _cancel() async {
     setState(() => _canceling = true);
@@ -106,39 +120,84 @@ class _NavStatusCardState extends ConsumerState<_NavStatusCard> {
   Widget build(BuildContext context) {
     final s = widget.status;
     final isNavigating = s.rawState == 'navigation';
+    final np = isNavigating ? s.navProgress : null;
+    final showCompletion = _showCompletion;
+
+    String subtitle;
+    double progressValue;
+    if (showCompletion) {
+      subtitle = 'Arrived!';
+      progressValue = 1.0;
+    } else if (isNavigating && np != null) {
+      progressValue = (np.percent / 100.0).clamp(0.0, 1.0);
+      final remaining = np.pathRemainingM < 1000 ? '${np.pathRemainingM.toStringAsFixed(1)}m' : '--';
+      final eta = np.estimatedRemainingS >= 0
+          ? '~${np.estimatedRemainingS.toStringAsFixed(0)}s'
+          : '--';
+      subtitle = 'POI #${np.poiIndex + 1} · $remaining · $eta';
+    } else if (isNavigating) {
+      subtitle = 'Navigating...';
+      progressValue = 0.0;
+    } else {
+      subtitle = s.navStatus;
+      progressValue = 0.0;
+    }
+
+    final active = isNavigating || showCompletion;
+    final progressColor = showCompletion ? Colors.green : Colors.blue;
 
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
-        child: Row(children: [
-          Icon(
-            isNavigating ? Icons.navigation : Icons.navigation_outlined,
-            color: isNavigating ? Colors.blue : Colors.grey,
-            size: 28,
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              const Text('Navigation',
-                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-              Text(
-                isNavigating ? 'Navigating...' : s.navStatus,
-                style: TextStyle(color: isNavigating ? Colors.blue : Colors.grey),
-              ),
-            ]),
-          ),
-          if (isNavigating)
-            OutlinedButton(
-              onPressed: _canceling ? null : _cancel,
-              style: OutlinedButton.styleFrom(foregroundColor: Colors.red),
-              child: _canceling
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Cancel'),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Row(children: [
+            Icon(
+              active ? Icons.navigation : Icons.navigation_outlined,
+              color: active ? progressColor : Colors.grey,
+              size: 28,
             ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                const Text('Navigation',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                Text(
+                  subtitle,
+                  style: TextStyle(color: active ? progressColor : Colors.grey),
+                ),
+              ]),
+            ),
+            if (isNavigating)
+              OutlinedButton(
+                onPressed: _canceling ? null : _cancel,
+                style: OutlinedButton.styleFrom(foregroundColor: Colors.red),
+                child: _canceling
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Cancel'),
+              ),
+          ]),
+          if (active) ...[
+            const SizedBox(height: 10),
+            LinearProgressIndicator(
+              value: progressValue,
+              color: progressColor,
+              backgroundColor: progressColor.withOpacity(0.15),
+              minHeight: 6,
+              borderRadius: BorderRadius.circular(3),
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                '${(progressValue * 100).toStringAsFixed(1)}%',
+                style: TextStyle(fontSize: 12, color: progressColor),
+              ),
+            ),
+          ],
         ]),
       ),
     );

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -245,7 +245,7 @@ class _GlobalMapView extends StatelessWidget {
                         mapInfo: mapInfo,
                         pose: p.mapPose,
                         pois: pois,
-                        globalPath: p.globalPath,
+                        globalPath: p.mapGlobalPath,
                         showGlobalPath: true,
                       ),
                     ),

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -33,6 +33,7 @@ class _OperateTabState extends ConsumerState<OperateTab> {
   bool _showTrajectory = true;
   bool _showGlobalPath = true;
   bool _showGlobalMap = false;
+  bool _navArrived = false;
 
   @override
   void initState() {
@@ -98,8 +99,16 @@ class _OperateTabState extends ConsumerState<OperateTab> {
       final nextState = next.valueOrNull?.rawState;
       if (prevState == 'navigation' && nextState != 'navigation') {
         ref.read(activeNavPoisProvider.notifier).state = const [];
+        setState(() => _navArrived = true);
+        Future.delayed(const Duration(milliseconds: 1200), () {
+          if (mounted) setState(() => _navArrived = false);
+        });
       }
     });
+
+    final status = ref.watch(deviceStatusProvider).valueOrNull;
+    final isNavigating = status?.rawState == 'navigation';
+    final np = isNavigating ? ref.watch(navProgressStreamProvider).valueOrNull : null;
 
     return Column(
       children: [
@@ -161,6 +170,13 @@ class _OperateTabState extends ConsumerState<OperateTab> {
                       _showGlobalPath = gp;
                     }),
                   ),
+                ),
+              if (isNavigating || _navArrived)
+                Positioned(
+                  bottom: 52,
+                  left: 10,
+                  right: 10,
+                  child: _NavProgressOverlay(np: np, arrived: _navArrived),
                 ),
               Positioned(
                 bottom: 10,
@@ -1396,4 +1412,60 @@ class _JoystickPainter extends CustomPainter {
   @override
   bool shouldRepaint(_JoystickPainter old) =>
       old.thumbOffset != thumbOffset || old.padRadius != padRadius;
+}
+
+// ── Nav progress overlay ──────────────────────────────────────────────────────
+
+class _NavProgressOverlay extends StatelessWidget {
+  final NavProgress? np;
+  final bool arrived;
+
+  const _NavProgressOverlay({this.np, required this.arrived});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = arrived ? Colors.green : Colors.blue;
+    final double value;
+    final String label;
+
+    if (arrived) {
+      value = 1.0;
+      label = 'Arrived!  100%';
+    } else if (np != null) {
+      value = (np!.percent / 100.0).clamp(0.0, 1.0);
+      final dist = '${np!.pathRemainingM.toStringAsFixed(1)}m';
+      final eta = np!.estimatedRemainingS >= 0
+          ? '~${np!.estimatedRemainingS.toStringAsFixed(0)}s'
+          : '--';
+      label = 'POI #${np!.poiIndex + 1}  ·  $dist  ·  $eta  ·  ${np!.percent.toStringAsFixed(1)}%';
+    } else {
+      value = 0.0;
+      label = 'Navigating...';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.black.withOpacity(0.65),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: TextStyle(color: color, fontSize: 12, fontWeight: FontWeight.w500)),
+          const SizedBox(height: 6),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              value: value,
+              color: color,
+              backgroundColor: color.withOpacity(0.25),
+              minHeight: 5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -905,6 +905,7 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
     final baseUrl = ref.watch(baseUrlProvider);
     final mapInfo = ref.watch(mapInfoProvider).valueOrNull;
     final planning = ref.watch(planningStreamProvider).valueOrNull;
+    final activeNavPois = ref.watch(activeNavPoisProvider);
 
     // Auto-select color topic on first load
     ref.listen<AsyncValue<List<String>>>(imageTopicsProvider, (_, next) {
@@ -960,7 +961,12 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
               planning.localized && baseUrl != null)
             Positioned(
               top: 8, left: 8,
-              child: _MapPip(mapInfo: mapInfo, planning: planning, baseUrl: baseUrl),
+              child: _MapPip(
+                mapInfo: mapInfo,
+                planning: planning,
+                baseUrl: baseUrl,
+                pois: activeNavPois,
+              ),
             ),
           // ── Topic selector ───────────────────────────────────────────
           Positioned(
@@ -1081,8 +1087,14 @@ class _MapPip extends StatelessWidget {
   final MapInfo mapInfo;
   final PlanningState planning;
   final String baseUrl;
+  final List<Poi> pois;
 
-  const _MapPip({required this.mapInfo, required this.planning, required this.baseUrl});
+  const _MapPip({
+    required this.mapInfo,
+    required this.planning,
+    required this.baseUrl,
+    this.pois = const [],
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1110,6 +1122,7 @@ class _MapPip extends StatelessWidget {
               painter: MapOverlayPainter(
                 mapInfo: mapInfo,
                 pose: planning.mapPose,
+                pois: pois,
                 globalPath: planning.mapGlobalPath,
                 showGlobalPath: true,
               ),

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -571,9 +571,10 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
         .map((p) => p.id)
         .toList();
     if (ids.isEmpty) return;
+    final navigator = Navigator.of(context);
     try {
       await ref.read(dioProvider).post('/nav/send-pois', data: {'poi_ids': ids});
-      if (mounted) Navigator.pop(context);
+      navigator.pop();
     } on DioException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
@@ -616,7 +617,7 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
             const Spacer(),
             FilledButton.icon(
               onPressed: (canGo && _checkedIds.isNotEmpty)
-                  ? () => poisAsync.whenData((pois) => _startNav(pois))
+                  ? () => _startNav(poisAsync.valueOrNull ?? [])
                   : null,
               icon: const Icon(Icons.navigation_rounded, size: 16),
               label: const Text('Go'),

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -573,6 +573,7 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
     if (ids.isEmpty) return;
     try {
       await ref.read(dioProvider).post('/nav/send-pois', data: {'poi_ids': ids});
+      if (mounted) Navigator.pop(context);
     } on DioException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -307,7 +307,6 @@ class _LocalPlanningView extends StatelessWidget {
                     CustomPaint(
                       painter: LocalPlanningPainter(
                         trajectory: p.trajectory,
-                        footprint: p.footprint,
                         globalPath: p.globalPath,
                         gridInfo: p.gridInfo,
                         odomPose: p.odomPose,
@@ -637,14 +636,12 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   Future<void> _startNav(List<Poi> pois) async {
     final selectedPois = pois.where((p) => _checkedIds.contains(p.id)).toList();
     if (selectedPois.isEmpty) return;
-    final navigator = Navigator.of(context);
     try {
       await ref.read(dioProvider).post(
         '/nav/send-pois',
         data: {'poi_ids': selectedPois.map((p) => p.id).toList()},
       );
       ref.read(activeNavPoisProvider.notifier).state = selectedPois;
-      navigator.pop();
     } on DioException catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -86,7 +86,6 @@ class _OperateTabState extends ConsumerState<OperateTab> {
   @override
   Widget build(BuildContext context) {
     final poisAsync = ref.watch(poisProvider);
-    final poseAsync = ref.watch(poseStreamProvider);
     final planningAsync = ref.watch(planningStreamProvider);
     final planning = planningAsync.valueOrNull;
     final localized = planning?.localized ?? false;
@@ -146,29 +145,29 @@ class _OperateTabState extends ConsumerState<OperateTab> {
                     ],
                   ),
                 ),
-              Positioned(
-                top: 8,
-                right: 8,
-                child: _LayerTogglePanel(
-                  showObstacle: _showObstacle,
-                  showEsdf: _showEsdf,
-                  showTrajectory: _showTrajectory,
-                  showGlobalPath: _showGlobalPath,
-                  onChanged: (obs, esdf, traj, gp) => setState(() {
-                    _showObstacle = obs;
-                    _showEsdf = esdf;
-                    _showTrajectory = traj;
-                    _showGlobalPath = gp;
-                  }),
+              if (!_showGlobalMap)
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: _LayerTogglePanel(
+                    showObstacle: _showObstacle,
+                    showEsdf: _showEsdf,
+                    showTrajectory: _showTrajectory,
+                    showGlobalPath: _showGlobalPath,
+                    onChanged: (obs, esdf, traj, gp) => setState(() {
+                      _showObstacle = obs;
+                      _showEsdf = esdf;
+                      _showTrajectory = traj;
+                      _showGlobalPath = gp;
+                    }),
+                  ),
                 ),
-              ),
               Positioned(
                 bottom: 10,
                 left: 10,
                 child: _PoiButton(
                   poisAsync: poisAsync,
                   statusAsync: ref.watch(deviceStatusProvider),
-                  pose: poseAsync.valueOrNull,
                 ),
               ),
               Positioned(
@@ -525,12 +524,10 @@ class _LocalizationChip extends StatelessWidget {
 class _PoiButton extends ConsumerStatefulWidget {
   final AsyncValue<List<Poi>> poisAsync;
   final AsyncValue<DeviceStatus> statusAsync;
-  final Pose? pose;
 
   const _PoiButton({
     required this.poisAsync,
     required this.statusAsync,
-    this.pose,
   });
 
   @override
@@ -583,7 +580,7 @@ class _PoiButtonState extends ConsumerState<_PoiButton> {
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
-        builder: (_) => _PoiSheet(pose: widget.pose),
+        builder: (_) => const _PoiSheet(),
       ),
       style: FilledButton.styleFrom(
         backgroundColor: Colors.black87,
@@ -597,8 +594,7 @@ class _PoiButtonState extends ConsumerState<_PoiButton> {
 }
 
 class _PoiSheet extends ConsumerStatefulWidget {
-  final Pose? pose;
-  const _PoiSheet({this.pose});
+  const _PoiSheet();
 
   @override
   ConsumerState<_PoiSheet> createState() => _PoiSheetState();

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -32,6 +32,7 @@ class _OperateTabState extends ConsumerState<OperateTab> {
   bool _showEsdf = true;
   bool _showTrajectory = true;
   bool _showGlobalPath = true;
+  bool _showGlobalMap = false;
 
   @override
   void initState() {
@@ -88,6 +89,18 @@ class _OperateTabState extends ConsumerState<OperateTab> {
     final poseAsync = ref.watch(poseStreamProvider);
     final planningAsync = ref.watch(planningStreamProvider);
     final planning = planningAsync.valueOrNull;
+    final localized = planning?.localized ?? false;
+    final activeNavPois = ref.watch(activeNavPoisProvider);
+    final mapInfo = ref.watch(mapInfoProvider).valueOrNull;
+    final baseUrl = ref.watch(baseUrlProvider);
+
+    ref.listen<AsyncValue<DeviceStatus>>(deviceStatusProvider, (prev, next) {
+      final prevState = prev?.valueOrNull?.rawState;
+      final nextState = next.valueOrNull?.rawState;
+      if (prevState == 'navigation' && nextState != 'navigation') {
+        ref.read(activeNavPoisProvider.notifier).state = const [];
+      }
+    });
 
     return Column(
       children: [
@@ -100,19 +113,38 @@ class _OperateTabState extends ConsumerState<OperateTab> {
           child: Stack(
             children: [
               Positioned.fill(
-                child: _LocalPlanningView(
-                  planning: planning,
-                  showObstacle: _showObstacle,
-                  showEsdf: _showEsdf,
-                  showTrajectory: _showTrajectory,
-                  showGlobalPath: _showGlobalPath,
-                ),
+                child: (_showGlobalMap && localized && mapInfo != null && baseUrl != null)
+                    ? _GlobalMapView(
+                        mapInfo: mapInfo,
+                        baseUrl: baseUrl,
+                        planning: planning,
+                        pois: activeNavPois,
+                      )
+                    : _LocalPlanningView(
+                        planning: planning,
+                        showObstacle: _showObstacle,
+                        showEsdf: _showEsdf,
+                        showTrajectory: _showTrajectory,
+                        showGlobalPath: _showGlobalPath,
+                      ),
               ),
               if (planning != null)
                 Positioned(
                   top: 8,
                   left: 8,
-                  child: _LocalizationChip(localized: planning.localized),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _LocalizationChip(localized: localized),
+                      if (localized) ...[
+                        const SizedBox(width: 6),
+                        _MapToggleButton(
+                          showGlobalMap: _showGlobalMap,
+                          onTap: () => setState(() => _showGlobalMap = !_showGlobalMap),
+                        ),
+                      ],
+                    ],
+                  ),
                 ),
               Positioned(
                 top: 8,
@@ -414,6 +446,46 @@ class _LayerRow extends StatelessWidget {
   }
 }
 
+// ── Map toggle button ─────────────────────────────────────────────────────────
+
+class _MapToggleButton extends StatelessWidget {
+  final bool showGlobalMap;
+  final VoidCallback onTap;
+
+  const _MapToggleButton({required this.showGlobalMap, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: showGlobalMap
+              ? Colors.blueAccent.withOpacity(0.85)
+              : Colors.black54,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              showGlobalMap ? Icons.map_rounded : Icons.grid_view_rounded,
+              color: Colors.white,
+              size: 14,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              showGlobalMap ? 'Global' : 'Local',
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 // ── Localization chip ─────────────────────────────────────────────────────────
 
 class _LocalizationChip extends StatelessWidget {
@@ -566,14 +638,15 @@ class _PoiSheetState extends ConsumerState<_PoiSheet> {
   }
 
   Future<void> _startNav(List<Poi> pois) async {
-    final ids = pois
-        .where((p) => _checkedIds.contains(p.id))
-        .map((p) => p.id)
-        .toList();
-    if (ids.isEmpty) return;
+    final selectedPois = pois.where((p) => _checkedIds.contains(p.id)).toList();
+    if (selectedPois.isEmpty) return;
     final navigator = Navigator.of(context);
     try {
-      await ref.read(dioProvider).post('/nav/send-pois', data: {'poi_ids': ids});
+      await ref.read(dioProvider).post(
+        '/nav/send-pois',
+        data: {'poi_ids': selectedPois.map((p) => p.id).toList()},
+      );
+      ref.read(activeNavPoisProvider.notifier).state = selectedPois;
       navigator.pop();
     } on DioException catch (e) {
       if (mounted) {

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -308,6 +308,7 @@ class _LocalPlanningView extends StatelessWidget {
                     CustomPaint(
                       painter: LocalPlanningPainter(
                         trajectory: p.trajectory,
+                        footprint: p.footprint,
                         globalPath: p.globalPath,
                         gridInfo: p.gridInfo,
                         odomPose: p.odomPose,

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -905,7 +905,6 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
     final baseUrl = ref.watch(baseUrlProvider);
     final mapInfo = ref.watch(mapInfoProvider).valueOrNull;
     final planning = ref.watch(planningStreamProvider).valueOrNull;
-    final activeNavPois = ref.watch(activeNavPoisProvider);
 
     // Auto-select color topic on first load
     ref.listen<AsyncValue<List<String>>>(imageTopicsProvider, (_, next) {
@@ -965,7 +964,6 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
                 mapInfo: mapInfo,
                 planning: planning,
                 baseUrl: baseUrl,
-                pois: activeNavPois,
               ),
             ),
           // ── Topic selector ───────────────────────────────────────────
@@ -1087,13 +1085,11 @@ class _MapPip extends StatelessWidget {
   final MapInfo mapInfo;
   final PlanningState planning;
   final String baseUrl;
-  final List<Poi> pois;
 
   const _MapPip({
     required this.mapInfo,
     required this.planning,
     required this.baseUrl,
-    this.pois = const [],
   });
 
   @override
@@ -1122,7 +1118,6 @@ class _MapPip extends StatelessWidget {
               painter: MapOverlayPainter(
                 mapInfo: mapInfo,
                 pose: planning.mapPose,
-                pois: pois,
                 globalPath: planning.mapGlobalPath,
                 showGlobalPath: true,
               ),

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -176,7 +176,7 @@ class _OperateTabState extends ConsumerState<OperateTab> {
                   bottom: 52,
                   left: 10,
                   right: 10,
-                  child: _NavProgressOverlay(np: np, arrived: _navArrived),
+                  child: _NavProgressOverlay(np: np, arrived: _navArrived, pois: activeNavPois),
                 ),
               Positioned(
                 bottom: 10,
@@ -1419,8 +1419,9 @@ class _JoystickPainter extends CustomPainter {
 class _NavProgressOverlay extends StatelessWidget {
   final NavProgress? np;
   final bool arrived;
+  final List<Poi> pois;
 
-  const _NavProgressOverlay({this.np, required this.arrived});
+  const _NavProgressOverlay({this.np, required this.arrived, this.pois = const []});
 
   @override
   Widget build(BuildContext context) {
@@ -1430,14 +1431,14 @@ class _NavProgressOverlay extends StatelessWidget {
 
     if (arrived) {
       value = 1.0;
-      label = 'Arrived!  100%';
+      label = 'Arrived';
     } else if (np != null) {
       value = (np!.percent / 100.0).clamp(0.0, 1.0);
+      final name = (np!.poiIndex < pois.length) ? pois[np!.poiIndex].name : 'POI ${np!.poiIndex + 1}';
       final dist = '${np!.pathRemainingM.toStringAsFixed(1)}m';
-      final eta = np!.estimatedRemainingS >= 0
-          ? '~${np!.estimatedRemainingS.toStringAsFixed(0)}s'
-          : '--';
-      label = 'POI #${np!.poiIndex + 1}  ·  $dist  ·  $eta  ·  ${np!.percent.toStringAsFixed(1)}%';
+      final eta = np!.estimatedRemainingS >= 0 ? '~${np!.estimatedRemainingS.toStringAsFixed(0)}s' : '--';
+      final pct = '${np!.percent.toStringAsFixed(0)}%';
+      label = '→ $name  $pct · $dist · $eta';
     } else {
       value = 0.0;
       label = 'Navigating...';

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -9,6 +9,7 @@ import '../core/models.dart';
 /// Global path arrives pre-converted to odom frame by the backend.
 class LocalPlanningPainter extends CustomPainter {
   final List<TrajPoint> trajectory;
+  final List<TrajPoint> footprint;
   final List<TrajPoint> globalPath;
   final GridInfo? gridInfo;
   final Pose? odomPose;
@@ -19,6 +20,7 @@ class LocalPlanningPainter extends CustomPainter {
 
   const LocalPlanningPainter({
     required this.trajectory,
+    this.footprint = const [],
     this.globalPath = const [],
     this.gridInfo,
     this.odomPose,
@@ -51,7 +53,8 @@ class LocalPlanningPainter extends CustomPainter {
 
     _drawRobotArrow(canvas, Offset(cx, cy), pose?.yaw ?? 0.0);
 
-    if (showFootprint) _drawFootprint(canvas, Offset(cx, cy), pose?.yaw ?? 0.0, scaleX);
+    if (showFootprint && footprint.isNotEmpty && pose != null)
+      _drawFootprint(canvas, cx, cy, scaleX, scaleY, pose);
   }
 
   void _drawTrajectory(Canvas canvas, double cx, double cy,
@@ -148,31 +151,19 @@ class LocalPlanningPainter extends CustomPainter {
     canvas.drawLine(Offset(px, py + r - arm), Offset(px, py + r + arm), cross);
   }
 
-  /// Draws the Go2 robot footprint rectangle around the robot arrow.
-  /// Uses pixel coords (like the arrow) so it's always visible regardless of zoom.
-  /// Proportions match Go2 config: length=0.7m, width=0.3m (front:rear = 1:1).
-  void _drawFootprint(Canvas canvas, Offset center, double yaw, double scale) {
-    // Arrow tip=14px, base=5px, half-w=6px. Make footprint clearly surround it.
-    final fl = math.max(0.35 * scale, 22.0);   // forward px
-    final rl = math.max(0.35 * scale, 18.0);   // rear px
-    final hw = math.max(0.15 * scale, 12.0);   // half-width px
-
-    final cosY = math.cos(yaw);
-    final sinY = math.sin(yaw);
-
-    Offset pt(double fwd, double lat) => Offset(
-      center.dx + fwd * cosY - lat * sinY,
-      center.dy - fwd * sinY - lat * cosY,
-    );
-
-    final corners = [pt(fl, hw), pt(fl, -hw), pt(-rl, -hw), pt(-rl, hw)];
-
-    final path = Path()
-      ..moveTo(corners[0].dx, corners[0].dy)
-      ..lineTo(corners[1].dx, corners[1].dy)
-      ..lineTo(corners[2].dx, corners[2].dy)
-      ..lineTo(corners[3].dx, corners[3].dy)
-      ..close();
+  /// Draws robot footprint from actual /planning/footprint PointCloud data.
+  /// Points are in world (odom) frame — same transform as trajectory.
+  void _drawFootprint(Canvas canvas, double cx, double cy,
+      double scaleX, double scaleY, Pose pose) {
+    final path = Path();
+    for (int i = 0; i < footprint.length; i++) {
+      final p = footprint[i];
+      final px = cx + (p.x - pose.x) * scaleX;
+      final py = cy - (p.y - pose.y) * scaleY;
+      if (i == 0) path.moveTo(px, py);
+      else path.lineTo(px, py);
+    }
+    path.close();
 
     canvas.drawPath(path,
         Paint()
@@ -205,6 +196,7 @@ class LocalPlanningPainter extends CustomPainter {
   @override
   bool shouldRepaint(LocalPlanningPainter old) =>
       trajectory != old.trajectory ||
+      footprint != old.footprint ||
       globalPath != old.globalPath ||
       gridInfo != old.gridInfo ||
       odomPose != old.odomPose ||

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -49,9 +49,9 @@ class LocalPlanningPainter extends CustomPainter {
     if (navTargetPose != null && pose != null)
       _drawNavTarget(canvas, cx, cy, scaleX, scaleY, pose, navTargetPose!);
 
-    if (showFootprint) _drawFootprint(canvas, Offset(cx, cy), pose?.yaw ?? 0.0, scaleX);
-
     _drawRobotArrow(canvas, Offset(cx, cy), pose?.yaw ?? 0.0);
+
+    if (showFootprint) _drawFootprint(canvas, Offset(cx, cy), pose?.yaw ?? 0.0, scaleX);
   }
 
   void _drawTrajectory(Canvas canvas, double cx, double cy,
@@ -177,10 +177,6 @@ class LocalPlanningPainter extends CustomPainter {
       ..lineTo(corners[3].dx, corners[3].dy)
       ..close();
 
-    canvas.drawPath(path,
-        Paint()
-          ..color = Colors.yellowAccent.withOpacity(0.25)
-          ..style = PaintingStyle.fill);
     canvas.drawPath(path,
         Paint()
           ..color = Colors.yellowAccent

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -15,7 +15,6 @@ class LocalPlanningPainter extends CustomPainter {
   final Pose? odomPose;
   final bool showTrajectory;
   final bool showGlobalPath;
-  final bool showFootprint;
   final TrajPoint? navTargetPose;
 
   const LocalPlanningPainter({
@@ -26,7 +25,6 @@ class LocalPlanningPainter extends CustomPainter {
     this.odomPose,
     this.showTrajectory = true,
     this.showGlobalPath = true,
-    this.showFootprint = true,
     this.navTargetPose,
   });
 
@@ -53,7 +51,7 @@ class LocalPlanningPainter extends CustomPainter {
 
     _drawRobotArrow(canvas, Offset(cx, cy), pose?.yaw ?? 0.0);
 
-    if (showFootprint && footprint.isNotEmpty && pose != null)
+    if (footprint.isNotEmpty && pose != null)
       _drawFootprint(canvas, cx, cy, scaleX, scaleY, pose);
   }
 
@@ -202,6 +200,5 @@ class LocalPlanningPainter extends CustomPainter {
       odomPose != old.odomPose ||
       showTrajectory != old.showTrajectory ||
       showGlobalPath != old.showGlobalPath ||
-      showFootprint != old.showFootprint ||
       navTargetPose != old.navTargetPose;
 }

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -148,27 +148,24 @@ class LocalPlanningPainter extends CustomPainter {
     canvas.drawLine(Offset(px, py + r - arm), Offset(px, py + r + arm), cross);
   }
 
-  /// Draws the Go2 robot footprint rectangle (0.7 m × 0.3 m) centered on the robot.
-  /// Mirrors /planning/footprint topic data — front_len=0.35, rear_len=0.35, half_w=0.15.
+  /// Draws the Go2 robot footprint rectangle around the robot arrow.
+  /// Uses pixel coords (like the arrow) so it's always visible regardless of zoom.
+  /// Proportions match Go2 config: length=0.7m, width=0.3m (front:rear = 1:1).
   void _drawFootprint(Canvas canvas, Offset center, double yaw, double scale) {
-    const fl = 0.35;  // front from control center (m)
-    const rl = 0.35;  // rear from control center (m)
-    const hw = 0.15;  // half-width (m)
+    // Arrow tip=14px, base=5px, half-w=6px. Make footprint clearly surround it.
+    final fl = math.max(0.35 * scale, 22.0);   // forward px
+    final rl = math.max(0.35 * scale, 18.0);   // rear px
+    final hw = math.max(0.15 * scale, 12.0);   // half-width px
 
     final cosY = math.cos(yaw);
     final sinY = math.sin(yaw);
 
-    Offset toCanvas(double fwdM, double latM) => Offset(
-      center.dx + (fwdM * cosY - latM * sinY) * scale,
-      center.dy - (fwdM * sinY + latM * cosY) * scale,
+    Offset pt(double fwd, double lat) => Offset(
+      center.dx + fwd * cosY - lat * sinY,
+      center.dy - fwd * sinY - lat * cosY,
     );
 
-    final corners = [
-      toCanvas(fl, hw),
-      toCanvas(fl, -hw),
-      toCanvas(-rl, -hw),
-      toCanvas(-rl, hw),
-    ];
+    final corners = [pt(fl, hw), pt(fl, -hw), pt(-rl, -hw), pt(-rl, hw)];
 
     final path = Path()
       ..moveTo(corners[0].dx, corners[0].dy)
@@ -181,7 +178,7 @@ class LocalPlanningPainter extends CustomPainter {
         Paint()
           ..color = Colors.yellowAccent
           ..style = PaintingStyle.stroke
-          ..strokeWidth = 2.5);
+          ..strokeWidth = 2.0);
   }
 
   void _drawRobotArrow(Canvas canvas, Offset center, double yaw) {

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -14,6 +14,7 @@ class LocalPlanningPainter extends CustomPainter {
   final Pose? odomPose;
   final bool showTrajectory;
   final bool showGlobalPath;
+  final bool showFootprint;
   final TrajPoint? navTargetPose;
 
   const LocalPlanningPainter({
@@ -23,6 +24,7 @@ class LocalPlanningPainter extends CustomPainter {
     this.odomPose,
     this.showTrajectory = true,
     this.showGlobalPath = true,
+    this.showFootprint = true,
     this.navTargetPose,
   });
 
@@ -46,6 +48,8 @@ class LocalPlanningPainter extends CustomPainter {
 
     if (navTargetPose != null && pose != null)
       _drawNavTarget(canvas, cx, cy, scaleX, scaleY, pose, navTargetPose!);
+
+    if (showFootprint) _drawFootprint(canvas, Offset(cx, cy), pose?.yaw ?? 0.0, scaleX);
 
     _drawRobotArrow(canvas, Offset(cx, cy), pose?.yaw ?? 0.0);
   }
@@ -144,6 +148,46 @@ class LocalPlanningPainter extends CustomPainter {
     canvas.drawLine(Offset(px, py + r - arm), Offset(px, py + r + arm), cross);
   }
 
+  /// Draws the Go2 robot footprint rectangle (0.7 m × 0.3 m) centered on the robot.
+  /// Mirrors /planning/footprint topic data — front_len=0.35, rear_len=0.35, half_w=0.15.
+  void _drawFootprint(Canvas canvas, Offset center, double yaw, double scale) {
+    const fl = 0.35;  // front from control center (m)
+    const rl = 0.35;  // rear from control center (m)
+    const hw = 0.15;  // half-width (m)
+
+    final cosY = math.cos(yaw);
+    final sinY = math.sin(yaw);
+
+    Offset toCanvas(double fwdM, double latM) => Offset(
+      center.dx + (fwdM * cosY - latM * sinY) * scale,
+      center.dy - (fwdM * sinY + latM * cosY) * scale,
+    );
+
+    final corners = [
+      toCanvas(fl, hw),
+      toCanvas(fl, -hw),
+      toCanvas(-rl, -hw),
+      toCanvas(-rl, hw),
+    ];
+
+    final path = Path()
+      ..moveTo(corners[0].dx, corners[0].dy)
+      ..lineTo(corners[1].dx, corners[1].dy)
+      ..lineTo(corners[2].dx, corners[2].dy)
+      ..lineTo(corners[3].dx, corners[3].dy)
+      ..close();
+
+    canvas.drawPath(path,
+        Paint()
+          ..color = Colors.yellowAccent.withOpacity(0.15)
+          ..style = PaintingStyle.fill);
+    canvas.drawPath(path,
+        Paint()
+          ..color = Colors.yellowAccent.withOpacity(0.75)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.5);
+  }
+
   void _drawRobotArrow(Canvas canvas, Offset center, double yaw) {
     final cosY = math.cos(yaw);
     final sinY = math.sin(yaw);
@@ -173,5 +217,6 @@ class LocalPlanningPainter extends CustomPainter {
       odomPose != old.odomPose ||
       showTrajectory != old.showTrajectory ||
       showGlobalPath != old.showGlobalPath ||
+      showFootprint != old.showFootprint ||
       navTargetPose != old.navTargetPose;
 }

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -9,7 +9,6 @@ import '../core/models.dart';
 /// Global path arrives pre-converted to odom frame by the backend.
 class LocalPlanningPainter extends CustomPainter {
   final List<TrajPoint> trajectory;
-  final List<TrajPoint> footprint;
   final List<TrajPoint> globalPath;
   final GridInfo? gridInfo;
   final Pose? odomPose;
@@ -19,7 +18,6 @@ class LocalPlanningPainter extends CustomPainter {
 
   const LocalPlanningPainter({
     required this.trajectory,
-    this.footprint = const [],
     this.globalPath = const [],
     this.gridInfo,
     this.odomPose,
@@ -50,9 +48,6 @@ class LocalPlanningPainter extends CustomPainter {
       _drawNavTarget(canvas, cx, cy, scaleX, scaleY, pose, navTargetPose!);
 
     _drawRobotArrow(canvas, Offset(cx, cy), pose?.yaw ?? 0.0);
-
-    if (footprint.isNotEmpty && pose != null)
-      _drawFootprint(canvas, cx, cy, scaleX, scaleY, pose);
   }
 
   void _drawTrajectory(Canvas canvas, double cx, double cy,
@@ -149,27 +144,6 @@ class LocalPlanningPainter extends CustomPainter {
     canvas.drawLine(Offset(px, py + r - arm), Offset(px, py + r + arm), cross);
   }
 
-  /// Draws robot footprint from actual /planning/footprint PointCloud data.
-  /// Points are in world (odom) frame — same transform as trajectory.
-  void _drawFootprint(Canvas canvas, double cx, double cy,
-      double scaleX, double scaleY, Pose pose) {
-    final path = Path();
-    for (int i = 0; i < footprint.length; i++) {
-      final p = footprint[i];
-      final px = cx + (p.x - pose.x) * scaleX;
-      final py = cy - (p.y - pose.y) * scaleY;
-      if (i == 0) path.moveTo(px, py);
-      else path.lineTo(px, py);
-    }
-    path.close();
-
-    canvas.drawPath(path,
-        Paint()
-          ..color = Colors.yellowAccent
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 2.0);
-  }
-
   void _drawRobotArrow(Canvas canvas, Offset center, double yaw) {
     final cosY = math.cos(yaw);
     final sinY = math.sin(yaw);
@@ -194,7 +168,6 @@ class LocalPlanningPainter extends CustomPainter {
   @override
   bool shouldRepaint(LocalPlanningPainter old) =>
       trajectory != old.trajectory ||
-      footprint != old.footprint ||
       globalPath != old.globalPath ||
       gridInfo != old.gridInfo ||
       odomPose != old.odomPose ||

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -179,13 +179,13 @@ class LocalPlanningPainter extends CustomPainter {
 
     canvas.drawPath(path,
         Paint()
-          ..color = Colors.yellowAccent.withOpacity(0.15)
+          ..color = Colors.yellowAccent.withOpacity(0.25)
           ..style = PaintingStyle.fill);
     canvas.drawPath(path,
         Paint()
-          ..color = Colors.yellowAccent.withOpacity(0.75)
+          ..color = Colors.yellowAccent
           ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.5);
+          ..strokeWidth = 2.5);
   }
 
   void _drawRobotArrow(Canvas canvas, Offset center, double yaw) {

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -249,9 +249,11 @@ class MapNode(Node):
 
         self.pois = {}
         self.poi_index = -1
+        self._nav_completed = False
 
         self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
         self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
+        self.nav_done_pub = self.create_publisher(Bool, '/mapping/nav_done', 10)
 
         self.current_pose_pub = self.create_publisher(Odometry, "/mapping/current_pose", 10)
         self.global_plan_pub = self.create_publisher(Path, '/mapping/global_plan', 10)
@@ -281,6 +283,7 @@ class MapNode(Node):
                 return
 
             self.poi_index = min(0, len(self.pois) - 1)
+            self._nav_completed = False
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
@@ -613,7 +616,10 @@ class MapNode(Node):
                 break
 
         if self.poi_index >= len(self.pois):
-            self.get_logger().info("All POIs have been visited, skip publishing nav path")
+            if not self._nav_completed:
+                self._nav_completed = True
+                self.get_logger().info("All POIs have been visited, nav done")
+                self.nav_done_pub.publish(Bool(data=True))
             return
 
         target_poi = self.pois[self.poi_index]

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -612,6 +612,16 @@ class MapNode(Node):
             diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
             diff_position_norm_z = np.linalg.norm(poi[2] - pose_in_map_position[2])
             if diff_position_norm_xy < 0.5 and diff_position_norm_z < 2.0:
+                if self._leg_initial_length is not None:
+                    arrived_msg = String()
+                    arrived_msg.data = json.dumps({
+                        "poi_index": self.poi_index,
+                        "percent": 100.0,
+                        "path_remaining_m": 0.0,
+                        "path_total_m": round(self._leg_initial_length, 2),
+                        "estimated_remaining_s": 0.0,
+                    })
+                    self.nav_progress_pub.publish(arrived_msg)
                 self.poi_index += 1
                 self._leg_initial_length = None
                 self._leg_start_time = None

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -1,5 +1,6 @@
 import rclpy
 import os
+import time
 from rclpy.node import Node
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path, Odometry
@@ -250,10 +251,14 @@ class MapNode(Node):
         self.pois = {}
         self.poi_index = -1
         self._nav_completed = False
+        self._leg_initial_length: float | None = None
+        self._leg_start_time: float | None = None
+        self._speed_estimate: float | None = None
 
         self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
         self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
         self.nav_done_pub = self.create_publisher(Bool, '/mapping/nav_done', 10)
+        self.nav_progress_pub = self.create_publisher(String, '/mapping/nav_progress', 10)
 
         self.current_pose_pub = self.create_publisher(Odometry, "/mapping/current_pose", 10)
         self.global_plan_pub = self.create_publisher(Path, '/mapping/global_plan', 10)
@@ -284,6 +289,9 @@ class MapNode(Node):
 
             self.poi_index = min(0, len(self.pois) - 1)
             self._nav_completed = False
+            self._leg_initial_length = None
+            self._leg_start_time = None
+            self._speed_estimate = None
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
@@ -605,6 +613,8 @@ class MapNode(Node):
             diff_position_norm_z = np.linalg.norm(poi[2] - pose_in_map_position[2])
             if diff_position_norm_xy < 0.5 and diff_position_norm_z < 2.0:
                 self.poi_index += 1
+                self._leg_initial_length = None
+                self._leg_start_time = None
                 dummy_pose = np.eye(4)
 
                 stamp_msg = self.get_clock().now().to_msg()
@@ -627,6 +637,35 @@ class MapNode(Node):
             paths_in_map = self.generate_nav_path_in_map(pose_in_map = pose_in_map, target_poi = target_poi)
 
         if paths_in_map is not None:
+            remaining_length = sum(
+                np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
+                for i in range(len(paths_in_map) - 1)
+            ) if len(paths_in_map) > 1 else 0.0
+
+            now = time.time()
+            if self._leg_initial_length is None:
+                self._leg_initial_length = remaining_length
+                self._leg_start_time = now
+
+            covered = self._leg_initial_length - remaining_length
+            elapsed = now - self._leg_start_time
+            if covered > 0.1 and elapsed > 1.0:
+                self._speed_estimate = covered / elapsed
+
+            initial = self._leg_initial_length
+            percent = max(0.0, min(100.0, covered / initial * 100.0)) if initial > 0 else 0.0
+            estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
+
+            progress_msg = String()
+            progress_msg.data = json.dumps({
+                "poi_index": self.poi_index,
+                "percent": round(percent, 1),
+                "path_remaining_m": round(remaining_length, 2),
+                "path_total_m": round(initial, 2),
+                "estimated_remaining_s": round(estimated_remaining_s, 1),
+            })
+            self.nav_progress_pub.publish(progress_msg)
+
             # use the max_speed to publish the position the robot should be after 5 seconds
             with Timer(name = "Find target position", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
                 max_speed = 0.5


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                 
                                              
  - **`/mapping/nav_progress` ROS topic** — `map_node` publishes per-POI path progress on every keyframe: current POI index, completion %, remaining path distance, and estimated remaining time. Speed is derived dynamically from covered  
  distance / elapsed time and carried over across POI transitions for a progressively better estimate. Publishes 100% on arrival before moving to the next POI.
  - **Dedicated `/ws/nav-progress` WebSocket** — backend subscribes to the ROS topic and forwards each message immediately via a new `/ws/nav-progress` endpoint, so the frontend updates at full topic rate instead of the 1 s status poll. 
  - **Navigation progress overlay in Operate tab** — floating overlay above the map buttons showing `→ <POI name>  XX% · X.Xm · ~Xs`. Flashes green "Arrived" for 1.2 s when all POIs are visited.                                           
  - **Fix: global map path coordinates** — `_GlobalMapView` was passing `globalPath` (odom frame) to `MapOverlayPainter`; corrected to `mapGlobalPath` (map frame) to match the coordinate system expected by `_worldToImage`.               
  - **Fix: relocalization map pose** — backend now stores `map_pose` when a relocalization message arrives so the PiP map has a robot position to draw immediately after localization.                                                       
  - **Auto nav-done** — `map_node` publishes `/mapping/nav_done` when all POIs are visited; backend transitions state `navigation → idle` and clears the active POI list in the frontend.                                                    
  - **Active POIs on PiP map** — PiP map shows the currently active nav POIs after Go is pressed. 


https://github.com/user-attachments/assets/5aa212c3-6f6b-426d-bd0d-a3c77ffc5731

