### PR TITLE
fix(control): limit native math threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ RUN apt-get update && apt-get install -y ros-humble-desktop \
 
 # env
 ENV RMW_FASTRTPS_PUBLICATION_MODE=ASYNCHRONOUS
+# Limit OpenBLAS worker threads globally to avoid high CPU on small NumPy/SciPy
+# workloads on Jetson. See OpenBLAS fix context: https://github.com/OpenMathLib/OpenBLAS/pull/4388
 ENV OPENBLAS_NUM_THREADS=1
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 ENV CYCLONEDDS_URI=/tinynav/scripts/cyclone_dds_localhost.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && apt-get install -y ros-humble-desktop \
 
 # env
 ENV RMW_FASTRTPS_PUBLICATION_MODE=ASYNCHRONOUS
+ENV OPENBLAS_NUM_THREADS=1
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 ENV CYCLONEDDS_URI=/tinynav/scripts/cyclone_dds_localhost.xml
 ENV PATH=$PATH:/usr/src/tensorrt/bin/

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -1,12 +1,3 @@
-import os
-# Limit native math libraries before importing numpy/scipy.
-# On Jetson/OpenBLAS, tiny matrix ops can otherwise spin multiple worker threads
-# and make this low-rate control node look like it uses >100% CPU.
-os.environ.setdefault('OPENBLAS_NUM_THREADS', '1')
-os.environ.setdefault('OMP_NUM_THREADS', '1')
-os.environ.setdefault('MKL_NUM_THREADS', '1')
-os.environ.setdefault('NUMEXPR_NUM_THREADS', '1')
-
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -1,3 +1,12 @@
+import os
+# Limit native math libraries before importing numpy/scipy.
+# On Jetson/OpenBLAS, tiny matrix ops can otherwise spin multiple worker threads
+# and make this low-rate control node look like it uses >100% CPU.
+os.environ.setdefault('OPENBLAS_NUM_THREADS', '1')
+os.environ.setdefault('OMP_NUM_THREADS', '1')
+os.environ.setdefault('MKL_NUM_THREADS', '1')
+os.environ.setdefault('NUMEXPR_NUM_THREADS', '1')
+
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist


### PR DESCRIPTION
## Summary
- limit OpenBLAS/OMP/MKL/NumExpr native worker threads to 1 before importing numpy/scipy in cmd_vel_control
- prevents small matrix operations in the low-rate Python control node from spawning busy native worker threads on Jetson

## Testing
- python3 -m py_compile tinynav/platforms/cmd_vel_control.py
- tested manually on current integration test machine by applying the same change in-place and restarting nav nodes
- observed cmd_vel_control CPU drop from ~170-180% to ~3-4% after warm-up while /cmd_vel remained ~12 Hz

before
<img width="2354" height="1060" alt="image" src="https://github.com/user-attachments/assets/5946a1a5-20a4-4e8e-82a2-63d22aa08719" />

after
<img width="2900" height="1184" alt="image" src="https://github.com/user-attachments/assets/b2a85e16-3745-4d7e-94ff-02a008977b42" />

