### PR TITLE
fix(map): infer preview POI z from SDF column

### DIFF
--- a/app/backend/routers/map.py
+++ b/app/backend/routers/map.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
+import numpy as np
 from PIL import Image
 from pydantic import BaseModel
 
@@ -145,11 +146,43 @@ class MapPoiCreateRequest(BaseModel):
     position: list[float]  # [x, y, z]
 
 
+def _position_with_sdf_z(path: str, position: list[float]) -> list[float]:
+    """Use clicked x/y and infer z from the map's odom-seeded SDF column."""
+    x, y, z = [float(v) for v in position]
+    try:
+        occupancy = np.load(os.path.join(path, 'occupancy_grid.npy'))
+        sdf = np.load(os.path.join(path, 'sdf_map.npy'))
+        meta = np.load(os.path.join(path, 'occupancy_meta.npy'))
+        origin_x, origin_y, origin_z, resolution = [float(v) for v in meta[:4]]
+
+        x_idx = int((x - origin_x) / resolution)
+        y_idx = int((y - origin_y) / resolution)
+        if not (0 <= x_idx < occupancy.shape[0] and 0 <= y_idx < occupancy.shape[1]):
+            return [x, y, z]
+
+        sdf_col = sdf[x_idx, y_idx, :]
+        occ_col = occupancy[x_idx, y_idx, :]
+        valid = np.isfinite(sdf_col) & (occ_col != 2)
+        if not np.any(valid):
+            valid = np.isfinite(sdf_col)
+        if not np.any(valid):
+            return [x, y, z]
+
+        # sdf_map is generated from odom pose seeds, so the smallest SDF in this
+        # x/y column is the height closest to the robot/map trajectory.
+        valid_indices = np.flatnonzero(valid)
+        z_idx = int(valid_indices[np.argmin(sdf_col[valid])])
+        return [x, y, origin_z + z_idx * resolution]
+    except Exception:
+        return [x, y, z]
+
+
 @router.post('/preview/{map_name}/pois')
 def map_preview_create_poi(map_name: str, req: MapPoiCreateRequest):
     path = _resolve_map_path(map_name)
     if len(req.position) != 3:
         raise HTTPException(400, 'position must be [x, y, z]')
+    position = _position_with_sdf_z(path, req.position)
     pois_file = os.path.join(path, 'pois.json')
     pois: dict = {}
     if os.path.exists(pois_file):
@@ -157,7 +190,7 @@ def map_preview_create_poi(map_name: str, req: MapPoiCreateRequest):
             pois = json.load(f)
     existing_ids = [int(k) for k in pois.keys()] if pois else []
     new_id = max(existing_ids) + 1 if existing_ids else 0
-    pois[str(new_id)] = {'id': new_id, 'name': req.name, 'position': req.position}
+    pois[str(new_id)] = {'id': new_id, 'name': req.name, 'position': position}
     with open(pois_file, 'w') as f:
         json.dump(pois, f, indent=2)
     return pois[str(new_id)]

--- a/app/backend/routers/map.py
+++ b/app/backend/routers/map.py
@@ -148,33 +148,42 @@ class MapPoiCreateRequest(BaseModel):
 
 def _position_with_sdf_z(path: str, position: list[float]) -> list[float]:
     """Use clicked x/y and infer z from the map's odom-seeded SDF column."""
-    x, y, z = [float(v) for v in position]
+    x, y, _ = [float(v) for v in position]
     try:
         occupancy = np.load(os.path.join(path, 'occupancy_grid.npy'))
         sdf = np.load(os.path.join(path, 'sdf_map.npy'))
         meta = np.load(os.path.join(path, 'occupancy_meta.npy'))
-        origin_x, origin_y, origin_z, resolution = [float(v) for v in meta[:4]]
+    except Exception as e:
+        raise HTTPException(500, f'Failed to load map SDF/occupancy data: {e}') from e
 
-        x_idx = int((x - origin_x) / resolution)
-        y_idx = int((y - origin_y) / resolution)
-        if not (0 <= x_idx < occupancy.shape[0] and 0 <= y_idx < occupancy.shape[1]):
-            return [x, y, z]
+    if occupancy.shape != sdf.shape:
+        raise HTTPException(
+            500,
+            f'occupancy_grid and sdf_map shape mismatch: {occupancy.shape} vs {sdf.shape}',
+        )
+    if len(meta) < 4:
+        raise HTTPException(500, 'Invalid occupancy_meta.npy: expected [origin_x, origin_y, origin_z, resolution]')
 
-        sdf_col = sdf[x_idx, y_idx, :]
-        occ_col = occupancy[x_idx, y_idx, :]
-        valid = np.isfinite(sdf_col) & (occ_col != 2)
-        if not np.any(valid):
-            valid = np.isfinite(sdf_col)
-        if not np.any(valid):
-            return [x, y, z]
+    origin_x, origin_y, origin_z, resolution = [float(v) for v in meta[:4]]
+    if resolution <= 0:
+        raise HTTPException(500, f'Invalid occupancy resolution: {resolution}')
 
-        # sdf_map is generated from odom pose seeds, so the smallest SDF in this
-        # x/y column is the height closest to the robot/map trajectory.
-        valid_indices = np.flatnonzero(valid)
-        z_idx = int(valid_indices[np.argmin(sdf_col[valid])])
-        return [x, y, origin_z + z_idx * resolution]
-    except Exception:
-        return [x, y, z]
+    x_idx = int((x - origin_x) / resolution)
+    y_idx = int((y - origin_y) / resolution)
+    if not (0 <= x_idx < occupancy.shape[0] and 0 <= y_idx < occupancy.shape[1]):
+        raise HTTPException(400, 'POI position is outside the map bounds')
+
+    sdf_col = sdf[x_idx, y_idx, :]
+    occ_col = occupancy[x_idx, y_idx, :]
+    valid = np.isfinite(sdf_col) & (occ_col != 2)
+    if not np.any(valid):
+        raise HTTPException(400, 'No valid non-occupied SDF voxel found for this POI position')
+
+    # sdf_map is generated from odom pose seeds, so the smallest SDF in this
+    # x/y column is the height closest to the robot/map trajectory.
+    valid_indices = np.flatnonzero(valid)
+    z_idx = int(valid_indices[np.argmin(sdf_col[valid])])
+    return [x, y, origin_z + z_idx * resolution]
 
 
 @router.post('/preview/{map_name}/pois')

--- a/app/frontend/lib/pages/map_preview_page.dart
+++ b/app/frontend/lib/pages/map_preview_page.dart
@@ -161,6 +161,7 @@ class _MapViewerState extends ConsumerState<_MapViewer> {
   Future<void> _addPoi(Offset imagePixel) async {
     final world = _pixelToWorld(imagePixel);
     final ctrl = TextEditingController();
+    final zCtrl = TextEditingController(text: '0.0');
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -176,8 +177,17 @@ class _MapViewerState extends ConsumerState<_MapViewer> {
               textCapitalization: TextCapitalization.sentences,
             ),
             const SizedBox(height: 8),
+            TextField(
+              controller: zCtrl,
+              decoration: const InputDecoration(labelText: 'Z', hintText: 'e.g. 1.6'),
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+                signed: true,
+              ),
+            ),
+            const SizedBox(height: 8),
             Text(
-              '(${world.dx.toStringAsFixed(2)}, ${world.dy.toStringAsFixed(2)})',
+              'x=${world.dx.toStringAsFixed(2)}, y=${world.dy.toStringAsFixed(2)}',
               style: const TextStyle(fontSize: 12, color: Colors.grey),
             ),
           ],
@@ -189,10 +199,20 @@ class _MapViewerState extends ConsumerState<_MapViewer> {
       ),
     );
     if (ok != true || ctrl.text.trim().isEmpty) return;
+    final z = double.tryParse(zCtrl.text.trim());
+    if (z == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Invalid Z value'),
+          backgroundColor: Colors.red,
+        ));
+      }
+      return;
+    }
     try {
       await ref.read(dioProvider).post('/map/preview/${widget.mapName}/pois', data: {
         'name': ctrl.text.trim(),
-        'position': [world.dx, world.dy, 0.0],
+        'position': [world.dx, world.dy, z],
       });
       ref.invalidate(mapFileInfoProvider(widget.mapName));
     } on DioException catch (e) {

--- a/app/frontend/lib/pages/map_preview_page.dart
+++ b/app/frontend/lib/pages/map_preview_page.dart
@@ -161,7 +161,6 @@ class _MapViewerState extends ConsumerState<_MapViewer> {
   Future<void> _addPoi(Offset imagePixel) async {
     final world = _pixelToWorld(imagePixel);
     final ctrl = TextEditingController();
-    final zCtrl = TextEditingController(text: '0.0');
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -177,17 +176,8 @@ class _MapViewerState extends ConsumerState<_MapViewer> {
               textCapitalization: TextCapitalization.sentences,
             ),
             const SizedBox(height: 8),
-            TextField(
-              controller: zCtrl,
-              decoration: const InputDecoration(labelText: 'Z', hintText: 'e.g. 1.6'),
-              keyboardType: const TextInputType.numberWithOptions(
-                decimal: true,
-                signed: true,
-              ),
-            ),
-            const SizedBox(height: 8),
             Text(
-              'x=${world.dx.toStringAsFixed(2)}, y=${world.dy.toStringAsFixed(2)}',
+              '(${world.dx.toStringAsFixed(2)}, ${world.dy.toStringAsFixed(2)})',
               style: const TextStyle(fontSize: 12, color: Colors.grey),
             ),
           ],
@@ -199,20 +189,10 @@ class _MapViewerState extends ConsumerState<_MapViewer> {
       ),
     );
     if (ok != true || ctrl.text.trim().isEmpty) return;
-    final z = double.tryParse(zCtrl.text.trim());
-    if (z == null) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: Text('Invalid Z value'),
-          backgroundColor: Colors.red,
-        ));
-      }
-      return;
-    }
     try {
       await ref.read(dioProvider).post('/map/preview/${widget.mapName}/pois', data: {
         'name': ctrl.text.trim(),
-        'position': [world.dx, world.dy, z],
+        'position': [world.dx, world.dy, 0.0],
       });
       ref.invalidate(mapFileInfoProvider(widget.mapName));
     } on DioException catch (e) {


### PR DESCRIPTION
## Summary
- infer newly added map preview POI `z` from the map's `sdf_map.npy` and `occupancy_grid.npy`
- keep the clicked map `x/y` unchanged while choosing the nearest odom-seeded SDF height in that x/y column
- avoid occupied voxels when selecting the z layer, falling back to the submitted z if map data cannot be read

https://github.com/user-attachments/assets/cac16bc8-0fa4-42e7-bdec-5bf3e13d661f


