### PR TITLE
feat(mapping): pace BagPlayer replay to prevent perception queue overflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -205,8 +205,9 @@ RUN git clone --recursive https://github.com/dmlc/decord.git /tmp/decord \
     && make -j"$(nproc)" \
     && cd ../python \
     && /usr/bin/python3 setup.py install \
+    && cp -f /tmp/decord/build/libdecord.so /usr/local/lib/libdecord.so \
     && DECORD_PKG_DIR=$(/usr/bin/python3 -c "import site; print(site.getsitepackages()[0] + '/decord')") \
-    && ln -sf /tmp/decord/build/libdecord.so "${DECORD_PKG_DIR}/libdecord.so" \
+    && ln -sf /usr/local/lib/libdecord.so "${DECORD_PKG_DIR}/libdecord.so" \
     && rm -rf /tmp/decord
 
 # Write entrypoint.sh (model build prompt only)

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,9 +204,9 @@ RUN git clone --recursive https://github.com/dmlc/decord.git /tmp/decord \
     && cmake .. -DUSE_CUDA=0 -DCMAKE_BUILD_TYPE=Release \
     && make -j"$(nproc)" \
     && cd ../python \
-    && /opt/venv/bin/python setup.py install \
-    && DECORD_PKG_DIR=$(/opt/venv/bin/python -c "import site; print(site.getsitepackages()[0] + '/decord')") \
-    && ln -sf /opt/venv/decord/libdecord.so "${DECORD_PKG_DIR}/libdecord.so" \
+    && /usr/bin/python3 setup.py install \
+    && DECORD_PKG_DIR=$(/usr/bin/python3 -c "import site; print(site.getsitepackages()[0] + '/decord')") \
+    && ln -sf /tmp/decord/build/libdecord.so "${DECORD_PKG_DIR}/libdecord.so" \
     && rm -rf /tmp/decord
 
 # Write entrypoint.sh (model build prompt only)

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -364,6 +364,8 @@ class BagPlayer(Node):
         self._use_stats_pacing = False
         self._startup_release_until_ns = None
         self._publish_ahead_limit_ns = int(1.0 * 1e9)
+        self._stall_cycles = 0
+        self._stall_cycle_limit = 5000
         self._no_odom_bootstrap_limit_ns = int(0.5 * 1e9)
         self._bootstrap_header_start_ns = None
         self._pending_message = None  # (topic, serialized_msg, bag_timestamp_ns, msg, msg_timestamp_ns)
@@ -580,13 +582,29 @@ class BagPlayer(Node):
         if self._startup_release_until_ns is None:
             self._startup_release_until_ns = selected_msg_ts_ns + int(1.0 * 1e9)
         if self._stats_msg_count < 2 and selected_msg_ts_ns > self._startup_release_until_ns:
+            self._stall_cycles += 1
+            if self._stall_cycles > self._stall_cycle_limit:
+                self.get_logger().warning(
+                    "BagPlayer exiting due to startup gate stall: "
+                    f"stats_msg_count={self._stats_msg_count}, selected_ts_ns={selected_msg_ts_ns}"
+                )
+                return False
             return True
 
         if self._use_stats_pacing:
             progress_ts_ns = self._latest_perception_timestamp_ns
             if progress_ts_ns is not None and selected_msg_ts_ns > progress_ts_ns + self._publish_ahead_limit_ns:
+                self._stall_cycles += 1
+                if self._stall_cycles > self._stall_cycle_limit:
+                    self.get_logger().warning(
+                        "BagPlayer exiting due to pacing stall: "
+                        f"selected_ts_ns={selected_msg_ts_ns}, progress_ts_ns={progress_ts_ns}, "
+                        f"ahead_limit_ns={self._publish_ahead_limit_ns}"
+                    )
+                    return False
                 return True
 
+        self._stall_cycles = 0
         topic, serialized_msg, timestamp_ns, msg, msg_timestamp_ns = self._topic_buffers[selected_topic].popleft()
         pub_and_type = self._topic_publishers.get(topic)
         if pub_and_type is None:

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -364,8 +364,6 @@ class BagPlayer(Node):
         self._state = "WAIT_INIT"
         self._startup_release_until_ns = None
         self._publish_ahead_limit_ns = int(1.0 * 1e9)
-        self._stall_cycles = 0
-        self._stall_cycle_limit = 5000
         self._schedule_window_ns = int(0.5 * 1e9)
         self._schedule_min_msgs = 64
 
@@ -515,17 +513,15 @@ class BagPlayer(Node):
 
         msg_timestamp_ns, _, topic, bag_timestamp_ns, msg = self._schedule_heap[0]
         if self._should_gate_message(msg_timestamp_ns):
-            self._stall_cycles += 1
-            if self._stall_cycles > self._stall_cycle_limit:
+            if self._reader_exhausted:
                 self.get_logger().warning(
-                    "BagPlayer exiting due to gating stall: "
+                    "BagPlayer exiting due to gated deadlock after reader exhausted: "
                     f"state={self._state}, stats_msg_count={self._stats_msg_count}, "
                     f"msg_ts_ns={msg_timestamp_ns}, progress_ts_ns={self._latest_perception_timestamp_ns}"
                 )
                 return False
             return True
 
-        self._stall_cycles = 0
         _, _, topic, bag_timestamp_ns, msg = heapq.heappop(self._schedule_heap)
         pub_and_type = self._topic_publishers.get(topic)
         if pub_and_type is None:

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -519,29 +519,6 @@ class BagPlayer(Node):
             )
             self._schedule_seq += 1
 
-    def _ready_to_start(self) -> bool:
-        required_topics = [
-            "/camera/camera/imu",
-            "/camera/camera/infra1/image_rect_raw",
-            "/camera/camera/infra2/image_rect_raw",
-            "/camera/camera/infra2/camera_info",
-        ]
-        missing = []
-        for topic in required_topics:
-            pub_and_type = self._topic_publishers.get(topic)
-            if pub_and_type is None:
-                continue
-            pub, _ = pub_and_type
-            if pub.get_subscription_count() <= 0:
-                missing.append(topic)
-        if missing:
-            self.get_logger().info(
-                "BagPlayer waiting subscribers before start: %s"
-                % ", ".join(missing)
-            )
-            return False
-        return True
-
     def _read_next_into_topic_buffer(self):
         if self._reader_exhausted:
             return False
@@ -714,7 +691,6 @@ class BuildMapNode(Node):
         self.pose_graph_used_pose = {}
         self.relative_pose_constraint = []
         self.last_keyframe_timestamp = None
-        self._processed_keyframe_timestamps = set()
         self.continuous_odom_recorder = OdomPoseRecorder(map_save_path, "mapping")
 
         os.makedirs(f"{map_save_path}", exist_ok=True)
@@ -820,25 +796,13 @@ class BuildMapNode(Node):
             keyframe_image_timestamp = int(keyframe_image_msg.header.stamp.sec * 1e9) + int(keyframe_image_msg.header.stamp.nanosec)
             keyframe_odom_timestamp = int(keyframe_odom_msg.header.stamp.sec * 1e9) + int(keyframe_odom_msg.header.stamp.nanosec)
             keyframe_depth_timestamp = int(depth_msg.header.stamp.sec * 1e9) + int(depth_msg.header.stamp.nanosec)
-            if keyframe_image_timestamp in self._processed_keyframe_timestamps:
-                self.get_logger().warning(
-                    f"Skip duplicate keyframe timestamp: {keyframe_image_timestamp}"
-                )
-                return
-            keyframe_index = len(self.odom) + 1
-            self.get_logger().info(
-                f"Processing keyframe #{keyframe_index}: ts_ns={keyframe_image_timestamp}"
-            )
             if keyframe_image_timestamp != keyframe_odom_timestamp or keyframe_image_timestamp != keyframe_depth_timestamp:
                 self.get_logger().error(f"Keyframe timestamp mismatch: {keyframe_image_timestamp} != {keyframe_odom_timestamp} != {keyframe_depth_timestamp}")
-                return
 
             depth = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="32FC1")
             odom, _ = msg2np(keyframe_odom_msg)
             infra1_image = self.bridge.imgmsg_to_cv2(keyframe_image_msg, desired_encoding="mono8")
             rgb_image = self.bridge.imgmsg_to_cv2(rgb_image_msg, desired_encoding="bgr8")
-
-        self._processed_keyframe_timestamps.add(keyframe_image_timestamp)
 
         with Timer(name = "save image and depth", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
             self.db.set_entry(keyframe_image_timestamp, depth = depth, infra1_image = infra1_image, rgb_image = rgb_image)

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -544,28 +544,7 @@ class BagPlayer(Node):
         pub, _ = pub_and_type
 
         self._publish_percent_from_timestamp(int(timestamp_ns))
-        header_stamp_sec = ""
-        header_stamp_nanosec = ""
-        header_timestamp_s = ""
-        if hasattr(msg, "header") and hasattr(msg.header, "stamp"):
-            header_stamp_sec = int(msg.header.stamp.sec)
-            header_stamp_nanosec = int(msg.header.stamp.nanosec)
-            # Keep the same conversion logic as perception_node.stamp2second.
-            header_timestamp_s = np.int64(header_stamp_sec) + np.int64(header_stamp_nanosec) * 1e-9
-        try:
-            if topic in (
-                "/camera/camera/infra1/image_rect_raw",
-                "/camera/camera/infra2/image_rect_raw",
-            ):
-                self.get_logger().info(
-                    f"BagPlayer publish {topic} timestamp: {header_timestamp_s}"
-                )
-            pub.publish(msg)
-        except Exception as e:
-            self.get_logger().error(
-                f"Failed to publish topic={topic} bag_ts={timestamp_ns} header_ts={msg_timestamp_ns}: {e}"
-            )
-            return True
+        pub.publish(msg)
 
         # Publish /clock with the same timestamp (for use_sim_time)
         if self._clock_pub is not None:

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -19,7 +19,6 @@ import os
 import argparse
 import sys
 import heapq
-from collections import deque
 import json
 
 from tinynav.tinynav_cpp_bind import pose_graph_solve

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -2,7 +2,7 @@ import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import Path, Odometry
-from std_msgs.msg import Bool, Float32
+from std_msgs.msg import Bool, Float32, String
 import numpy as np
 
 from sensor_msgs.msg import PointCloud2
@@ -11,13 +11,16 @@ from visualization_msgs.msg import Marker, MarkerArray
 from std_msgs.msg import ColorRGBA
 from tinynav.core.math_utils import matrix_to_quat, msg2np, estimate_pose, tf2np, depth_to_cloud
 from sensor_msgs.msg import Image, CameraInfo, CompressedImage
-from message_filters import Subscriber, ApproximateTimeSynchronizer
+from message_filters import Subscriber, ApproximateTimeSynchronizer, InputAligner, SimpleFilter
 from cv_bridge import CvBridge
 import cv2
 from codetiming import Timer
 import os
 import argparse
 import sys
+import heapq
+from collections import deque
+import json
 
 from tinynav.tinynav_cpp_bind import pose_graph_solve
 from tinynav.core.models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
@@ -37,6 +40,8 @@ from scipy.spatial.transform import Rotation as R
 from scipy.ndimage import distance_transform_edt
 
 from rclpy.executors import SingleThreadedExecutor
+from rclpy.duration import Duration
+from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
 from rosbag2_py import SequentialReader, StorageOptions, ConverterOptions
 from rosidl_runtime_py.utilities import get_message
 from rosgraph_msgs.msg import Clock
@@ -346,8 +351,56 @@ class BagPlayer(Node):
         # /clock publisher (for use_sim_time)
         self._clock_pub = self.create_publisher(Clock, "/clock", 10)
         self._mapping_percent_pub = self.create_publisher(Float32, "/mapping/percent", 10)
+        stats_qos = QoSProfile(depth=10)
+        stats_qos.reliability = ReliabilityPolicy.RELIABLE
+        stats_qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        self._stats_progress_sub = self.create_subscription(
+            String, "/slam/data", self._stats_progress_callback, stats_qos
+        )
+
+        self._stats_msg_count = 0
+        self._latest_perception_timestamp_ns = None
+        self._perception_initialized = False
+        self._use_stats_pacing = False
+        self._startup_release_until_ns = None
+        self._publish_ahead_limit_ns = int(1.0 * 1e9)
+        self._no_odom_bootstrap_limit_ns = int(0.5 * 1e9)
+        self._bootstrap_header_start_ns = None
+        self._pending_message = None  # (topic, serialized_msg, bag_timestamp_ns, msg, msg_timestamp_ns)
+        self._schedule_heap = []  # (msg_timestamp_ns, seq, topic, serialized_msg, bag_timestamp_ns, msg)
+        self._schedule_seq = 0
+        self._schedule_lookahead = 256
 
         self.get_logger().info(f"BagPlayer opened bag: {bag_uri}")
+        bag_name = os.path.basename(os.path.normpath(bag_uri)) or "bag"
+        self._topic_timestamp_log_path = os.path.join("/tinynav", f"{bag_name}_topic_timestamps.log")
+        self._topic_timestamp_log_file = open(self._topic_timestamp_log_path, "w", encoding="utf-8")
+        self._topic_timestamp_log_file.write(
+            "topic,bag_timestamp_ns,header_stamp_sec,header_stamp_nanosec,header_timestamp_s\n"
+        )
+        self._topic_timestamp_log_file.flush()
+        self.get_logger().info(f"BagPlayer topic timestamp log: {self._topic_timestamp_log_path}")
+        self._started = False
+        self._topic_buffers = {topic: deque() for topic in self._topic_publishers.keys()}
+        self._reader_exhausted = False
+        self._aligned_queue = deque()  # (topic, serialized_msg, bag_timestamp_ns, msg, msg_timestamp_ns)
+        self._aligner_meta = {}
+        self._aligner_topics = [
+            topic for topic in self._topic_publishers.keys() if topic != "/tf_static"
+        ]
+        self._aligner_filters = {topic: SimpleFilter() for topic in self._aligner_topics}
+        if self._aligner_topics:
+            self._input_aligner = InputAligner(
+                Duration(seconds=1.0),
+                *[self._aligner_filters[topic] for topic in self._aligner_topics],
+            )
+            for idx, topic in enumerate(self._aligner_topics):
+                self._input_aligner.setInputPeriod(idx, Duration(seconds=self._topic_period_s(topic)))
+                self._input_aligner.registerCallback(
+                    idx, lambda msg, topic_name=topic: self._on_aligned_message(topic_name, msg)
+                )
+        else:
+            self._input_aligner = None
 
     def _scan_bag_time_range(self, bag_uri: str, storage_id: str, serialization_format: str) -> tuple[int, int]:
         # We have not found a rosbag2_py API that exposes the bag time range directly,
@@ -392,41 +445,232 @@ class BagPlayer(Node):
             self._last_percent_log_time = now
 
     def _publish_percent_from_timestamp(self, timestamp_ns: int) -> None:
-        percent = 100.0 * (timestamp_ns - self.start_timestamp_ns) / (self.end_timestamp_ns - self.start_timestamp_ns)
+        denom = self.end_timestamp_ns - self.start_timestamp_ns
+        if denom <= 0:
+            self._publish_percent(100.0)
+            return
+        percent = 100.0 * (timestamp_ns - self.start_timestamp_ns) / denom
         self._publish_percent(percent)
+
+    def _stats_progress_callback(self, stats_msg: String):
+        payload = json.loads(stats_msg.data)
+        self._stats_msg_count += 1
+        if bool(payload.get("initialized", False)):
+            self._perception_initialized = True
+        if self._stats_msg_count >= 2:
+            self._use_stats_pacing = True
+
+        timestamp_s = payload.get("timestamp", None)
+        if timestamp_s is None:
+            return
+        timestamp_s = float(timestamp_s)
+        if timestamp_s < 0.0:
+            return
+        self._latest_perception_timestamp_ns = int(timestamp_s * 1e9)
+        self.get_logger().info(
+            f"BagPlayer /slam/data latest timestamp: {timestamp_s:.9f}"
+        )
+
+    def _message_timestamp_ns(self, msg, fallback_timestamp_ns: int) -> int:
+        if hasattr(msg, "header") and hasattr(msg.header, "stamp"):
+            return int(msg.header.stamp.sec * 1e9) + int(msg.header.stamp.nanosec)
+        return int(fallback_timestamp_ns)
+
+    def _topic_period_s(self, topic: str) -> float:
+        if topic == "/camera/camera/imu":
+            return 0.005
+        if topic == "/insight/vio_20hz":
+            return 0.05
+        if topic.endswith("/image_rect_raw"):
+            return 1.0 / 30.0
+        return 0.1
+
+    def _on_aligned_message(self, topic: str, msg) -> None:
+        meta = self._aligner_meta.pop(id(msg), None)
+        if meta is None:
+            msg_timestamp_ns = self._message_timestamp_ns(msg, 0)
+            self._aligned_queue.append((topic, None, int(msg_timestamp_ns), msg, int(msg_timestamp_ns)))
+            return
+        serialized_msg, bag_timestamp_ns = meta
+        msg_timestamp_ns = self._message_timestamp_ns(msg, int(bag_timestamp_ns))
+        self._aligned_queue.append(
+            (topic, serialized_msg, int(bag_timestamp_ns), msg, int(msg_timestamp_ns))
+        )
+
+    def _fill_schedule_buffer(self):
+        while len(self._schedule_heap) < self._schedule_lookahead and self._reader.has_next():
+            topic, serialized_msg, bag_timestamp_ns = self._reader.read_next()
+            pub_and_type = self._topic_publishers.get(topic)
+            if pub_and_type is None:
+                continue
+            _, msg_type = pub_and_type
+            msg = deserialize_message(serialized_msg, msg_type)
+            msg_timestamp_ns = self._message_timestamp_ns(msg, int(bag_timestamp_ns))
+            heapq.heappush(
+                self._schedule_heap,
+                (
+                    int(msg_timestamp_ns),
+                    self._schedule_seq,
+                    topic,
+                    serialized_msg,
+                    int(bag_timestamp_ns),
+                    msg,
+                ),
+            )
+            self._schedule_seq += 1
+
+    def _ready_to_start(self) -> bool:
+        required_topics = [
+            "/camera/camera/imu",
+            "/camera/camera/infra1/image_rect_raw",
+            "/camera/camera/infra2/image_rect_raw",
+            "/camera/camera/infra2/camera_info",
+        ]
+        missing = []
+        for topic in required_topics:
+            pub_and_type = self._topic_publishers.get(topic)
+            if pub_and_type is None:
+                continue
+            pub, _ = pub_and_type
+            if pub.get_subscription_count() <= 0:
+                missing.append(topic)
+        if missing:
+            self.get_logger().info(
+                "BagPlayer waiting subscribers before start: %s"
+                % ", ".join(missing)
+            )
+            return False
+        return True
+
+    def _read_next_into_topic_buffer(self):
+        if self._reader_exhausted:
+            return False
+        if not self._reader.has_next():
+            self._reader_exhausted = True
+            return False
+        topic, serialized_msg, bag_timestamp_ns = self._reader.read_next()
+        pub_and_type = self._topic_publishers.get(topic)
+        if pub_and_type is None:
+            return True
+        _, msg_type = pub_and_type
+        msg = deserialize_message(serialized_msg, msg_type)
+        msg_timestamp_ns = self._message_timestamp_ns(msg, int(bag_timestamp_ns))
+        if self._bootstrap_header_start_ns is None:
+            self._bootstrap_header_start_ns = msg_timestamp_ns
+
+        # No-drop replay mode: do not pass through InputAligner here.
+        # Buffer every bag message directly, then publish in global min-timestamp order.
+        q = self._topic_buffers.get(topic)
+        if q is None:
+            return True
+        q.append(
+            (topic, serialized_msg, int(bag_timestamp_ns), msg, int(msg_timestamp_ns))
+        )
+        return True
+
+    def _fill_topic_heads(self):
+        while True:
+            missing = [topic for topic, q in self._topic_buffers.items() if len(q) == 0]
+            if not missing:
+                return
+            if self._reader_exhausted:
+                return
+            if not self._read_next_into_topic_buffer():
+                return
 
     def play_next(self) -> bool:
         """
         Publish the next message from the bag.
         Returns False when there are no more messages.
         """
-        if not self._reader.has_next():
+        if not self._started:
+            if not self._perception_initialized:
+                return True
+            self._started = True
+            self.get_logger().info("BagPlayer start publishing after perception init signal.")
+
+        self._fill_topic_heads()
+        candidate_heads = []
+        for topic, q in self._topic_buffers.items():
+            if q:
+                _, _, bag_timestamp_ns, _, msg_timestamp_ns = q[0]
+                candidate_heads.append((msg_timestamp_ns, bag_timestamp_ns, topic))
+        if not candidate_heads:
             return False
 
-        topic, serialized_msg, timestamp_ns = self._reader.read_next()
-        self._publish_percent_from_timestamp(int(timestamp_ns))
+        selected_msg_ts_ns, _, selected_topic = min(candidate_heads, key=lambda x: x[0])
 
-        # Find publisher + msg type for this topic
+        if self._startup_release_until_ns is None:
+            self._startup_release_until_ns = selected_msg_ts_ns + int(1.0 * 1e9)
+        if self._stats_msg_count < 2 and selected_msg_ts_ns > self._startup_release_until_ns:
+            return True
+
+        if self._use_stats_pacing:
+            progress_ts_ns = self._latest_perception_timestamp_ns
+            if progress_ts_ns is not None and selected_msg_ts_ns > progress_ts_ns + self._publish_ahead_limit_ns:
+                return True
+
+        topic, serialized_msg, timestamp_ns, msg, msg_timestamp_ns = self._topic_buffers[selected_topic].popleft()
         pub_and_type = self._topic_publishers.get(topic)
         if pub_and_type is None:
             # No publisher (should not really happen, but don't crash playback)
             self.get_logger().warn(f"No publisher for topic '{topic}'")
             return True
 
-        pub, msg_type = pub_and_type
+        pub, _ = pub_and_type
 
-        # Deserialize and publish actual message
-        msg = deserialize_message(serialized_msg, msg_type)
-        pub.publish(msg)
+        try:
+            self._publish_percent_from_timestamp(int(timestamp_ns))
+        except Exception as e:
+            self.get_logger().error(
+                f"Failed to publish percent for topic={topic} bag_ts={timestamp_ns}: {e}"
+            )
+        header_stamp_sec = ""
+        header_stamp_nanosec = ""
+        header_timestamp_s = ""
+        if hasattr(msg, "header") and hasattr(msg.header, "stamp"):
+            header_stamp_sec = int(msg.header.stamp.sec)
+            header_stamp_nanosec = int(msg.header.stamp.nanosec)
+            # Keep the same conversion logic as perception_node.stamp2second.
+            header_timestamp_s = np.int64(header_stamp_sec) + np.int64(header_stamp_nanosec) * 1e-9
+        try:
+            self._topic_timestamp_log_file.write(
+                f"{topic},{int(timestamp_ns)},{header_stamp_sec},{header_stamp_nanosec},{header_timestamp_s}\n"
+            )
+            self._topic_timestamp_log_file.flush()
+            if topic in (
+                "/camera/camera/infra1/image_rect_raw",
+                "/camera/camera/infra2/image_rect_raw",
+            ):
+                self.get_logger().info(
+                    f"BagPlayer publish {topic} timestamp: {header_timestamp_s}"
+                )
+            pub.publish(msg)
+        except Exception as e:
+            self.get_logger().error(
+                f"Failed to publish topic={topic} bag_ts={timestamp_ns} header_ts={msg_timestamp_ns}: {e}"
+            )
+            return True
 
         # Publish /clock with the same timestamp (for use_sim_time)
         if self._clock_pub is not None:
-            clock_msg = Clock()
-            clock_msg.clock.sec = int(timestamp_ns // 1_000_000_000)
-            clock_msg.clock.nanosec = int(timestamp_ns % 1_000_000_000)
-            self._clock_pub.publish(clock_msg)
+            try:
+                clock_msg = Clock()
+                clock_msg.clock.sec = int(timestamp_ns // 1_000_000_000)
+                clock_msg.clock.nanosec = int(timestamp_ns % 1_000_000_000)
+                self._clock_pub.publish(clock_msg)
+            except Exception as e:
+                self.get_logger().error(
+                    f"Failed to publish /clock for bag_ts={timestamp_ns}: {e}"
+                )
 
         return True
+
+    def destroy_node(self):
+        if hasattr(self, "_topic_timestamp_log_file") and self._topic_timestamp_log_file is not None:
+            self._topic_timestamp_log_file.close()
+            self._topic_timestamp_log_file = None
+        super().destroy_node()
 
 class BuildMapNode(Node):
     def __init__(self, map_save_path:str, verbose_timer: bool = True):
@@ -470,6 +714,7 @@ class BuildMapNode(Node):
         self.pose_graph_used_pose = {}
         self.relative_pose_constraint = []
         self.last_keyframe_timestamp = None
+        self._processed_keyframe_timestamps = set()
         self.continuous_odom_recorder = OdomPoseRecorder(map_save_path, "mapping")
 
         os.makedirs(f"{map_save_path}", exist_ok=True)
@@ -575,13 +820,25 @@ class BuildMapNode(Node):
             keyframe_image_timestamp = int(keyframe_image_msg.header.stamp.sec * 1e9) + int(keyframe_image_msg.header.stamp.nanosec)
             keyframe_odom_timestamp = int(keyframe_odom_msg.header.stamp.sec * 1e9) + int(keyframe_odom_msg.header.stamp.nanosec)
             keyframe_depth_timestamp = int(depth_msg.header.stamp.sec * 1e9) + int(depth_msg.header.stamp.nanosec)
+            if keyframe_image_timestamp in self._processed_keyframe_timestamps:
+                self.get_logger().warning(
+                    f"Skip duplicate keyframe timestamp: {keyframe_image_timestamp}"
+                )
+                return
+            keyframe_index = len(self.odom) + 1
+            self.get_logger().info(
+                f"Processing keyframe #{keyframe_index}: ts_ns={keyframe_image_timestamp}"
+            )
             if keyframe_image_timestamp != keyframe_odom_timestamp or keyframe_image_timestamp != keyframe_depth_timestamp:
                 self.get_logger().error(f"Keyframe timestamp mismatch: {keyframe_image_timestamp} != {keyframe_odom_timestamp} != {keyframe_depth_timestamp}")
+                return
 
             depth = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding="32FC1")
             odom, _ = msg2np(keyframe_odom_msg)
             infra1_image = self.bridge.imgmsg_to_cv2(keyframe_image_msg, desired_encoding="mono8")
             rgb_image = self.bridge.imgmsg_to_cv2(rgb_image_msg, desired_encoding="bgr8")
+
+        self._processed_keyframe_timestamps.add(keyframe_image_timestamp)
 
         with Timer(name = "save image and depth", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
             self.db.set_entry(keyframe_image_timestamp, depth = depth, infra1_image = infra1_image, rgb_image = rgb_image)

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -18,7 +18,6 @@ from codetiming import Timer
 import os
 import argparse
 import sys
-import heapq
 from collections import deque
 import json
 
@@ -366,12 +365,7 @@ class BagPlayer(Node):
         self._publish_ahead_limit_ns = int(1.0 * 1e9)
         self._stall_cycles = 0
         self._stall_cycle_limit = 5000
-        self._no_odom_bootstrap_limit_ns = int(0.5 * 1e9)
         self._bootstrap_header_start_ns = None
-        self._pending_message = None  # (topic, serialized_msg, bag_timestamp_ns, msg, msg_timestamp_ns)
-        self._schedule_heap = []  # (msg_timestamp_ns, seq, topic, serialized_msg, bag_timestamp_ns, msg)
-        self._schedule_seq = 0
-        self._schedule_lookahead = 256
 
         self.get_logger().info(f"BagPlayer opened bag: {bag_uri}")
         bag_name = os.path.basename(os.path.normpath(bag_uri)) or "bag"
@@ -498,28 +492,6 @@ class BagPlayer(Node):
         self._aligned_queue.append(
             (topic, serialized_msg, int(bag_timestamp_ns), msg, int(msg_timestamp_ns))
         )
-
-    def _fill_schedule_buffer(self):
-        while len(self._schedule_heap) < self._schedule_lookahead and self._reader.has_next():
-            topic, serialized_msg, bag_timestamp_ns = self._reader.read_next()
-            pub_and_type = self._topic_publishers.get(topic)
-            if pub_and_type is None:
-                continue
-            _, msg_type = pub_and_type
-            msg = deserialize_message(serialized_msg, msg_type)
-            msg_timestamp_ns = self._message_timestamp_ns(msg, int(bag_timestamp_ns))
-            heapq.heappush(
-                self._schedule_heap,
-                (
-                    int(msg_timestamp_ns),
-                    self._schedule_seq,
-                    topic,
-                    serialized_msg,
-                    int(bag_timestamp_ns),
-                    msg,
-                ),
-            )
-            self._schedule_seq += 1
 
     def _read_next_into_topic_buffer(self):
         if self._reader_exhausted:

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -11,7 +11,7 @@ from visualization_msgs.msg import Marker, MarkerArray
 from std_msgs.msg import ColorRGBA
 from tinynav.core.math_utils import matrix_to_quat, msg2np, estimate_pose, tf2np, depth_to_cloud
 from sensor_msgs.msg import Image, CameraInfo, CompressedImage
-from message_filters import Subscriber, ApproximateTimeSynchronizer, InputAligner, SimpleFilter
+from message_filters import Subscriber, ApproximateTimeSynchronizer
 from cv_bridge import CvBridge
 import cv2
 from codetiming import Timer
@@ -39,7 +39,6 @@ from scipy.spatial.transform import Rotation as R
 from scipy.ndimage import distance_transform_edt
 
 from rclpy.executors import SingleThreadedExecutor
-from rclpy.duration import Duration
 from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
 from rosbag2_py import SequentialReader, StorageOptions, ConverterOptions
 from rosidl_runtime_py.utilities import get_message
@@ -371,24 +370,6 @@ class BagPlayer(Node):
         self._started = False
         self._topic_buffers = {topic: deque() for topic in self._topic_publishers.keys()}
         self._reader_exhausted = False
-        self._aligned_queue = deque()  # (topic, serialized_msg, bag_timestamp_ns, msg, msg_timestamp_ns)
-        self._aligner_meta = {}
-        self._aligner_topics = [
-            topic for topic in self._topic_publishers.keys() if topic != "/tf_static"
-        ]
-        self._aligner_filters = {topic: SimpleFilter() for topic in self._aligner_topics}
-        if self._aligner_topics:
-            self._input_aligner = InputAligner(
-                Duration(seconds=1.0),
-                *[self._aligner_filters[topic] for topic in self._aligner_topics],
-            )
-            for idx, topic in enumerate(self._aligner_topics):
-                self._input_aligner.setInputPeriod(idx, Duration(seconds=self._topic_period_s(topic)))
-                self._input_aligner.registerCallback(
-                    idx, lambda msg, topic_name=topic: self._on_aligned_message(topic_name, msg)
-                )
-        else:
-            self._input_aligner = None
 
     def _scan_bag_time_range(self, bag_uri: str, storage_id: str, serialization_format: str) -> tuple[int, int]:
         # We have not found a rosbag2_py API that exposes the bag time range directly,
@@ -455,35 +436,14 @@ class BagPlayer(Node):
         if timestamp_s < 0.0:
             return
         self._latest_perception_timestamp_ns = int(timestamp_s * 1e9)
-        self.get_logger().info(
+        self.get_logger().debug(
             f"BagPlayer /slam/data latest timestamp: {timestamp_s:.9f}"
         )
 
-    def _message_timestamp_ns(self, msg, fallback_timestamp_ns: int) -> int:
+    def _message_timestamp_ns(self, msg) -> int | None:
         if hasattr(msg, "header") and hasattr(msg.header, "stamp"):
             return int(msg.header.stamp.sec * 1e9) + int(msg.header.stamp.nanosec)
-        return int(fallback_timestamp_ns)
-
-    def _topic_period_s(self, topic: str) -> float:
-        if topic == "/camera/camera/imu":
-            return 0.005
-        if topic == "/insight/vio_20hz":
-            return 0.05
-        if topic.endswith("/image_rect_raw"):
-            return 1.0 / 30.0
-        return 0.1
-
-    def _on_aligned_message(self, topic: str, msg) -> None:
-        meta = self._aligner_meta.pop(id(msg), None)
-        if meta is None:
-            msg_timestamp_ns = self._message_timestamp_ns(msg, 0)
-            self._aligned_queue.append((topic, None, int(msg_timestamp_ns), msg, int(msg_timestamp_ns)))
-            return
-        serialized_msg, bag_timestamp_ns = meta
-        msg_timestamp_ns = self._message_timestamp_ns(msg, int(bag_timestamp_ns))
-        self._aligned_queue.append(
-            (topic, serialized_msg, int(bag_timestamp_ns), msg, int(msg_timestamp_ns))
-        )
+        return None
 
     def _read_next_into_topic_buffer(self):
         if self._reader_exhausted:
@@ -497,12 +457,17 @@ class BagPlayer(Node):
             return True
         _, msg_type = pub_and_type
         msg = deserialize_message(serialized_msg, msg_type)
-        msg_timestamp_ns = self._message_timestamp_ns(msg, int(bag_timestamp_ns))
+        msg_timestamp_ns = self._message_timestamp_ns(msg)
+        if msg_timestamp_ns is None:
+            self.get_logger().debug(
+                f"Skip topic without header stamp: {topic}"
+            )
+            return True
         if self._bootstrap_header_start_ns is None:
             self._bootstrap_header_start_ns = msg_timestamp_ns
 
-        # No-drop replay mode: do not pass through InputAligner here.
-        # Buffer every bag message directly, then publish in global min-timestamp order.
+        # No-drop replay mode: buffer every bag message directly,
+        # then publish in global min-timestamp order.
         q = self._topic_buffers.get(topic)
         if q is None:
             return True

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -18,6 +18,7 @@ from codetiming import Timer
 import os
 import argparse
 import sys
+import heapq
 from collections import deque
 import json
 
@@ -360,15 +361,17 @@ class BagPlayer(Node):
         self._latest_perception_timestamp_ns = None
         self._perception_initialized = False
         self._use_stats_pacing = False
+        self._state = "WAIT_INIT"
         self._startup_release_until_ns = None
         self._publish_ahead_limit_ns = int(1.0 * 1e9)
         self._stall_cycles = 0
         self._stall_cycle_limit = 5000
-        self._bootstrap_header_start_ns = None
+        self._schedule_window_ns = int(0.5 * 1e9)
+        self._schedule_min_msgs = 64
 
         self.get_logger().info(f"BagPlayer opened bag: {bag_uri}")
-        self._started = False
-        self._topic_buffers = {topic: deque() for topic in self._topic_publishers.keys()}
+        self._schedule_heap = []  # (msg_timestamp_ns, seq, topic, bag_timestamp_ns, msg)
+        self._schedule_seq = 0
         self._reader_exhausted = False
 
     def _scan_bag_time_range(self, bag_uri: str, storage_id: str, serialization_format: str) -> tuple[int, int]:
@@ -445,96 +448,85 @@ class BagPlayer(Node):
             return int(msg.header.stamp.sec * 1e9) + int(msg.header.stamp.nanosec)
         return None
 
-    def _read_next_into_topic_buffer(self):
-        if self._reader_exhausted:
-            return False
-        if not self._reader.has_next():
-            self._reader_exhausted = True
-            return False
-        topic, serialized_msg, bag_timestamp_ns = self._reader.read_next()
-        pub_and_type = self._topic_publishers.get(topic)
-        if pub_and_type is None:
-            return True
-        _, msg_type = pub_and_type
-        msg = deserialize_message(serialized_msg, msg_type)
-        msg_timestamp_ns = self._message_timestamp_ns(msg)
-        if msg_timestamp_ns is None:
-            self.get_logger().debug(
-                f"Skip topic without header stamp: {topic}"
+    def _heap_time_span_ns(self) -> int:
+        if len(self._schedule_heap) <= 1:
+            return 0
+        min_ts = int(self._schedule_heap[0][0])
+        max_ts = max(int(item[0]) for item in self._schedule_heap)
+        return max_ts - min_ts
+
+    def _fill_schedule_buffer(self):
+        while not self._reader_exhausted:
+            if len(self._schedule_heap) >= self._schedule_min_msgs and self._heap_time_span_ns() >= self._schedule_window_ns:
+                return
+            if not self._reader.has_next():
+                self._reader_exhausted = True
+                return
+            topic, serialized_msg, bag_timestamp_ns = self._reader.read_next()
+            pub_and_type = self._topic_publishers.get(topic)
+            if pub_and_type is None:
+                continue
+            _, msg_type = pub_and_type
+            msg = deserialize_message(serialized_msg, msg_type)
+            msg_timestamp_ns = self._message_timestamp_ns(msg)
+            if msg_timestamp_ns is None:
+                self.get_logger().debug(f"Skip topic without header stamp: {topic}")
+                continue
+            heapq.heappush(
+                self._schedule_heap,
+                (
+                    int(msg_timestamp_ns),
+                    self._schedule_seq,
+                    topic,
+                    int(bag_timestamp_ns),
+                    msg,
+                ),
             )
-            return True
-        if self._bootstrap_header_start_ns is None:
-            self._bootstrap_header_start_ns = msg_timestamp_ns
+            self._schedule_seq += 1
 
-        # No-drop replay mode: buffer every bag message directly,
-        # then publish in global min-timestamp order.
-        q = self._topic_buffers.get(topic)
-        if q is None:
-            return True
-        q.append(
-            (topic, serialized_msg, int(bag_timestamp_ns), msg, int(msg_timestamp_ns))
-        )
-        return True
+    def _should_gate_message(self, msg_timestamp_ns: int) -> bool:
+        if self._state == "WAIT_INIT":
+            if not self._perception_initialized:
+                return True
+            self._state = "BOOTSTRAP"
+            self._startup_release_until_ns = msg_timestamp_ns + int(1.0 * 1e9)
+            return False
 
-    def _fill_topic_heads(self):
-        while True:
-            missing = [topic for topic, q in self._topic_buffers.items() if len(q) == 0]
-            if not missing:
-                return
-            if self._reader_exhausted:
-                return
-            if not self._read_next_into_topic_buffer():
-                return
+        if self._state == "BOOTSTRAP":
+            if self._stats_msg_count < 2 and msg_timestamp_ns > self._startup_release_until_ns:
+                return True
+            if self._stats_msg_count >= 2:
+                self._state = "FOLLOW_STATS"
+
+        if self._state == "FOLLOW_STATS" and self._use_stats_pacing:
+            progress_ts_ns = self._latest_perception_timestamp_ns
+            if progress_ts_ns is not None and msg_timestamp_ns > progress_ts_ns + self._publish_ahead_limit_ns:
+                return True
+        return False
 
     def play_next(self) -> bool:
         """
         Publish the next message from the bag.
         Returns False when there are no more messages.
         """
-        if not self._started:
-            if not self._perception_initialized:
-                return True
-            self._started = True
-            self.get_logger().info("BagPlayer start publishing after perception init signal.")
+        self._fill_schedule_buffer()
+        if not self._schedule_heap:
+            return not self._reader_exhausted
 
-        self._fill_topic_heads()
-        candidate_heads = []
-        for topic, q in self._topic_buffers.items():
-            if q:
-                _, _, bag_timestamp_ns, _, msg_timestamp_ns = q[0]
-                candidate_heads.append((msg_timestamp_ns, bag_timestamp_ns, topic))
-        if not candidate_heads:
-            return False
-
-        selected_msg_ts_ns, _, selected_topic = min(candidate_heads, key=lambda x: x[0])
-
-        if self._startup_release_until_ns is None:
-            self._startup_release_until_ns = selected_msg_ts_ns + int(1.0 * 1e9)
-        if self._stats_msg_count < 2 and selected_msg_ts_ns > self._startup_release_until_ns:
+        msg_timestamp_ns, _, topic, bag_timestamp_ns, msg = self._schedule_heap[0]
+        if self._should_gate_message(msg_timestamp_ns):
             self._stall_cycles += 1
             if self._stall_cycles > self._stall_cycle_limit:
                 self.get_logger().warning(
-                    "BagPlayer exiting due to startup gate stall: "
-                    f"stats_msg_count={self._stats_msg_count}, selected_ts_ns={selected_msg_ts_ns}"
+                    "BagPlayer exiting due to gating stall: "
+                    f"state={self._state}, stats_msg_count={self._stats_msg_count}, "
+                    f"msg_ts_ns={msg_timestamp_ns}, progress_ts_ns={self._latest_perception_timestamp_ns}"
                 )
                 return False
             return True
 
-        if self._use_stats_pacing:
-            progress_ts_ns = self._latest_perception_timestamp_ns
-            if progress_ts_ns is not None and selected_msg_ts_ns > progress_ts_ns + self._publish_ahead_limit_ns:
-                self._stall_cycles += 1
-                if self._stall_cycles > self._stall_cycle_limit:
-                    self.get_logger().warning(
-                        "BagPlayer exiting due to pacing stall: "
-                        f"selected_ts_ns={selected_msg_ts_ns}, progress_ts_ns={progress_ts_ns}, "
-                        f"ahead_limit_ns={self._publish_ahead_limit_ns}"
-                    )
-                    return False
-                return True
-
         self._stall_cycles = 0
-        topic, serialized_msg, timestamp_ns, msg, msg_timestamp_ns = self._topic_buffers[selected_topic].popleft()
+        _, _, topic, bag_timestamp_ns, msg = heapq.heappop(self._schedule_heap)
         pub_and_type = self._topic_publishers.get(topic)
         if pub_and_type is None:
             # No publisher (should not really happen, but don't crash playback)
@@ -543,14 +535,14 @@ class BagPlayer(Node):
 
         pub, _ = pub_and_type
 
-        self._publish_percent_from_timestamp(int(timestamp_ns))
+        self._publish_percent_from_timestamp(int(bag_timestamp_ns))
         pub.publish(msg)
 
         # Publish /clock with the same timestamp (for use_sim_time)
         if self._clock_pub is not None:
             clock_msg = Clock()
-            clock_msg.clock.sec = int(timestamp_ns // 1_000_000_000)
-            clock_msg.clock.nanosec = int(timestamp_ns % 1_000_000_000)
+            clock_msg.clock.sec = int(bag_timestamp_ns // 1_000_000_000)
+            clock_msg.clock.nanosec = int(bag_timestamp_ns % 1_000_000_000)
             self._clock_pub.publish(clock_msg)
 
         return True

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -368,14 +368,6 @@ class BagPlayer(Node):
         self._bootstrap_header_start_ns = None
 
         self.get_logger().info(f"BagPlayer opened bag: {bag_uri}")
-        bag_name = os.path.basename(os.path.normpath(bag_uri)) or "bag"
-        self._topic_timestamp_log_path = os.path.join("/tinynav", f"{bag_name}_topic_timestamps.log")
-        self._topic_timestamp_log_file = open(self._topic_timestamp_log_path, "w", encoding="utf-8")
-        self._topic_timestamp_log_file.write(
-            "topic,bag_timestamp_ns,header_stamp_sec,header_stamp_nanosec,header_timestamp_s\n"
-        )
-        self._topic_timestamp_log_file.flush()
-        self.get_logger().info(f"BagPlayer topic timestamp log: {self._topic_timestamp_log_path}")
         self._started = False
         self._topic_buffers = {topic: deque() for topic in self._topic_publishers.keys()}
         self._reader_exhausted = False
@@ -601,10 +593,6 @@ class BagPlayer(Node):
             # Keep the same conversion logic as perception_node.stamp2second.
             header_timestamp_s = np.int64(header_stamp_sec) + np.int64(header_stamp_nanosec) * 1e-9
         try:
-            self._topic_timestamp_log_file.write(
-                f"{topic},{int(timestamp_ns)},{header_stamp_sec},{header_stamp_nanosec},{header_timestamp_s}\n"
-            )
-            self._topic_timestamp_log_file.flush()
             if topic in (
                 "/camera/camera/infra1/image_rect_raw",
                 "/camera/camera/infra2/image_rect_raw",
@@ -632,12 +620,6 @@ class BagPlayer(Node):
                 )
 
         return True
-
-    def destroy_node(self):
-        if hasattr(self, "_topic_timestamp_log_file") and self._topic_timestamp_log_file is not None:
-            self._topic_timestamp_log_file.close()
-            self._topic_timestamp_log_file = None
-        super().destroy_node()
 
 class BuildMapNode(Node):
     def __init__(self, map_save_path:str, verbose_timer: bool = True):

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -543,12 +543,7 @@ class BagPlayer(Node):
 
         pub, _ = pub_and_type
 
-        try:
-            self._publish_percent_from_timestamp(int(timestamp_ns))
-        except Exception as e:
-            self.get_logger().error(
-                f"Failed to publish percent for topic={topic} bag_ts={timestamp_ns}: {e}"
-            )
+        self._publish_percent_from_timestamp(int(timestamp_ns))
         header_stamp_sec = ""
         header_stamp_nanosec = ""
         header_timestamp_s = ""
@@ -574,15 +569,10 @@ class BagPlayer(Node):
 
         # Publish /clock with the same timestamp (for use_sim_time)
         if self._clock_pub is not None:
-            try:
-                clock_msg = Clock()
-                clock_msg.clock.sec = int(timestamp_ns // 1_000_000_000)
-                clock_msg.clock.nanosec = int(timestamp_ns % 1_000_000_000)
-                self._clock_pub.publish(clock_msg)
-            except Exception as e:
-                self.get_logger().error(
-                    f"Failed to publish /clock for bag_ts={timestamp_ns}: {e}"
-                )
+            clock_msg = Clock()
+            clock_msg.clock.sec = int(timestamp_ns // 1_000_000_000)
+            clock_msg.clock.nanosec = int(timestamp_ns % 1_000_000_000)
+            self._clock_pub.publish(clock_msg)
 
         return True
 

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -696,7 +696,12 @@ class MapNode(Node):
             or poi_goal_idx[2] < 0
             or poi_goal_idx[2] >= self.occupancy_map.shape[2]
         ):
+            self.logger.warning(
+                f"Out of occupancy map: start_idx={start_idx}, "
+                f"poi_goal_idx={poi_goal_idx}, map_shape={self.occupancy_map.shape}"
+            )
             return None 
+
         sdf_start_path = search_close_to_sdf_map(start_idx, self.sdf_map, self.occupancy_map, 0.2)
         sdf_goal_path = search_close_to_sdf_map(poi_goal_idx, self.sdf_map, self.occupancy_map, 0.2)
 

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -120,19 +120,6 @@ class PerceptionNode(Node):
         self.right_sub = Subscriber(self, Image, "/camera/camera/infra2/image_rect_raw")
         self.ts = ApproximateTimeSynchronizer([self.left_sub, self.right_sub], queue_size=30, slop=0.02)
         self.ts.registerCallback(self.images_callback)
-        # Debug-only raw subscribers to separate transport reception from ATS pairing.
-        self.left_raw_sub_debug = self.create_subscription(
-            Image,
-            "/camera/camera/infra1/image_rect_raw",
-            self.left_raw_callback_debug,
-            10,
-        )
-        self.right_raw_sub_debug = self.create_subscription(
-            Image,
-            "/camera/camera/infra2/image_rect_raw",
-            self.right_raw_callback_debug,
-            10,
-        )
 
         self.input_aligner_imu_filter = SimpleFilter()
         self.input_aligner_stereo_filter = SimpleFilter()

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -191,12 +191,6 @@ class PerceptionNode(Node):
         self.keyframe_queue = []
         self.logger.info("PerceptionNode initialized.")
         self.process_cnt = 0
-        self.left_raw_count_debug = 0
-        self.right_raw_count_debug = 0
-        self.ats_pair_count_debug = 0
-        self.left_raw_last_stamp_debug = None
-        self.right_raw_last_stamp_debug = None
-        self.ats_pair_last_stamp_debug = None
 
     def info_callback(self, msg):
         if self.K is None:
@@ -618,7 +612,7 @@ class PerceptionNode(Node):
             last_keyframe = self.keyframe_queue[-2]
             current_keyframe = self.keyframe_queue[-1]
             if keyframe_check(last_keyframe.pose, current_keyframe.pose) or current_keyframe.timestamp - last_keyframe.timestamp > 3.0:
-                self.logger.info(
+                self.logger.debug(
                     f"Publish keyframe timestamp: {stamp2second(left_msg.header.stamp):.9f}"
                 )
                 self.keyframe_pose_pub.publish(np2msg(current_keyframe.pose, left_msg.header.stamp, "world", "camera", current_keyframe.velocity))
@@ -658,7 +652,7 @@ def main(args=None):
     perception_node = PerceptionNode(verbose_timer=parsed_args.verbose_timer)
     imu_propagator_node = ImuPropagatorNode()
 
-    executor = rclpy.executors.MultiThreadedExecutor(2)
+    executor = rclpy.executors.MultiThreadedExecutor()
     executor.add_node(perception_node)
     executor.add_node(imu_propagator_node)
     executor.spin()

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -262,20 +262,6 @@ class PerceptionNode(Node):
         if self.input_aligner_seen_stereo:
             self.input_aligner.dispatchMessages()
 
-    def left_raw_callback_debug(self, msg):
-        self.left_raw_count_debug += 1
-        self.left_raw_last_stamp_debug = stamp2second(msg.header.stamp)
-        self.logger.debug(
-            f"left_raw_callback_debug stamp2second={self.left_raw_last_stamp_debug:.9f}"
-        )
-
-    def right_raw_callback_debug(self, msg):
-        self.right_raw_count_debug += 1
-        self.right_raw_last_stamp_debug = stamp2second(msg.header.stamp)
-        self.logger.debug(
-            f"right_raw_callback_debug stamp2second={self.right_raw_last_stamp_debug:.9f}"
-        )
-
     def images_callback(self, left_msg, right_msg):
         self.logger.debug(
             "images_callback stamp2second left=%.9f right=%.9f"
@@ -284,8 +270,6 @@ class PerceptionNode(Node):
                 stamp2second(right_msg.header.stamp),
             )
         )
-        self.ats_pair_count_debug += 1
-        self.ats_pair_last_stamp_debug = stamp2second(left_msg.header.stamp)
         stereo_pair_msg = StereoPairMsg(header=left_msg.header, left_msg=left_msg, right_msg=right_msg)
         self.input_aligner_stereo_filter.signalMessage(stereo_pair_msg)
         self.input_aligner_seen_stereo = True

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -14,7 +14,7 @@ from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from sensor_msgs.msg import Image, Imu, CameraInfo
 from std_msgs.msg import String
-from rclpy.qos import QoSProfile, ReliabilityPolicy
+from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
 from rclpy.duration import Duration
 from tinynav.core.math_utils import rot_from_two_vector, np2msg, np2tf, estimate_pose, se3_inv
 from tinynav.core.math_utils import uf_init, uf_union, uf_all_sets_list
@@ -36,7 +36,7 @@ _KEYFRAME_MIN_DISTANCE = 0.1    # unit: meter
 _KEYFRAME_MIN_ROTATE_DEGREE = 0.1 # unit: degree
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 
 def keyframe_check(T_i, T_j):
@@ -118,14 +118,27 @@ class PerceptionNode(Node):
         self.camerainfo_sub = self.create_subscription(CameraInfo, "/camera/camera/infra2/camera_info", self.info_callback, 10)
         self.left_sub = Subscriber(self, Image, "/camera/camera/infra1/image_rect_raw")
         self.right_sub = Subscriber(self, Image, "/camera/camera/infra2/image_rect_raw")
-        self.ts = ApproximateTimeSynchronizer([self.left_sub, self.right_sub], queue_size=10, slop=0.02)
+        self.ts = ApproximateTimeSynchronizer([self.left_sub, self.right_sub], queue_size=30, slop=0.02)
         self.ts.registerCallback(self.images_callback)
+        # Debug-only raw subscribers to separate transport reception from ATS pairing.
+        self.left_raw_sub_debug = self.create_subscription(
+            Image,
+            "/camera/camera/infra1/image_rect_raw",
+            self.left_raw_callback_debug,
+            10,
+        )
+        self.right_raw_sub_debug = self.create_subscription(
+            Image,
+            "/camera/camera/infra2/image_rect_raw",
+            self.right_raw_callback_debug,
+            10,
+        )
 
         self.input_aligner_imu_filter = SimpleFilter()
         self.input_aligner_stereo_filter = SimpleFilter()
         self.input_aligner = InputAligner(Duration(seconds=1.000), self.input_aligner_imu_filter, self.input_aligner_stereo_filter)
         self.input_aligner.setInputPeriod(0, Duration(seconds=0.005))
-        self.input_aligner.setInputPeriod(1, Duration(seconds=0.01))
+        self.input_aligner.setInputPeriod(1, Duration(seconds=0.033))
         self.input_aligner.registerCallback(0, self._aligned_imu_callback)
         self.input_aligner.registerCallback(1, self._aligned_stereo_callback)
         self.input_aligner_seen_imu = False
@@ -137,7 +150,10 @@ class PerceptionNode(Node):
         self.keyframe_pose_pub = self.create_publisher(Odometry, "/slam/keyframe_odom", 10)
         self.keyframe_image_pub = self.create_publisher(Image, "/slam/keyframe_image", 10)
         self.keyframe_depth_pub = self.create_publisher(Image, "/slam/keyframe_depth", 10)
-        self.stats_pub = self.create_publisher(String, "/slam/data", 10)
+        stats_qos = QoSProfile(depth=10)
+        stats_qos.reliability = ReliabilityPolicy.RELIABLE
+        stats_qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+        self.stats_pub = self.create_publisher(String, "/slam/data", stats_qos)
 
         self.accel_readings = []
         self.last_processed_timestamp = 0.0
@@ -161,15 +177,22 @@ class PerceptionNode(Node):
 
         self.T_imu_body_to_camera = np.array(
                             [[1, 0, 0, 0],
-                             [0, 0, -1, 0], 
+                             [0, 0, -1, 0],
                              [0, 1, 0, 0],
                              [0, 0, 0, 1]])
+        self.stats_pub.publish(String(data=json.dumps({"initialized": True, "timestamp": -1.0})))
 
-        self.imu_measurements = deque(maxlen=1000)
+        self.imu_measurements = deque(maxlen=10000)
 
         self.keyframe_queue = []
         self.logger.info("PerceptionNode initialized.")
         self.process_cnt = 0
+        self.left_raw_count_debug = 0
+        self.right_raw_count_debug = 0
+        self.ats_pair_count_debug = 0
+        self.left_raw_last_stamp_debug = None
+        self.right_raw_last_stamp_debug = None
+        self.ats_pair_last_stamp_debug = None
 
     def info_callback(self, msg):
         if self.K is None:
@@ -199,18 +222,28 @@ class PerceptionNode(Node):
         # if the timestamp jump is too large, it means the IMU is not working properly
         if self.imu_last_received_timestamp is not None and current_timestamp - self.imu_last_received_timestamp > 0.1:
             delta_timestamp = current_timestamp - self.imu_last_received_timestamp
-            self.get_logger().warning(f"IMU timestamp jump {delta_timestamp} s is too large, it means the IMU is not working properly")
+            self.logger.warning(f"IMU timestamp jump {delta_timestamp} s is too large, it means the IMU is not working properly")
         self.imu_last_received_timestamp = current_timestamp
         accel_data = np.array([[imu_msg.linear_acceleration.x], [imu_msg.linear_acceleration.y], [imu_msg.linear_acceleration.z]])
         gyro_data = np.array([[imu_msg.angular_velocity.x], [imu_msg.angular_velocity.y], [imu_msg.angular_velocity.z]])
         self.imu_measurements.append([current_timestamp, accel_data.flatten(), gyro_data.flatten()])
 
     def _aligned_imu_callback(self, imu_msg):
+        self.logger.debug(
+            f"_aligned_imu_callback stamp2second={stamp2second(imu_msg.header.stamp):.9f}"
+        )
         self._process_imu_msg(imu_msg)
 
     def _aligned_stereo_callback(self, stereo_pair_msg):
         left_msg = stereo_pair_msg.left_msg
         right_msg = stereo_pair_msg.right_msg
+        self.logger.debug(
+            " _aligned_stereo_callback stamp2second left=%.9f right=%.9f"
+            % (
+                stamp2second(left_msg.header.stamp),
+                stamp2second(right_msg.header.stamp),
+            )
+        )
         image_timestamp = stamp2second(left_msg.header.stamp)
         if image_timestamp - self.last_processed_timestamp < 0.1333:
             return
@@ -220,16 +253,41 @@ class PerceptionNode(Node):
         with Timer(name="Perception Loop", text="[{name}] Elapsed time: {milliseconds:.0f} ms\n\n", logger=self.logger.info):
             processed = asyncio.run(self.process(left_msg, right_msg))
         if processed:
+            processed["timestamp"] = float(image_timestamp)
             processed["stats"]["loop_ms"] = (time.perf_counter() - loop_start) * 1000.0
             self.stats_pub.publish(String(data=json.dumps(processed)))
 
     def imu_callback(self, imu_msg):
+        self.logger.debug(f"imu_callback stamp2second={stamp2second(imu_msg.header.stamp):.9f}")
         self.input_aligner_imu_filter.signalMessage(imu_msg)
         self.input_aligner_seen_imu = True
         if self.input_aligner_seen_stereo:
             self.input_aligner.dispatchMessages()
 
+    def left_raw_callback_debug(self, msg):
+        self.left_raw_count_debug += 1
+        self.left_raw_last_stamp_debug = stamp2second(msg.header.stamp)
+        self.logger.debug(
+            f"left_raw_callback_debug stamp2second={self.left_raw_last_stamp_debug:.9f}"
+        )
+
+    def right_raw_callback_debug(self, msg):
+        self.right_raw_count_debug += 1
+        self.right_raw_last_stamp_debug = stamp2second(msg.header.stamp)
+        self.logger.debug(
+            f"right_raw_callback_debug stamp2second={self.right_raw_last_stamp_debug:.9f}"
+        )
+
     def images_callback(self, left_msg, right_msg):
+        self.logger.debug(
+            "images_callback stamp2second left=%.9f right=%.9f"
+            % (
+                stamp2second(left_msg.header.stamp),
+                stamp2second(right_msg.header.stamp),
+            )
+        )
+        self.ats_pair_count_debug += 1
+        self.ats_pair_last_stamp_debug = stamp2second(left_msg.header.stamp)
         stereo_pair_msg = StereoPairMsg(header=left_msg.header, left_msg=left_msg, right_msg=right_msg)
         self.input_aligner_stereo_filter.signalMessage(stereo_pair_msg)
         self.input_aligner_seen_stereo = True
@@ -322,7 +380,7 @@ class PerceptionNode(Node):
                 self.K,
                 idx_valid
             )
-            self.logger.debug("Estimated T_kf_curr:\n", T_kf_curr)
+            self.logger.debug(f"Estimated T_kf_curr: \n{T_kf_curr}")
         # for new frame, we first add it as keyframe, if not, we pop it later
         self.keyframe_queue.append(
             Keyframe(
@@ -408,8 +466,8 @@ class PerceptionNode(Node):
                         kf_prev = self.keyframe_queue[i]
                         kf_curr = self.keyframe_queue[j]
 
-                    self.logger.debug("timestamp prev: ", kf_prev.timestamp)
-                    self.logger.debug("timestamp curr: ", kf_curr.timestamp)
+                    self.logger.debug(f"timestamp prev:  {kf_prev.timestamp}")
+                    self.logger.debug(f"timestamp curr:  {kf_curr.timestamp}")
                     with Timer(name="[cached result[1.1/3]]", text="[{name}] Elapsed time: {milliseconds:.03f} ms", logger=self.logger.debug):
                         prev_left_extract_result = await self.superpoint.infer(kf_prev.image)
                     with Timer(name="[cached result[1.2/3]]", text="[{name}] Elapsed time: {milliseconds:.03f} ms", logger=self.logger.debug):
@@ -438,7 +496,6 @@ class PerceptionNode(Node):
 
                         depth = kf_curr.depth
 
-                        logging.debug(f"match cnt: {len(kpt_pre)}")
                         state, _, _, _, inliers = estimate_pose(
                             kpt_pre,
                             kpt_cur,
@@ -454,7 +511,7 @@ class PerceptionNode(Node):
                         else:
                             for idx in range(len(match_indices)):
                                 match_indices[idx] = -1
-                            self.logger.warning(f"match cnt: {len(kpt_pre)} is too small, {len(inlier_set)} inliers.enable velocity constraint")
+                            self.logger.warning(f"keyframe {i} match cnt: {len(kpt_pre)},but PnP {len(inlier_set)} inliers.enable velocity constraint")
                             velocity_constraint = gtsam.PriorFactorVector(V(i), np.zeros(3), gtsam.noiseModel.Diagonal.Sigmas(np.array([0.25, 0.25, 0.25])))
                             graph.add(velocity_constraint)
 
@@ -466,7 +523,7 @@ class PerceptionNode(Node):
                                 idx_curr = j * _M + match_idx
                                 uf_union(idx_prev, idx_curr, uf)
                                 count += 1
-                        self.logger.debug(f"{i} match {j} after Pnp filter count: {count}")
+                        self.logger.debug(f"{i} match {j} {len(kpt_pre)}, Pnp filter count: {count}")
 
             with Timer(name="[found track]", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.logger.debug):
                 tracks = uf_all_sets_list(uf, min_component_size=2)
@@ -557,9 +614,18 @@ class PerceptionNode(Node):
             last_keyframe = self.keyframe_queue[-2]
             current_keyframe = self.keyframe_queue[-1]
             if keyframe_check(last_keyframe.pose, current_keyframe.pose) or current_keyframe.timestamp - last_keyframe.timestamp > 3.0:
+                self.logger.info(
+                    f"Publish keyframe timestamp: {stamp2second(left_msg.header.stamp):.9f}"
+                )
                 self.keyframe_pose_pub.publish(np2msg(current_keyframe.pose, left_msg.header.stamp, "world", "camera", current_keyframe.velocity))
                 self.keyframe_image_pub.publish(left_msg)
                 self.keyframe_depth_pub.publish(depth_msg)
+
+                T_ij = se3_inv(last_keyframe.pose) @ current_keyframe.pose
+                t_diff = np.linalg.norm(T_ij[:3, 3])
+                if t_diff > 2.0:
+                    self.logger.debug(f"keyframe jumps {t_diff} m, exit")
+                    exit(0)
             else:
                 self.keyframe_queue.pop()
 
@@ -582,12 +648,18 @@ def main(args=None):
     rclpy.init(args=args)
     parser = argparse.ArgumentParser(description='Run TinyNav perception node.')
     parser.add_argument('--verbose_timer', action='store_true', help='Print timing for key pipeline stages.')
+    parser.add_argument('--enable_odom_log', action='store_true', help='Write logs to odom.log file.')
+    parser.add_argument('--odom_log_path', type=str, default='odom.log', help='Path to odom log file.')
     parsed_args = parser.parse_args(args=sys.argv[1:] if args is None else args)
+    if parsed_args.enable_odom_log:
+        file_handler = logging.FileHandler(parsed_args.odom_log_path)
+        file_handler.setFormatter(logging.Formatter('%(asctime)s - %(filename)s:%(lineno)d - %(message)s'))
+        logging.getLogger().addHandler(file_handler)
 
     perception_node = PerceptionNode(verbose_timer=parsed_args.verbose_timer)
     imu_propagator_node = ImuPropagatorNode()
 
-    executor = rclpy.executors.MultiThreadedExecutor()
+    executor = rclpy.executors.MultiThreadedExecutor(2)
     executor.add_node(perception_node)
     executor.add_node(imu_propagator_node)
     executor.spin()
@@ -596,5 +668,5 @@ def main(args=None):
     rclpy.shutdown()
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     main()

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -36,7 +36,6 @@ _KEYFRAME_MIN_DISTANCE = 0.1    # unit: meter
 _KEYFRAME_MIN_ROTATE_DEGREE = 0.1 # unit: degree
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def keyframe_check(T_i, T_j):
@@ -167,7 +166,25 @@ class PerceptionNode(Node):
                              [0, 0, -1, 0],
                              [0, 1, 0, 0],
                              [0, 0, 0, 1]])
-        self.stats_pub.publish(String(data=json.dumps({"initialized": True, "timestamp": -1.0})))
+        self.stats_pub.publish(
+            String(
+                data=json.dumps(
+                    {
+                        "initialized": True,
+                        "timestamp": -1.0,
+                        "stats": {"process_cnt": 0, "loop_ms": 0.0},
+                        "metrics": {
+                            "num_keyframes": 0,
+                            "num_tracks": 0,
+                            "num_factors": 0,
+                            "num_variables": 0,
+                            "initial_error": 0.0,
+                            "final_error": 0.0,
+                        },
+                    }
+                )
+            )
+        )
 
         self.imu_measurements = deque(maxlen=10000)
 
@@ -607,12 +624,6 @@ class PerceptionNode(Node):
                 self.keyframe_pose_pub.publish(np2msg(current_keyframe.pose, left_msg.header.stamp, "world", "camera", current_keyframe.velocity))
                 self.keyframe_image_pub.publish(left_msg)
                 self.keyframe_depth_pub.publish(depth_msg)
-
-                T_ij = se3_inv(last_keyframe.pose) @ current_keyframe.pose
-                t_diff = np.linalg.norm(T_ij[:3, 3])
-                if t_diff > 2.0:
-                    self.logger.debug(f"keyframe jumps {t_diff} m, exit")
-                    exit(0)
             else:
                 self.keyframe_queue.pop()
 
@@ -632,6 +643,7 @@ class PerceptionNode(Node):
 
 
 def main(args=None):
+    logging.basicConfig(level=logging.INFO)
     rclpy.init(args=args)
     parser = argparse.ArgumentParser(description='Run TinyNav perception node.')
     parser.add_argument('--verbose_timer', action='store_true', help='Print timing for key pipeline stages.')
@@ -655,5 +667,4 @@ def main(args=None):
     rclpy.shutdown()
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
     main()


### PR DESCRIPTION
## Goal
Control BagPlayer sending speed so perception_node does not get flooded.

When BagPlayer publishes too fast, perception_node subscriber queues can fill and drop messages. Those drops break temporal consistency and can lead to large VIO drift.

## What This PR Changes
- add BagPlayer startup handshake with /slam/data initialization signal
- add stats-driven pacing using /slam/data timestamp feedback from perception_node
- refactor BagPlayer replay scheduler to global timestamp ordering with bounded lookahead window
- add explicit replay state flow (WAIT_INIT, BOOTSTRAP, FOLLOW_STATS)
- add deterministic exit conditions for end-of-bag and gated deadlock cases
- remove obsolete/debug-heavy paths to keep replay behavior predictable

## Expected Impact
- lower risk of flooding perception_node callbacks
- lower risk of subscriber queue overflow and dropped key messages
- more stable timestamp flow into perception and more stable VIO behavior

## Validation
- python -m py_compile tinynav/core/build_map_node.py
- python -m py_compile tinynav/core/perception_node.py
- replay timestamp checks in devcontainer using rosbag2_py
- container import/smoke checks used during iteration
