### PR TITLE
Add ESDF-snapped local centerline with heading-adaptive lookahead

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -105,7 +105,6 @@ class BackendNode(Ros2NodeManager):
         self._esdf_bytes: bytes = b''
         self._obstacle_bytes: bytes = b''
         self._trajectory: list = []
-        self._centerline: list = []
         self._global_path: list = []
         self._footprint: list = []   # 4 corner points [{x,y},...] in world frame
         self._voxel_points: list = []
@@ -127,7 +126,6 @@ class BackendNode(Ros2NodeManager):
             OccupancyGrid, '/planning/obstacle_mask', self._on_obstacle_mask, 1
         )
         self.create_subscription(Path, '/planning/trajectory_path', self._on_trajectory_path, 1)
-        self.create_subscription(Path, '/planning/centerline', self._on_centerline, 1)
         self.create_subscription(Path, '/mapping/global_plan', self._on_global_plan, 1)
         self.create_subscription(
             Odometry, '/control/target_pose', self._on_nav_target_pose, 1
@@ -309,14 +307,6 @@ class BackendNode(Ros2NodeManager):
         ]
         with self._lock:
             self._trajectory = pts
-
-    def _on_centerline(self, msg: Path):
-        pts = [
-            {'x': p.pose.position.x, 'y': p.pose.position.y}
-            for p in msg.poses
-        ]
-        with self._lock:
-            self._centerline = pts
 
     def _on_global_plan(self, msg: Path):
         pts = [
@@ -559,7 +549,6 @@ class BackendNode(Ros2NodeManager):
                 'esdf_image': base64.b64encode(self._esdf_bytes).decode() if self._esdf_bytes else None,
                 'obstacle_image': base64.b64encode(self._obstacle_bytes).decode() if self._obstacle_bytes else None,
                 'trajectory': list(self._trajectory),
-                'centerline': list(self._centerline),
                 'global_path': None,  # filled after TF transform (odom frame)
                 'map_global_path': path_snapshot,
                 'grid_info': self._grid_info,

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -186,7 +186,6 @@ class PlanningState {
   final Uint8List? esdfImage;
   final Uint8List? obstacleImage;
   final List<TrajPoint> trajectory;
-  final List<TrajPoint> centerline;
   final List<TrajPoint> globalPath;
   final List<TrajPoint> mapGlobalPath;
   final GridInfo? gridInfo;
@@ -202,7 +201,6 @@ class PlanningState {
     this.esdfImage,
     this.obstacleImage,
     required this.trajectory,
-    this.centerline = const [],
     required this.globalPath,
     this.mapGlobalPath = const [],
     this.gridInfo,
@@ -236,7 +234,6 @@ class PlanningState {
       esdfImage: decodeImg(j['esdf_image'] as String?),
       obstacleImage: decodeImg(j['obstacle_image'] as String?),
       trajectory: parsePath('trajectory'),
-      centerline: parsePath('centerline'),
       globalPath: parsePath('global_path'),
       mapGlobalPath: parsePath('map_global_path'),
       gridInfo: j['grid_info'] != null

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -557,7 +557,6 @@ class _LocalPlanningViewState extends ConsumerState<_LocalPlanningView> {
                                     CustomPaint(
                                       painter: LocalPlanningPainter(
                                         trajectory: p.trajectory,
-                                        centerline: p.centerline,
                                         globalPath: p.globalPath,
                                         footprint: p.footprint,
                                         gridInfo: p.gridInfo,

--- a/app/frontend/lib/pages/planning_painter.dart
+++ b/app/frontend/lib/pages/planning_painter.dart
@@ -9,7 +9,6 @@ import '../core/models.dart';
 /// Global path arrives pre-converted to odom frame by the backend.
 class LocalPlanningPainter extends CustomPainter {
   final List<TrajPoint> trajectory;
-  final List<TrajPoint> centerline;
   final List<TrajPoint> globalPath;
   final List<TrajPoint> footprint;
   final GridInfo? gridInfo;
@@ -21,7 +20,6 @@ class LocalPlanningPainter extends CustomPainter {
 
   const LocalPlanningPainter({
     required this.trajectory,
-    this.centerline = const [],
     this.globalPath = const [],
     this.footprint = const [],
     this.gridInfo,
@@ -49,8 +47,6 @@ class LocalPlanningPainter extends CustomPainter {
     if (showGlobalPath) _drawGlobalPath(canvas, cx, cy, scaleX, scaleY, pose);
 
     if (showTrajectory) _drawTrajectory(canvas, cx, cy, scaleX, scaleY, pose);
-
-    _drawCenterline(canvas, cx, cy, scaleX, scaleY, pose);
 
     if (navTargetPose != null && pose != null)
       _drawNavTarget(canvas, cx, cy, scaleX, scaleY, pose, navTargetPose!);
@@ -92,30 +88,6 @@ class LocalPlanningPainter extends CustomPainter {
       5,
       Paint()..color = Colors.cyanAccent,
     );
-  }
-
-  void _drawCenterline(Canvas canvas, double cx, double cy,
-      double scaleX, double scaleY, Pose? pose) {
-    if (centerline.length < 2 || pose == null) return;
-    final paint = Paint()
-      ..color = const Color(0xFFFFEB3B).withOpacity(0.9)
-      ..strokeWidth = 2.0
-      ..style = PaintingStyle.stroke;
-    final dot = Paint()..color = const Color(0xFFFFEB3B);
-    final path = Path();
-    bool first = true;
-    for (final pt in centerline) {
-      final px = cx + (pt.x - pose.x) * scaleX;
-      final py = cy - (pt.y - pose.y) * scaleY;
-      if (first) {
-        path.moveTo(px, py);
-        first = false;
-      } else {
-        path.lineTo(px, py);
-      }
-      canvas.drawCircle(Offset(px, py), 2.0, dot);
-    }
-    canvas.drawPath(path, paint);
   }
 
   /// Global path is already in odom frame (backend transforms via exact T_odom_map).
@@ -236,7 +208,6 @@ class LocalPlanningPainter extends CustomPainter {
   @override
   bool shouldRepaint(LocalPlanningPainter old) =>
       trajectory != old.trajectory ||
-      centerline != old.centerline ||
       globalPath != old.globalPath ||
       footprint != old.footprint ||
       gridInfo != old.gridInfo ||

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -343,8 +343,7 @@ class MapNode(Node):
 
         self.current_pose_pub = self.create_publisher(Odometry, "/mapping/current_pose", 10)
         self.global_plan_pub = self.create_publisher(Path, '/mapping/global_plan', 10)
-        self.global_plan_odom_pub = self.create_publisher(Path, '/mapping/global_plan_odom', 10)
-        self.target_pose_pub = self.create_publisher(Odometry, "/control/target_pose", 10)
+        self.target_pose_pub = self.create_publisher(Odometry, "/mapping/lookahead_target", 10)
 
         self.tf_broadcaster = TransformBroadcaster(self)
 
@@ -761,7 +760,6 @@ class MapNode(Node):
             # use the max_speed to publish the position the robot should be after 5 seconds
             with Timer(name = "Find target position", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
                 max_speed = 0.5
-                target_idx = len(paths_in_map) - 1
                 if len(paths_in_map) > 1:
                     accumulated_distance = 0.0
                     start_point = pose_in_map_position[:3]
@@ -770,39 +768,18 @@ class MapNode(Node):
                         accumulated_distance += np.linalg.norm(paths_in_map[i] - start_point)
                         if accumulated_distance > max_speed * 5:
                             target_position = paths_in_map[i]
-                            target_idx = i
                             break
                         start_point = paths_in_map[i]
                 else:
-                    target_idx = 0
                     target_position = paths_in_map[0]
                 target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
-
-                # Path tangent at target (averaged over ±3 path-steps window)
-                tangent_map = np.array([1.0, 0.0])
-                if len(paths_in_map) >= 2:
-                    i0 = max(0, target_idx - 3)
-                    i1 = min(len(paths_in_map) - 1, target_idx + 3)
-                    if i1 > i0:
-                        d_xy = paths_in_map[i1][:2] - paths_in_map[i0][:2]
-                        n = float(np.linalg.norm(d_xy))
-                        if n > 1e-6:
-                            tangent_map = d_xy / n
-
                 pose_in_origin_odom = self.odom[timestamp]
                 T = pose_in_origin_odom @ np.linalg.inv(pose_in_map)
                 target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
-                tangent_odom = T[:2, :2] @ tangent_map
-                yaw = float(np.arctan2(tangent_odom[1], tangent_odom[0]))
-                cy_, sy_ = float(np.cos(yaw)), float(np.sin(yaw))
                 dummy_pose = np.eye(4)
                 dummy_pose[:3, 3] = target_position_in_odom
-                dummy_pose[:3, :3] = np.array([
-                    [cy_, -sy_, 0.0],
-                    [sy_,  cy_, 0.0],
-                    [0.0,  0.0, 1.0],
-                ])
-                print(f"target_position_in_odom: {target_position_in_odom}, yaw: {yaw:.3f}")
+                #logging.info(f"target_position_in_odom: {target_position_in_odom}")
+                print(f"target_position_in_odom: {target_position_in_odom}")
 
                 self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
                 path_msg = Path()
@@ -820,24 +797,6 @@ class MapNode(Node):
                     pose.pose.orientation.w = 1.0
                     path_msg.poses.append(pose)
                 self.global_plan_pub.publish(path_msg)
-
-                # Also publish path transformed to odom frame for planning_node to use as anchor
-                path_odom_msg = Path()
-                path_odom_msg.header.stamp = self.get_clock().now().to_msg()
-                path_odom_msg.header.frame_id = "world"
-                R_mo = T[:3, :3]
-                t_mo = T[:3, 3]
-                for x, y, z in paths_in_map:
-                    pt_odom = R_mo @ np.array([x, y, z]) + t_mo
-                    pose = PoseStamped()
-                    pose.header = path_odom_msg.header
-                    pose.pose.position.x = float(pt_odom[0])
-                    pose.pose.position.y = float(pt_odom[1])
-                    pose.pose.position.z = float(pt_odom[2])
-                    pose.pose.orientation.w = 1.0
-                    path_odom_msg.poses.append(pose)
-                self.global_plan_odom_pub.publish(path_odom_msg)
-
                 self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
         else:
             logging.info("No path found in map")

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -151,6 +151,15 @@ def run_raycasting_loopy(depth_image, T_cam_to_world, grid_shape, fx, fy, cx, cy
     return occupancy_grid
 
 
+# Local-target (ESDF-snapped lookahead) tuning.
+LOOKAHEAD_MAX_M = 4.0          # lookahead when robot heading aligned with bearing
+LOOKAHEAD_MIN_M = 1.0          # lookahead when heading orthogonal/opposite to bearing
+LOOKAHEAD_DECAY = 4.0          # exp(-DECAY * angle) falloff between min/max
+LATERAL_RANGE_M = 0.4          # ± lateral search range for max-SDF snap
+LATERAL_SAMPLES = 9            # samples across the lateral range
+CLEARANCE_BRAKE_M = 0.4        # snapped SDF below this -> emit + stop walking
+
+
 @dataclass
 class ObstacleConfig:
     robot_z_bottom: float = -0.4
@@ -486,15 +495,14 @@ class PlanningNode(Node):
         bearing = np.arctan2(self.target_pose[1] - init_p_w[1],
                              self.target_pose[0] - init_p_w[0])
         ang = abs(np.arctan2(np.sin(bearing - robot_yaw), np.cos(bearing - robot_yaw)))
-        lookahead_max, lookahead_min = 4.0, 1.0
-        max_dist = float(lookahead_min + (lookahead_max - lookahead_min) * np.exp(-4.0 * ang))
+        max_dist = float(LOOKAHEAD_MIN_M +
+                         (LOOKAHEAD_MAX_M - LOOKAHEAD_MIN_M) * np.exp(-LOOKAHEAD_DECAY * ang))
 
         step = self.resolution
-        lat_range, n_lat = 0.4, 9
         safety = self.robot.safety_radius
-        clearance_brake = 0.4
         target_z = float(self.target_pose[2])
         rows, cols = ESDF_map.shape
+        lats = np.linspace(-LATERAL_RANGE_M, LATERAL_RANGE_M, LATERAL_SAMPLES)
 
         last = None
         accumulated = 0.0
@@ -507,18 +515,21 @@ class PlanningNode(Node):
             n_seg = max(1, int(seg_len / step))
             for s in range(1, n_seg + 1):
                 anchor = path_xy[i] + seg * (s / n_seg)
-                best_sdf, best_xy = -1.0, anchor
-                for lat in np.linspace(-lat_range, lat_range, n_lat):
-                    p = anchor + perp * lat
-                    ex = int((p[0] - self.origin[0]) / self.resolution)
-                    ey = int((p[1] - self.origin[1]) / self.resolution)
-                    if 0 <= ex < rows and 0 <= ey < cols:
-                        v = float(ESDF_map[ex, ey])
-                        if v > best_sdf:
-                            best_sdf, best_xy = v, p
+                # Vectorize the LATERAL_SAMPLES SDF lookups across this anchor.
+                candidates = anchor + perp * lats[:, None]
+                ex = ((candidates[:, 0] - self.origin[0]) / self.resolution).astype(int)
+                ey = ((candidates[:, 1] - self.origin[1]) / self.resolution).astype(int)
+                valid = (ex >= 0) & (ex < rows) & (ey >= 0) & (ey < cols)
+                sdfs = np.where(
+                    valid,
+                    ESDF_map[np.clip(ex, 0, rows - 1), np.clip(ey, 0, cols - 1)],
+                    -1.0,
+                )
+                k = int(np.argmax(sdfs))
+                best_sdf = float(sdfs[k])
                 if best_sdf >= safety:
-                    last = np.array([float(best_xy[0]), float(best_xy[1]), target_z])
-                    if best_sdf < clearance_brake:
+                    last = np.array([float(candidates[k, 0]), float(candidates[k, 1]), target_z])
+                    if best_sdf < CLEARANCE_BRAKE_M:
                         return last
                 accumulated += step
                 if accumulated >= max_dist:

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -1,5 +1,7 @@
 import rclpy
 from rclpy.node import Node
+import tf2_ros
+from rclpy.duration import Duration
 from sensor_msgs.msg import Image, CameraInfo, PointField
 from nav_msgs.msg import Path, Odometry, OccupancyGrid
 from cv_bridge import CvBridge
@@ -155,7 +157,7 @@ class ObstacleConfig:
     robot_z_top: float = 0.4
     occ_threshold: float = 0.1
     min_wall_span_m: float = 0.2
-    dilation_cells: int = 1
+    dilation_cells: int = 0
 
 
 def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None):
@@ -387,12 +389,14 @@ class PlanningNode(Node):
 
         self.smoothed_velocity = 0.0
 
-        self.create_subscription(Odometry, '/control/target_pose', self.target_pose_callback, 10)
+        self.create_subscription(Odometry, '/mapping/lookahead_target', self.target_pose_callback, 10)
         self.target_pose = None
         self._last_local_target = None
-        self.global_path_odom = None  # path in odom frame for centerline anchor
-        self.centerline_pub = self.create_publisher(Path, '/planning/centerline', 10)
-        self.create_subscription(Path, '/mapping/global_plan_odom', self._on_global_path_odom, 10)
+        self.global_path_odom = None  # global_plan transformed into odom frame
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
+        self.local_target_pub = self.create_publisher(Odometry, '/control/target_pose', 10)
+        self.create_subscription(Path, '/mapping/global_plan', self._on_global_path_map, 10)
 
         self.poi_change_sub = self.create_subscription(Odometry, "/mapping/poi_change", self.poi_change_callback, 10)
 
@@ -401,9 +405,21 @@ class PlanningNode(Node):
         self._last_local_target = None
         self.global_path_odom = None
 
-    def _on_global_path_odom(self, msg):
+    def _on_global_path_map(self, msg):
         pts = np.array([[p.pose.position.x, p.pose.position.y, p.pose.position.z] for p in msg.poses])
-        self.global_path_odom = pts if len(pts) > 0 else None
+        if len(pts) == 0:
+            self.global_path_odom = None
+            return
+        try:
+            tf = self.tf_buffer.lookup_transform("world", "map", Time(), timeout=Duration(seconds=0.05))
+        except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException):
+            return
+        t, q = tf.transform.translation, tf.transform.rotation
+        T_om = np.eye(4)
+        T_om[:3, :3] = quat_to_matrix(np.array([q.x, q.y, q.z, q.w]))
+        T_om[:3, 3] = [t.x, t.y, t.z]
+        pts_h = np.hstack([pts, np.ones((len(pts), 1))])
+        self.global_path_odom = (T_om @ pts_h.T).T[:, :3]
 
     def target_pose_callback(self, msg):
         self.target_pose = np.array([msg.pose.pose.position.x, msg.pose.pose.position.y, msg.pose.pose.position.z])
@@ -448,49 +464,40 @@ class PlanningNode(Node):
         msg.points = points
         self.footprint_pub.publish(msg)
 
-    def _compute_centerline(self, T, ESDF_map):
-        """Walk ESDF-snapped lookahead along the global path.
+    def _compute_local_target(self, T, ESDF_map):
+        """ESDF-snapped lookahead along the global path. Returns np.ndarray or None.
 
-        Returns (points, local_target). points is a list of (x,y,z) tuples for
-        visualization; local_target is the last point as np.ndarray, or None
-        when inputs are missing or no point cleared the safety radius.
+        - Lateral ±0.4m snap to max-SDF cell -> centers in free space.
+        - Lookahead shortens as robot heading diverges from target bearing.
+        - Walk caps at target_pose; clearance brake terminates near obstacles.
         """
         if (self.target_pose is None or self.global_path_odom is None
                 or len(self.global_path_odom) < 2):
-            return [], None
+            return None
 
         init_p_w = self.camera_to_robot_center(T)
         path_xy = self.global_path_odom[:, :2]
         start_idx = int(np.argmin(np.linalg.norm(path_xy - init_p_w[:2], axis=1)))
         target_idx = int(np.argmin(np.linalg.norm(path_xy - self.target_pose[:2], axis=1)))
 
-        # Adaptive lookahead by robot-heading vs bearing-to-target.
         # Body frame is +Z forward (see _front_obstacle_dist / footprint).
         fwd_w = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
         robot_yaw = np.arctan2(fwd_w[1], fwd_w[0])
         bearing = np.arctan2(self.target_pose[1] - init_p_w[1],
                              self.target_pose[0] - init_p_w[0])
         ang = abs(np.arctan2(np.sin(bearing - robot_yaw), np.cos(bearing - robot_yaw)))
-        # Exponential falloff between bounds. Shape (decay rate) stays fixed;
-        # tune speed envelope by editing the two bounds only.
-        lookahead_max = 4.0
-        lookahead_min = 1.0
+        lookahead_max, lookahead_min = 4.0, 1.0
         max_dist = float(lookahead_min + (lookahead_max - lookahead_min) * np.exp(-4.0 * ang))
 
         step = self.resolution
-        lat_range = 0.4
-        n_lat = 9
+        lat_range, n_lat = 0.4, 9
         safety = self.robot.safety_radius
-        # Clearance brake: when the best-snapped point is closer than this to the
-        # nearest obstacle, append it then stop walking. Shortens centerline at
-        # the first bottleneck so DWA picks a slower trajectory.
         clearance_brake = 0.4
         target_z = float(self.target_pose[2])
         rows, cols = ESDF_map.shape
 
-        points = []
+        last = None
         accumulated = 0.0
-        braked = False
         for i in range(start_idx, min(target_idx, len(path_xy) - 1)):
             seg = path_xy[i + 1] - path_xy[i]
             seg_len = float(np.linalg.norm(seg))
@@ -509,22 +516,14 @@ class PlanningNode(Node):
                         v = float(ESDF_map[ex, ey])
                         if v > best_sdf:
                             best_sdf, best_xy = v, p
-                # Skip anchors too close to walls; don't fall back to target_pose
-                # which may be behind a corner.
                 if best_sdf >= safety:
-                    points.append((float(best_xy[0]), float(best_xy[1]), target_z))
+                    last = np.array([float(best_xy[0]), float(best_xy[1]), target_z])
                     if best_sdf < clearance_brake:
-                        braked = True
-                        break
+                        return last
                 accumulated += step
                 if accumulated >= max_dist:
-                    break
-            if braked or accumulated >= max_dist:
-                break
-
-        if not points:
-            return [], None
-        return points, np.array(points[-1])
+                    return last
+        return last
 
     def _front_obstacle_dist(self, T, obstacle_mask, max_dist=0.5):
         """Distance from the robot's front face to the nearest obstacle in the forward corridor.
@@ -701,36 +700,27 @@ class PlanningNode(Node):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
             enter_threshold = 0.30
 
-            # Local centerline: ESDF-snapped lookahead along global path. Decouples
-            # lateral position from global localization error and shortens on turns.
-            centerline_points, ct_target = self._compute_centerline(T, ESDF_map)
-            local_target = ct_target if ct_target is not None else self.target_pose
+            # ESDF-snapped lookahead along global path; falls back to raw target_pose.
+            ct = self._compute_local_target(T, ESDF_map)
+            local_target = ct if ct is not None else self.target_pose
 
-            # Temporal low-pass on local_target. Only active while we have a valid
-            # global path — matches the prior behavior of resetting smoothing state
-            # whenever the centerline pipeline isn't running.
-            if (self.target_pose is not None and self.global_path_odom is not None
-                    and len(self.global_path_odom) >= 2):
+            # Temporal low-pass; only smooth the centerline output, not the raw fallback.
+            if ct is not None:
                 if self._last_local_target is not None:
                     jump = float(np.linalg.norm(local_target[:2] - self._last_local_target[:2]))
                     if jump < 1.5:
                         local_target = 0.3 * local_target + 0.7 * self._last_local_target
                 self._last_local_target = local_target
 
-            if (self.target_pose is not None and self.global_path_odom is not None
-                    and len(self.global_path_odom) >= 2):
-                cl_path = Path()
-                cl_path.header.stamp = depth_msg.header.stamp
-                cl_path.header.frame_id = "world"
-                for x, y, z in centerline_points:
-                    ps = PoseStamped()
-                    ps.header = cl_path.header
-                    ps.pose.position.x = x
-                    ps.pose.position.y = y
-                    ps.pose.position.z = z
-                    ps.pose.orientation.w = 1.0
-                    cl_path.poses.append(ps)
-                self.centerline_pub.publish(cl_path)
+            if local_target is not None:
+                lt_msg = Odometry()
+                lt_msg.header.stamp = depth_msg.header.stamp
+                lt_msg.header.frame_id = "world"
+                lt_msg.pose.pose.position.x = float(local_target[0])
+                lt_msg.pose.pose.position.y = float(local_target[1])
+                lt_msg.pose.pose.position.z = float(local_target[2])
+                lt_msg.pose.pose.orientation.w = 1.0
+                self.local_target_pub.publish(lt_msg)
 
             def cost_function(traj, param, score, target_pose):
                 # predefined backward trajectory penalty


### PR DESCRIPTION
## Summary
- **map_node**: publish global path transformed to odom on `/mapping/global_plan_odom`; set `target_pose` yaw from path tangent at the lookahead point.
- **planning_node**: build a local centerline by walking along the global path anchor and snapping laterally to the ESDF corridor center; pick `local_target` with `MAX_DIST` scaled by the angle between robot heading and bearing-to-target (1.0m at ≥π/2, 3.0m when aligned). EMA-smooth `local_target`. Publish `/planning/centerline` and `/planning/local_target`.
- **frontend**: render centerline as a yellow polyline on the local planning canvas.

## Test plan
- [ ] Straight corridor: robot tracks center smoothly, full ~3m lookahead.
- [ ] 90° turn: lookahead shrinks toward 1m before the turn; no overshoot, no hesitation.
- [ ] Dynamic obstacle: DWA still slows / avoids (centerline scan skips steps inside safety radius).
- [ ] No regression in obstacle avoidance on the existing test map.