### PR TITLE
fix(perception): reuse async loop for LightGlue cache hits

### DIFF
--- a/tests/test_models_trt.py
+++ b/tests/test_models_trt.py
@@ -99,72 +99,78 @@ def test_lightglue_cache_hit_with_consecutive_salted_pairs():
         salted = np.clip(base.astype(np.int16) + noise, 0, 255).astype(np.uint8)
         images.append(salted)
 
-    async def _one_perception_style_round():
-        n_window = 5
-        keyframe_queue = []
-        sp_s = 0.0
-        lg_s = 0.0
-        match_signatures = []
-        sliding_reuse_checks = 0
-        sliding_reuse_hits = 0
-        seen_pairs = set()
+    n_window = 5
+    keyframe_queue = []
+    sp_s = 0.0
+    lg_s = 0.0
+    match_signatures = []
+    sliding_reuse_checks = 0
+    sliding_reuse_hits = 0
+    seen_pairs = set()
+    loop = asyncio.new_event_loop()
 
-        async def _run_pair(img_a, img_b):
-            nonlocal sp_s, lg_s
-            t_sp = time.perf_counter()
-            r0 = await superpoint.infer(img_a)
-            r1 = await superpoint.infer(img_b)
-            sp_s += time.perf_counter() - t_sp
+    async def _infer_two_images_and_match(frame_idx, new_img):
+        nonlocal sliding_reuse_checks, sliding_reuse_hits
+        local_signatures = []
 
-            t_lg = time.perf_counter()
+        # 1) infer/match previous keyframe with new image
+        prev_idx, prev_img = keyframe_queue[-1]
+        process_key = (prev_idx, frame_idx)
+        r0 = await superpoint.infer(prev_img)
+        r1 = await superpoint.infer(new_img)
+        m = await lightglue.infer(
+            r0["kpts"], r1["kpts"],
+            r0["descps"], r1["descps"],
+            r0["mask"], r1["mask"],
+            prev_img.shape, new_img.shape,
+        )
+        local_signatures.append(int(np.sum(m["match_indices"] != -1)))
+        seen_pairs.add(process_key)
+
+        # 2) append new keyframe into sliding window
+        keyframe_queue.append((frame_idx, new_img))
+        if len(keyframe_queue) > n_window:
+            keyframe_queue.pop(0)
+
+        # 3) sliding-window consecutive pairs
+        start = max(0, len(keyframe_queue) - n_window)
+        window = keyframe_queue[start:]
+        for i in range(0, len(window) - 1):
+            info_before_window = lightglue.infer.cache_info()
+            idx_a, img_a_w = window[i]
+            idx_b, img_b_w = window[i + 1]
+            pair_key = (idx_a, idx_b)
+            r0 = await superpoint.infer(img_a_w)
+            r1 = await superpoint.infer(img_b_w)
             m = await lightglue.infer(
                 r0["kpts"], r1["kpts"],
                 r0["descps"], r1["descps"],
                 r0["mask"], r1["mask"],
-                img_a.shape, img_b.shape,
+                img_a_w.shape, img_b_w.shape,
             )
-            lg_s += time.perf_counter() - t_lg
-            return m
+            local_signatures.append(int(np.sum(m["match_indices"] != -1)))
 
-        for frame_idx, img in enumerate(images):
+            if pair_key in seen_pairs:
+                sliding_reuse_checks += 1
+                window_delta_hit = lightglue.infer.cache_info().hits - info_before_window.hits
+                if window_delta_hit >= 1:
+                    sliding_reuse_hits += 1
+            seen_pairs.add(pair_key)
+
+        return local_signatures
+
+    for frame_idx, img in enumerate(images):
+        if len(keyframe_queue) < 1:
             keyframe_queue.append((frame_idx, img))
-            if len(keyframe_queue) < 2:
-                continue
+            continue
 
-            # Perception process(): prev/current for newest frame.
-            prev_idx, prev_img = keyframe_queue[-2]
-            curr_idx, curr_img = keyframe_queue[-1]
-            process_key = (prev_idx, curr_idx)
-            m = await _run_pair(prev_img, curr_img)
-            match_signatures.append(int(np.sum(m["match_indices"] != -1)))
-            seen_pairs.add(process_key)
+        frame_signatures = loop.run_until_complete(_infer_two_images_and_match(frame_idx, img))
+        #frame_signatures = asyncio.run(_infer_two_images_and_match(frame_idx, img))
+        match_signatures.extend(frame_signatures)
 
-            # Perception cached association loop: adjacent pairs in last _N keyframes.
-            start = max(0, len(keyframe_queue) - n_window)
-            for i in range(start, len(keyframe_queue) - 1):
-                info_before_window = lightglue.infer.cache_info()
-                idx_a, img_a = keyframe_queue[i]
-                idx_b, img_b = keyframe_queue[i + 1]
-                pair_key = (idx_a, idx_b)
-                m2 = await _run_pair(img_a, img_b)
-                match_signatures.append(int(np.sum(m2["match_indices"] != -1)))
-
-                # Any pair already inferred earlier in this round should hit here.
-                if pair_key in seen_pairs:
-                    sliding_reuse_checks += 1
-                    window_delta_hit = lightglue.infer.cache_info().hits - info_before_window.hits
-                    if window_delta_hit >= 1:
-                        sliding_reuse_hits += 1
-                seen_pairs.add(pair_key)
-
-            if len(keyframe_queue) > n_window:
-                keyframe_queue.pop(0)
-
-        return match_signatures, sp_s, lg_s, sliding_reuse_checks, sliding_reuse_hits, lightglue.infer.cache_info()
-
-    (
-        sig, sp_s, lg_s, sliding_reuse_checks, sliding_reuse_hits, info_final
-    ) = asyncio.run(_one_perception_style_round())
+    sig = match_signatures
+    info_final = lightglue.infer.cache_info()
+    loop.close()
 
     assert sliding_reuse_checks > 0, "No sliding-window reuse checks were performed."
     assert sliding_reuse_hits == sliding_reuse_checks, (

--- a/tests/test_models_trt.py
+++ b/tests/test_models_trt.py
@@ -25,6 +25,160 @@ def test_superpoint_trt_with_cache():
     assert np.array_equal(extract_result_origin['kpts'], extract_result_first['kpts']), "Cached first kpts result does not match original result."
     assert np.array_equal(extract_result_origin['descps'], extract_result_first['descps']), "Cached first descps result does not match original result."
 
+
+def test_superpoint_trt_cache_hit_with_32_salted_images():
+    """
+    Build 32 salted variants from tests/data/000000.png and run SuperPoint twice.
+    Verify second pass hits async LRU cache.
+    """
+    superpoint = SuperPointTRT()
+    superpoint.infer.cache_clear()
+
+    base_path = "/tinynav/tests/data/000000.png"
+    base = cv2.imread(base_path, cv2.IMREAD_GRAYSCALE)
+    assert base is not None, f"Failed to load {base_path}"
+
+    rng = np.random.default_rng(42)
+    images = []
+    for _ in range(32):
+        noise = rng.integers(-8, 9, size=base.shape, dtype=np.int16)
+        salted = np.clip(base.astype(np.int16) + noise, 0, 255).astype(np.uint8)
+        images.append(salted)
+
+    async def _run_two_pass():
+        t0 = time.perf_counter()
+        first = [await superpoint.infer(img) for img in images]
+        first_elapsed_local = time.perf_counter() - t0
+        info_first = superpoint.infer.cache_info()
+
+        t1 = time.perf_counter()
+        second = [await superpoint.infer(img) for img in images]
+        second_elapsed_local = time.perf_counter() - t1
+        info_second = superpoint.infer.cache_info()
+        return first, second, first_elapsed_local, second_elapsed_local, info_first, info_second
+
+    first_results, second_results, first_elapsed, second_elapsed, info_after_first, info_after_second = asyncio.run(_run_two_pass())
+
+    for r0, r1 in zip(first_results, second_results):
+        assert np.array_equal(r0["kpts"], r1["kpts"])
+        assert np.array_equal(r0["descps"], r1["descps"])
+        assert np.array_equal(r0["mask"], r1["mask"])
+
+    hits_gained = info_after_second.hits - info_after_first.hits
+    assert hits_gained >= len(images), (
+        f"Expected at least {len(images)} cache hits on second pass, got {hits_gained}. "
+        f"cache_info after first={info_after_first}, after second={info_after_second}"
+    )
+
+    print(
+        f"SuperPoint cache test: first={first_elapsed:.3f}s second={second_elapsed:.3f}s "
+        f"hits_gained={hits_gained}"
+    )
+
+
+def test_lightglue_cache_hit_with_consecutive_salted_pairs():
+    """
+    Follow perception_node infer pattern:
+      1) current-frame prev/current matching
+      2) sliding-window (_N=5) adjacent-pair association loop
+    Run two rounds and verify LightGlue cache hits on round 2.
+    """
+    superpoint = SuperPointTRT()
+    lightglue = LightGlueTRT()
+    superpoint.infer.cache_clear()
+    lightglue.infer.cache_clear()
+
+    base_path = "/tinynav/tests/data/000000.png"
+    base = cv2.imread(base_path, cv2.IMREAD_GRAYSCALE)
+    assert base is not None, f"Failed to load {base_path}"
+
+    rng = np.random.default_rng(123)
+    images = []
+    for _ in range(500):
+        noise = rng.integers(-8, 9, size=base.shape, dtype=np.int16)
+        salted = np.clip(base.astype(np.int16) + noise, 0, 255).astype(np.uint8)
+        images.append(salted)
+
+    async def _one_perception_style_round():
+        n_window = 5
+        keyframe_queue = []
+        sp_s = 0.0
+        lg_s = 0.0
+        match_signatures = []
+        sliding_reuse_checks = 0
+        sliding_reuse_hits = 0
+        seen_pairs = set()
+
+        async def _run_pair(img_a, img_b):
+            nonlocal sp_s, lg_s
+            t_sp = time.perf_counter()
+            r0 = await superpoint.infer(img_a)
+            r1 = await superpoint.infer(img_b)
+            sp_s += time.perf_counter() - t_sp
+
+            t_lg = time.perf_counter()
+            m = await lightglue.infer(
+                r0["kpts"], r1["kpts"],
+                r0["descps"], r1["descps"],
+                r0["mask"], r1["mask"],
+                img_a.shape, img_b.shape,
+            )
+            lg_s += time.perf_counter() - t_lg
+            return m
+
+        for frame_idx, img in enumerate(images):
+            keyframe_queue.append((frame_idx, img))
+            if len(keyframe_queue) < 2:
+                continue
+
+            # Perception process(): prev/current for newest frame.
+            prev_idx, prev_img = keyframe_queue[-2]
+            curr_idx, curr_img = keyframe_queue[-1]
+            process_key = (prev_idx, curr_idx)
+            m = await _run_pair(prev_img, curr_img)
+            match_signatures.append(int(np.sum(m["match_indices"] != -1)))
+            seen_pairs.add(process_key)
+
+            # Perception cached association loop: adjacent pairs in last _N keyframes.
+            start = max(0, len(keyframe_queue) - n_window)
+            for i in range(start, len(keyframe_queue) - 1):
+                info_before_window = lightglue.infer.cache_info()
+                idx_a, img_a = keyframe_queue[i]
+                idx_b, img_b = keyframe_queue[i + 1]
+                pair_key = (idx_a, idx_b)
+                m2 = await _run_pair(img_a, img_b)
+                match_signatures.append(int(np.sum(m2["match_indices"] != -1)))
+
+                # Any pair already inferred earlier in this round should hit here.
+                if pair_key in seen_pairs:
+                    sliding_reuse_checks += 1
+                    window_delta_hit = lightglue.infer.cache_info().hits - info_before_window.hits
+                    if window_delta_hit >= 1:
+                        sliding_reuse_hits += 1
+                seen_pairs.add(pair_key)
+
+            if len(keyframe_queue) > n_window:
+                keyframe_queue.pop(0)
+
+        return match_signatures, sp_s, lg_s, sliding_reuse_checks, sliding_reuse_hits, lightglue.infer.cache_info()
+
+    (
+        sig, sp_s, lg_s, sliding_reuse_checks, sliding_reuse_hits, info_final
+    ) = asyncio.run(_one_perception_style_round())
+
+    assert sliding_reuse_checks > 0, "No sliding-window reuse checks were performed."
+    assert sliding_reuse_hits == sliding_reuse_checks, (
+        f"Expected all reused sliding-window pairs to hit cache, got "
+        f"{sliding_reuse_hits}/{sliding_reuse_checks}. cache_info={info_final}"
+    )
+
+    print(
+        "LightGlue cache test: "
+        f"sliding_reuse_hits={sliding_reuse_hits}/{sliding_reuse_checks} "
+        f"superpoint_total={sp_s:.3f}s lightglue_total={lg_s:.3f}s "
+        f"cache_info={info_final}"
+    )
+
 def test_lightglue_trt_with_cache():
     lightglue = LightGlueTRT()
 

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -168,6 +168,7 @@ class PerceptionNode(Node):
         self.imu_measurements = deque(maxlen=1000)
 
         self.keyframe_queue = []
+        self._async_loop = asyncio.new_event_loop()
         self.logger.info("PerceptionNode initialized.")
         self.process_cnt = 0
 
@@ -218,10 +219,16 @@ class PerceptionNode(Node):
         self.last_processed_timestamp = image_timestamp
         loop_start = time.perf_counter()
         with Timer(name="Perception Loop", text="[{name}] Elapsed time: {milliseconds:.0f} ms\n\n", logger=self.logger.info):
-            processed = asyncio.run(self.process(left_msg, right_msg))
+            processed = self._async_loop.run_until_complete(self.process(left_msg, right_msg))
         if processed:
             processed["stats"]["loop_ms"] = (time.perf_counter() - loop_start) * 1000.0
             self.stats_pub.publish(String(data=json.dumps(processed)))
+
+    def destroy_node(self):
+        if self._async_loop is not None:
+            self._async_loop.close()
+            self._async_loop = None
+        return super().destroy_node()
 
     def imu_callback(self, imu_msg):
         self.input_aligner_imu_filter.signalMessage(imu_msg)
@@ -251,7 +258,7 @@ class PerceptionNode(Node):
             self.keyframe_queue.append(
                 Keyframe(
                     timestamp=current_timestamp,
-                    image=left_img,
+                    image=left_img.copy(),
                     disparity=disparity,
                     depth=depth,
                     pose=self.T_body_last,
@@ -327,7 +334,7 @@ class PerceptionNode(Node):
         self.keyframe_queue.append(
             Keyframe(
                 timestamp=current_timestamp,
-                image=left_img,
+                image=left_img.copy(),
                 disparity=disparity,
                 depth=depth,
                 pose=self.keyframe_queue[-1].pose @ T_kf_curr,
@@ -424,7 +431,8 @@ class PerceptionNode(Node):
                             prev_left_extract_result["mask"],
                             current_left_extract_result["mask"],
                             kf_prev.image.shape,
-                            kf_curr.image.shape)
+                            kf_curr.image.shape,
+                        )
                     with Timer(name="[cached result[2/3]]", text="[{name}] Elapsed time: {milliseconds:.03f} ms", logger=self.logger.debug):
                         prev_keypoints = prev_left_extract_result["kpts"][0]  # (n, 2)
                         current_keypoints = current_left_extract_result["kpts"][0]  # (n, 2)
@@ -585,11 +593,11 @@ def main(args=None):
     parsed_args = parser.parse_args(args=sys.argv[1:] if args is None else args)
 
     perception_node = PerceptionNode(verbose_timer=parsed_args.verbose_timer)
-    imu_propagator_node = ImuPropagatorNode()
+    #imu_propagator_node = ImuPropagatorNode()
 
-    executor = rclpy.executors.MultiThreadedExecutor()
+    executor = rclpy.executors.MultiThreadedExecutor(1)
     executor.add_node(perception_node)
-    executor.add_node(imu_propagator_node)
+    #executor.add_node(imu_propagator_node)
     executor.spin()
     perception_node.destroy_node()
     imu_propagator_node.destroy_node()

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -258,7 +258,7 @@ class PerceptionNode(Node):
             self.keyframe_queue.append(
                 Keyframe(
                     timestamp=current_timestamp,
-                    image=left_img.copy(),
+                    image=left_img,
                     disparity=disparity,
                     depth=depth,
                     pose=self.T_body_last,
@@ -334,7 +334,7 @@ class PerceptionNode(Node):
         self.keyframe_queue.append(
             Keyframe(
                 timestamp=current_timestamp,
-                image=left_img.copy(),
+                image=left_img,
                 disparity=disparity,
                 depth=depth,
                 pose=self.keyframe_queue[-1].pose @ T_kf_curr,
@@ -404,7 +404,6 @@ class PerceptionNode(Node):
                 uf = uf_init(len(self.keyframe_queue[-_N:]) * _M)
 
             self.logger.debug(f"Processing {len(self.keyframe_queue)} keyframes for data association.")
-            
             # Process pairs of keyframes from last _N keyframes: extract features (SuperPoint),
             # match by LightGlue, filter by geometric consistency (pose estimation), 
             # and build tracks via Union-Find

--- a/tinynav/core/perception_node.py
+++ b/tinynav/core/perception_node.py
@@ -593,11 +593,11 @@ def main(args=None):
     parsed_args = parser.parse_args(args=sys.argv[1:] if args is None else args)
 
     perception_node = PerceptionNode(verbose_timer=parsed_args.verbose_timer)
-    #imu_propagator_node = ImuPropagatorNode()
+    imu_propagator_node = ImuPropagatorNode()
 
-    executor = rclpy.executors.MultiThreadedExecutor(1)
+    executor = rclpy.executors.MultiThreadedExecutor()
     executor.add_node(perception_node)
-    #executor.add_node(imu_propagator_node)
+    executor.add_node(imu_propagator_node)
     executor.spin()
     perception_node.destroy_node()
     imu_propagator_node.destroy_node()


### PR DESCRIPTION
## Summary
- reuse a persistent asyncio event loop in `PerceptionNode` so cached SuperPoint/LightGlue async calls remain valid across perception frames
- add a LightGlue cache regression test that mirrors the perception flow: previous/current matching, keyframe insertion, then sliding-window consecutive-pair matching

## Why
- `asyncio.run(...)` creates and closes a new event loop each call, which prevented stable async cache reuse across frames
- repeated LightGlue matching inside the sliding window should hit cache for already-seen consecutive pairs
- the test now exercises the same call shape as perception: one persistent loop with one async frame step per image

## Validation
- `python -m py_compile tinynav/core/perception_node.py`
- `python -m py_compile tests/test_models_trt.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_models_trt.py -k test_lightglue_cache_hit_with_consecutive_salted_pairs -s` inside devcontainer
- target test passed with `sliding_reuse_hits=1990/1990` and `cache_info=CacheInfo(hits=1990, misses=499, maxsize=32, currsize=32)`
