### PR TITLE
feat(tool): add SDF path editor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -207,9 +207,10 @@ RUN git clone --recursive https://github.com/dmlc/decord.git /tmp/decord \
     && cmake .. -DUSE_CUDA=0 -DCMAKE_BUILD_TYPE=Release \
     && make -j"$(nproc)" \
     && cd ../python \
-    && /opt/venv/bin/python setup.py install \
-    && DECORD_PKG_DIR=$(/opt/venv/bin/python -c "import site; print(site.getsitepackages()[0] + '/decord')") \
-    && ln -sf /opt/venv/decord/libdecord.so "${DECORD_PKG_DIR}/libdecord.so" \
+    && /usr/bin/python3 setup.py install \
+    && cp -f /tmp/decord/build/libdecord.so /usr/local/lib/libdecord.so \
+    && DECORD_PKG_DIR=$(/usr/bin/python3 -c "import site; print(site.getsitepackages()[0] + '/decord')") \
+    && ln -sf /usr/local/lib/libdecord.so "${DECORD_PKG_DIR}/libdecord.so" \
     && rm -rf /tmp/decord
 
 # Write entrypoint.sh (model build prompt only)

--- a/app/frontend/lib/pages/local_voxel_painter.dart
+++ b/app/frontend/lib/pages/local_voxel_painter.dart
@@ -38,13 +38,15 @@ class LocalVoxelPainter extends CustomPainter {
 
     _drawGroundGrid(canvas, center, scale);
 
-    final zRange = _zRange(points);
+    final zBase = pose.z ?? 0.0;
+    final zRange = _zRange(points, zBase);
     final sorted = [...points]
       ..sort((a, b) => _depth(a, pose).compareTo(_depth(b, pose)));
     for (final p in sorted) {
-      final c = _project3d(center, scale, p.x - pose.x, p.y - pose.y, p.z);
+      final rz = p.z - zBase;
+      final c = _project3d(center, scale, p.x - pose.x, p.y - pose.y, rz);
       if (c.dx < -10 || c.dx > size.width + 10 || c.dy < -10 || c.dy > size.height + 10) continue;
-      final color = _heightColor(_zNorm(p.z, zRange.$1, zRange.$2));
+      final color = _heightColor(_zNorm(rz, zRange.$1, zRange.$2));
       canvas.drawCircle(c, 2.25, Paint()..color = color.withOpacity(0.92));
     }
 
@@ -77,9 +79,9 @@ class LocalVoxelPainter extends CustomPainter {
     return rx + ry + p.z;
   }
 
-  (double, double) _zRange(List<VoxelPoint> pts) {
+  (double, double) _zRange(List<VoxelPoint> pts, double zBase) {
     if (pts.isEmpty) return (-0.4, 0.8);
-    final zs = pts.map((p) => p.z).toList()..sort();
+    final zs = pts.map((p) => p.z - zBase).toList()..sort();
     final loIdx = (zs.length * 0.05).floor().clamp(0, zs.length - 1).toInt();
     final hiIdx = (zs.length * 0.95).floor().clamp(0, zs.length - 1).toInt();
     final lo = zs[loIdx];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "cuda_python==12.6.0; platform_machine == 'aarch64'",
     "cuda-python==12.2.0; platform_machine == 'x86_64'",
     "pybind11",
-    "huggingface_hub",
+    "huggingface_hub==1.9.2",
     "einops",
     "async-lru",
     "tyro",

--- a/tinynav/core/build_map_node.py
+++ b/tinynav/core/build_map_node.py
@@ -1,50 +1,43 @@
-import rclpy
-from rclpy.node import Node
-from geometry_msgs.msg import PoseStamped
-from nav_msgs.msg import Path, Odometry
-from std_msgs.msg import Bool, Float32
-import numpy as np
-
-from sensor_msgs.msg import PointCloud2
-from std_msgs.msg import Header
-from visualization_msgs.msg import Marker, MarkerArray
-from std_msgs.msg import ColorRGBA
-from tinynav.core.math_utils import matrix_to_quat, msg2np, estimate_pose, tf2np, depth_to_cloud
-from sensor_msgs.msg import Image, CameraInfo, CompressedImage
-from message_filters import Subscriber, ApproximateTimeSynchronizer
-from cv_bridge import CvBridge
-import cv2
-from codetiming import Timer
-import os
-from dataclasses import dataclass
-
-import tyro
-
-from tinynav.tinynav_cpp_bind import pose_graph_solve
-from tinynav.core.models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
-from tinynav.core.planning_node import run_raycasting_loopy
-import logging
 import asyncio
+import logging
+import os
 import shelve
 import time
-from tqdm import tqdm
+from contextlib import contextmanager
+from dataclasses import dataclass
+from math import inf
+from typing import Callable, Dict, Optional
+
+import cv2
 import einops
-from tf2_msgs.msg import TFMessage
-from typing import Dict
-from tool.video_db import VideoDB
-
-from tf2_ros import TransformBroadcaster
-from geometry_msgs.msg import TransformStamped,Point
-from scipy.spatial.transform import Rotation as R
-from scipy.ndimage import distance_transform_edt
-
+import numpy as np
+import rclpy
+import tyro
+from cv_bridge import CvBridge
+from geometry_msgs.msg import PoseStamped, TransformStamped, Point
+from message_filters import Subscriber, ApproximateTimeSynchronizer
+from nav_msgs.msg import Path, Odometry
 from rclpy.executors import SingleThreadedExecutor
-from rosbag2_py import SequentialReader, StorageOptions, ConverterOptions
-from rosidl_runtime_py.utilities import get_message
-from rosgraph_msgs.msg import Clock
+from rclpy.node import Node
 from rclpy.serialization import deserialize_message
+from rosbag2_py import SequentialReader, StorageOptions, ConverterOptions
+from rosgraph_msgs.msg import Clock
+from rosidl_runtime_py.utilities import get_message
+from scipy.ndimage import distance_transform_edt
+from scipy.spatial.transform import Rotation as R
+from sensor_msgs.msg import Image, CameraInfo, CompressedImage, PointCloud2
+from std_msgs.msg import Bool, Float32, Header, ColorRGBA
+from tabulate import tabulate
+from tf2_msgs.msg import TFMessage
+from tf2_ros import TransformBroadcaster
+from tqdm import tqdm
+from visualization_msgs.msg import Marker, MarkerArray
 
-
+from tinynav.core.math_utils import matrix_to_quat, msg2np, estimate_pose, tf2np, depth_to_cloud
+from tinynav.core.models_trt import LightGlueTRT, Dinov2TRT, SuperPointTRT
+from tinynav.core.planning_node import run_raycasting_loopy
+from tinynav.tinynav_cpp_bind import pose_graph_solve
+from tool.video_db import VideoDB
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +48,88 @@ class BuildMapArgs:
     map_save_path: str = "tinynav_db"
     play_rate: float = 1.0
     verbose_timer: bool = True
+    # Minimum growth in keyframe count before running global pose-graph solve + TF republish.
+    # Mirrors COLMAP IncrementalPipeline::ba_global_frames_ratio (default 1.1).
+    global_frames_ratio: float = 1.1
+
+
+def check_global_frames_ratio(num_frames: int, prev_num_frames: int, frames_ratio: float) -> bool:
+    """Return whether to run global refinement (pose graph + TF), using COLMAP's frames-ratio rule.
+
+    Adapted from COLMAP ``IncrementalPipeline::CheckRunGlobalRefinement`` (frames branch only):
+    ``NumRegFrames() >= ba_global_frames_ratio * ba_prev_num_reg_frames``.
+
+    Here ``num_frames`` is the current keyframe count and ``prev_num_frames`` is the count at the
+    last global refinement. Set ``frames_ratio`` to 1.0 to refine on every keyframe.
+    """
+    return num_frames >= frames_ratio * prev_num_frames
+
+
+@dataclass
+class StageStats:
+    count: int = 0
+    total_s: float = 0.0
+    min_s: float = inf
+    max_s: float = 0.0
+
+    def record(self, duration_s: float) -> None:
+        self.count += 1
+        self.total_s += duration_s
+        self.min_s = min(self.min_s, duration_s)
+        self.max_s = max(self.max_s, duration_s)
+
+
+class StageTimer:
+    def __init__(self, verbose_logger: Optional[Callable[[str], None]] = None):
+        self._stats: Dict[str, StageStats] = {}
+        self.verbose_logger = verbose_logger
+
+    def record(self, name: str, duration_s: float) -> None:
+        if name not in self._stats:
+            self._stats[name] = StageStats()
+        self._stats[name].record(duration_s)
+        if self.verbose_logger is not None:
+            self.verbose_logger(f"[{name}] Elapsed time: {duration_s * 1000:.0f} ms")
+
+    @contextmanager
+    def timed(self, name: str):
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.record(name, time.perf_counter() - t0)
+
+    def log_summary(self, log_fn: Callable[[str], None]) -> None:
+        if not self._stats:
+            log_fn("No stage timing data collected.")
+            return
+
+        grand_total = sum(s.total_s for s in self._stats.values())
+        rows = []
+        for name, stats in sorted(self._stats.items(), key=lambda item: -item[1].total_s):
+            mean_s = stats.total_s / stats.count if stats.count else 0.0
+            min_ms = stats.min_s * 1000 if stats.count else 0.0
+            pct = (100.0 * stats.total_s / grand_total) if grand_total > 0 else 0.0
+            rows.append([
+                name,
+                stats.count,
+                round(stats.total_s, 3),
+                round(mean_s * 1000, 1),
+                round(min_ms, 1),
+                round(stats.max_s * 1000, 1),
+                round(pct, 1),
+            ])
+
+        table = tabulate(
+            rows,
+            headers=["stage", "count", "total_s", "mean_ms", "min_ms", "max_ms", "pct"],
+            tablefmt="simple",
+        )
+        note = "pct is each stage total_s / sum of all stage totals (non-overlapping leaf stages)"
+        log_fn(
+            f"=== Build map stage timing ===\n{table}\n"
+            f"Grand total: {round(grand_total, 3)} s ({note})"
+        )
 
 
 def z_value_to_color(z, z_min, z_max):
@@ -112,7 +187,7 @@ def find_loop(target_embedding:np.ndarray, embeddings:np.ndarray, loop_similarit
             loop_list.append((idx, similarity_array[idx]))
     return loop_list[-loop_top_k:]
 
-def generate_occupancy_map(poses, db, K, baseline, resolution = 0.1, step = 100):
+def generate_occupancy_map(poses, db, K, baseline, resolution = 0.1, step = 100, stage_timer: Optional[StageTimer] = None):
     """
         Generate a occupancy grid map from the depth images.
         The occupancy grid map is a 3D grid with the following values:
@@ -138,14 +213,22 @@ def generate_occupancy_map(poses, db, K, baseline, resolution = 0.1, step = 100)
     global_grid = np.zeros(global_grid_shape, dtype=np.float32)
 
     odom_positions = []
-    for timestamp, odom_pose in tqdm(poses.items()):
-        depth, _, _, _, _ = db.get_depth_embedding_features_images(timestamp)
-        odom_translation = odom_pose[:3, 3]
-        local_origin = np.floor(odom_translation / resolution) * resolution - 0.5 * np.array(raycast_shape) * resolution
-        local_grid = run_raycasting_loopy(depth, odom_pose, raycast_shape, fx, fy, cx, cy, local_origin, step, resolution, filter_ground = True)
-        global_grid, global_origin = merge_local_into_global(global_grid, global_origin, local_grid, local_origin, resolution)
-        odom_position = odom_pose[:3, 3]
-        odom_positions.append(odom_position)
+
+    def _raycast_all_poses():
+        nonlocal global_grid, global_origin
+        for timestamp, odom_pose in tqdm(poses.items()):
+            depth, _, _, _, _ = db.get_depth_embedding_features_images(timestamp)
+            odom_translation = odom_pose[:3, 3]
+            local_origin = np.floor(odom_translation / resolution) * resolution - 0.5 * np.array(raycast_shape) * resolution
+            local_grid = run_raycasting_loopy(depth, odom_pose, raycast_shape, fx, fy, cx, cy, local_origin, step, resolution, filter_ground = True)
+            global_grid, global_origin = merge_local_into_global(global_grid, global_origin, local_grid, local_origin, resolution)
+            odom_positions.append(odom_pose[:3, 3])
+
+    if stage_timer is not None:
+        with stage_timer.timed("occupancy_raycast"):
+            _raycast_all_poses()
+    else:
+        _raycast_all_poses()
 
     voxels = int(np.prod(global_grid_shape))
     print(
@@ -156,16 +239,21 @@ def generate_occupancy_map(poses, db, K, baseline, resolution = 0.1, step = 100)
     )
 
     # Compute SDF as voxel distance to nearest odom seed using SciPy EDT.
-    with Timer(name="sdf_distance_transform_edt", text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
+    def _compute_sdf():
         if len(odom_positions) == 0:
-            sdf_map = np.full(global_grid_shape, np.inf, dtype=np.float32)
-        else:
-            seed_mask = np.ones(global_grid_shape, dtype=np.uint8)
-            odom_positions_np = np.asarray(odom_positions, dtype=np.float32)
-            seed_indices = np.rint((odom_positions_np - global_origin) / resolution).astype(np.int32)
-            seed_indices = np.clip(seed_indices, 0, global_grid_shape - 1)
-            seed_mask[seed_indices[:, 0], seed_indices[:, 1], seed_indices[:, 2]] = 0
-            sdf_map = distance_transform_edt(seed_mask, sampling=(resolution, resolution, resolution)).astype(np.float32)
+            return np.full(global_grid_shape, np.inf, dtype=np.float32)
+        seed_mask = np.ones(global_grid_shape, dtype=np.uint8)
+        odom_positions_np = np.asarray(odom_positions, dtype=np.float32)
+        seed_indices = np.rint((odom_positions_np - global_origin) / resolution).astype(np.int32)
+        seed_indices = np.clip(seed_indices, 0, global_grid_shape - 1)
+        seed_mask[seed_indices[:, 0], seed_indices[:, 1], seed_indices[:, 2]] = 0
+        return distance_transform_edt(seed_mask, sampling=(resolution, resolution, resolution)).astype(np.float32)
+
+    if stage_timer is not None:
+        with stage_timer.timed("occupancy_sdf"):
+            sdf_map = _compute_sdf()
+    else:
+        sdf_map = _compute_sdf()
 
     # 0 is the unknown.
     grid_type = np.zeros_like(global_grid, dtype=np.uint8)
@@ -464,11 +552,23 @@ class BagPlayer(Node):
         return True
 
 class BuildMapNode(Node):
-    def __init__(self, map_save_path:str, verbose_timer: bool = True):
+    def __init__(
+        self,
+        map_save_path: str,
+        verbose_timer: bool = True,
+        global_frames_ratio: float = 1.1,
+    ):
         super().__init__('build_map_node')
+        if global_frames_ratio < 1.0:
+            raise ValueError(f"global_frames_ratio must be >= 1.0, got {global_frames_ratio}")
         self.verbose_timer = verbose_timer
+        self.global_frames_ratio = global_frames_ratio
+        # Keyframe count at the last global refinement (COLMAP: ba_prev_num_reg_frames).
+        self._global_prev_num_frames = 0
         self.logger = logging.getLogger(__name__)
-        self.timer_logger = self.logger.info if verbose_timer else self.logger.debug
+        self.stage_timer = StageTimer(
+            verbose_logger=self.logger.info if verbose_timer else None,
+        )
         self.super_point_extractor = SuperPointTRT()
         self.light_glue_matcher = LightGlueTRT()
         self.dinov2_model = Dinov2TRT()
@@ -600,13 +700,13 @@ class BuildMapNode(Node):
                 self.mapping_save_finished_pub.publish(save_finished_msg)
 
     def keyframe_callback(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image, rgb_image_msg:Image):
-        with Timer(name="Mapping Loop", text="[{name}] Elapsed time: {milliseconds:.0f} ms\n\n", logger=self.timer_logger):
+        with self.stage_timer.timed("mapping_loop"):
             if self.K is None:
                 return
             self.process(keyframe_image_msg, keyframe_odom_msg, depth_msg, rgb_image_msg)
 
     def process(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image, rgb_image_msg:Image):
-        with Timer(name = "Msg decode", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("msg_decode"):
             keyframe_image_timestamp = int(keyframe_image_msg.header.stamp.sec * 1e9) + int(keyframe_image_msg.header.stamp.nanosec)
             keyframe_odom_timestamp = int(keyframe_odom_msg.header.stamp.sec * 1e9) + int(keyframe_odom_msg.header.stamp.nanosec)
             keyframe_depth_timestamp = int(depth_msg.header.stamp.sec * 1e9) + int(depth_msg.header.stamp.nanosec)
@@ -618,66 +718,80 @@ class BuildMapNode(Node):
             infra1_image = self.bridge.imgmsg_to_cv2(keyframe_image_msg, desired_encoding="mono8")
             rgb_image = self.bridge.imgmsg_to_cv2(rgb_image_msg, desired_encoding="bgr8")
 
-        with Timer(name = "save image and depth", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("save_image_and_depth"):
             self.db.set_entry(keyframe_image_timestamp, depth = depth, infra1_image = infra1_image, rgb_image = rgb_image)
 
-        with Timer(name = "get embeddings", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("get_embeddings"):
             embedding = self.get_embeddings(infra1_image)
             embedding = embedding / np.linalg.norm(embedding)
             self.db.set_entry(keyframe_image_timestamp, embedding = embedding)
-        with Timer(name = "super point extractor", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("super_point_extractor"):
             features = asyncio.run(self.super_point_extractor.infer(infra1_image))
             self.db.set_entry(keyframe_image_timestamp, features = features)
 
-        with Timer(name = "loop and pose graph solve", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            if len(self.odom) == 0 and self.last_keyframe_timestamp is None:
-                self.odom[keyframe_image_timestamp] = odom
-                self.pose_graph_used_pose[keyframe_image_timestamp] = odom
-            else:
-                last_keyframe_odom_pose = self.odom[self.last_keyframe_timestamp]
-                T_prev_curr = np.linalg.inv(last_keyframe_odom_pose) @ odom
-                self.relative_pose_constraint.append((keyframe_image_timestamp, self.last_keyframe_timestamp, T_prev_curr))
-                self.pose_graph_used_pose[keyframe_image_timestamp] = odom
-                self.odom[keyframe_image_timestamp] = odom
+        if len(self.odom) == 0 and self.last_keyframe_timestamp is None:
+            self.odom[keyframe_image_timestamp] = odom
+            self.pose_graph_used_pose[keyframe_image_timestamp] = odom
+        else:
+            last_keyframe_odom_pose = self.odom[self.last_keyframe_timestamp]
+            T_prev_curr = np.linalg.inv(last_keyframe_odom_pose) @ odom
+            self.relative_pose_constraint.append((keyframe_image_timestamp, self.last_keyframe_timestamp, T_prev_curr))
+            self.pose_graph_used_pose[keyframe_image_timestamp] = odom
+            self.odom[keyframe_image_timestamp] = odom
+            self.detect_loop_closure(keyframe_image_timestamp)
 
+        self.maybe_run_global_refinement()
 
-                def find_loop_and_pose_graph(timestamp):
-                    target_embedding = self.db.get_embedding(timestamp)
-                    valid_timestamp = [t for t in self.pose_graph_used_pose.keys() if t + 10 * 1e9 < timestamp]
-                    valid_embeddings = np.array([self.db.get_embedding(t) for t in valid_timestamp])
-
-                    idx_to_timestamp = {i:t for i, t in enumerate(valid_timestamp)}
-                    with Timer(name = "find loop", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-                        loop_list = find_loop(target_embedding, valid_embeddings, self.loop_similarity_threshold, self.loop_top_k)
-                    with Timer(name = "Relative pose estimation", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-                        for idx, similarity in loop_list:
-                            prev_timestamp = idx_to_timestamp[idx]
-                            curr_timestamp = timestamp
-                            prev_depth, _, prev_features, _, _ = self.db.get_depth_embedding_features_images(prev_timestamp)
-                            curr_depth, _, curr_features, _, _ = self.db.get_depth_embedding_features_images(curr_timestamp)
-                            prev_matched_keypoints, curr_matched_keypoints, matches = self.match_keypoints(prev_features, curr_features)
-                            success, T_prev_curr, _, _, inliers = estimate_pose(prev_matched_keypoints, curr_matched_keypoints, curr_depth, self.K)
-                            if success and len(inliers) >= 100:
-                                self.relative_pose_constraint.append((curr_timestamp, prev_timestamp, T_prev_curr))
-                                print(f"Added loop relative pose constraint: {curr_timestamp} -> {prev_timestamp}")
-                    with Timer(name = "solve pose graph", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-                        self.pose_graph_used_pose = solve_pose_graph(self.pose_graph_used_pose, self.relative_pose_constraint, max_iteration_num = 5)
-                find_loop_and_pose_graph(keyframe_image_timestamp)
-
-        with Timer(name = "publish local pointcloud", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("publish_local_pointcloud"):
             cloud = depth_to_cloud(depth, self.K, 30, 3)
             self.publish_local_map(cloud, 'camera_'+str(keyframe_image_timestamp))
 
-        with Timer(name = "tf publish", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            self.publish_all_transforms()
-
-        with Timer(name = "pose graph trajectory publish", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("pose_graph_trajectory_publish"):
             self.pose_graph_trajectory_publish(keyframe_image_timestamp)
         self.last_keyframe_timestamp = keyframe_image_timestamp
 
     def get_embeddings(self, image: np.ndarray) -> np.ndarray:
         # shape: (1, 768)
         return asyncio.run(self.dinov2_model.infer(image))
+
+    def detect_loop_closure(self, timestamp: int) -> None:
+        target_embedding = self.db.get_embedding(timestamp)
+        valid_timestamp = [t for t in self.pose_graph_used_pose.keys() if t + 10 * 1e9 < timestamp]
+        valid_embeddings = np.array([self.db.get_embedding(t) for t in valid_timestamp])
+        idx_to_timestamp = {i: t for i, t in enumerate(valid_timestamp)}
+
+        with self.stage_timer.timed("find_loop"):
+            loop_list = find_loop(target_embedding, valid_embeddings, self.loop_similarity_threshold, self.loop_top_k)
+        with self.stage_timer.timed("relative_pose_estimation"):
+            for idx, _similarity in loop_list:
+                prev_timestamp = idx_to_timestamp[idx]
+                curr_timestamp = timestamp
+                prev_depth, _, prev_features, _, _ = self.db.get_depth_embedding_features_images(prev_timestamp)
+                curr_depth, _, curr_features, _, _ = self.db.get_depth_embedding_features_images(curr_timestamp)
+                prev_matched_keypoints, curr_matched_keypoints, _matches = self.match_keypoints(prev_features, curr_features)
+                success, T_prev_curr, _, _, inliers = estimate_pose(prev_matched_keypoints, curr_matched_keypoints, curr_depth, self.K)
+                if success and len(inliers) >= 100:
+                    self.relative_pose_constraint.append((curr_timestamp, prev_timestamp, T_prev_curr))
+                    print(f"Added loop relative pose constraint: {curr_timestamp} -> {prev_timestamp}")
+
+    def maybe_run_global_refinement(self) -> None:
+        """Run pose-graph optimization and full TF publish when the map has grown enough.
+
+        Loop detection still runs every keyframe; this batches the expensive global steps using
+        COLMAP's ``ba_global_frames_ratio`` policy (see ``check_global_frames_ratio``).
+        A final full solve runs in ``save_mapping`` regardless of this gate.
+        """
+        num_frames = len(self.pose_graph_used_pose)
+        if not check_global_frames_ratio(num_frames, self._global_prev_num_frames, self.global_frames_ratio):
+            return
+
+        with self.stage_timer.timed("solve_pose_graph_online"):
+            self.pose_graph_used_pose = solve_pose_graph(
+                self.pose_graph_used_pose, self.relative_pose_constraint, max_iteration_num=5
+            )
+        with self.stage_timer.timed("tf_publish"):
+            self.publish_all_transforms()
+        self._global_prev_num_frames = num_frames
 
     def match_keypoints(self, feats0:dict, feats1:dict, image_shape = np.array([848, 480], dtype = np.int64)) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         match_result = asyncio.run(self.light_glue_matcher.infer(feats0["kpts"], feats1["kpts"], feats0['descps'], feats1['descps'], feats0['mask'], feats1['mask'], image_shape, image_shape))
@@ -725,8 +839,12 @@ class BuildMapNode(Node):
         # Save continuous poses
         self.continuous_odom_recorder.save_to_disk()
 
-        with Timer(name = "final pose graph", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+        with self.stage_timer.timed("final_pose_graph"):
             self.pose_graph_used_pose = solve_pose_graph(self.pose_graph_used_pose, self.relative_pose_constraint)
+
+        with self.stage_timer.timed("tf_publish"):
+            self.publish_all_transforms()
+        self._global_prev_num_frames = len(self.pose_graph_used_pose)
 
         np.save(f"{self.map_save_path}/poses.npy", self.pose_graph_used_pose, allow_pickle = True)
         np.save(f"{self.map_save_path}/intrinsics.npy", self.K)
@@ -743,18 +861,25 @@ class BuildMapNode(Node):
         occupancy_resolution = 0.1
         occupancy_step = 10
         occupancy_grid, occupancy_origin, occupancy_2d_image, sdf_map = generate_occupancy_map(
-            self.pose_graph_used_pose, occupancy_db, self.K, self.baseline, occupancy_resolution, occupancy_step
+            self.pose_graph_used_pose,
+            occupancy_db,
+            self.K,
+            self.baseline,
+            occupancy_resolution,
+            occupancy_step,
+            stage_timer=self.stage_timer,
         )
         occupancy_db.close()
-        occupancy_meta = np.array([occupancy_origin[0], occupancy_origin[1], occupancy_origin[2], occupancy_resolution], dtype=np.float32)
-        np.save(f"{self.map_save_path}/occupancy_grid.npy", occupancy_grid)
-        np.save(f"{self.map_save_path}/occupancy_meta.npy", occupancy_meta)
-        np.save(f"{self.map_save_path}/sdf_map.npy", sdf_map)
-        cv2.imwrite(f"{self.map_save_path}/occupancy_2d_image.png", occupancy_2d_image)
+        with self.stage_timer.timed("occupancy_save_files"):
+            occupancy_meta = np.array([occupancy_origin[0], occupancy_origin[1], occupancy_origin[2], occupancy_resolution], dtype=np.float32)
+            np.save(f"{self.map_save_path}/occupancy_grid.npy", occupancy_grid)
+            np.save(f"{self.map_save_path}/occupancy_meta.npy", occupancy_meta)
+            np.save(f"{self.map_save_path}/sdf_map.npy", sdf_map)
+            cv2.imwrite(f"{self.map_save_path}/occupancy_2d_image.png", occupancy_2d_image)
 
         self._save_completed = True
         self.get_logger().info("Full mapping data saved successfully")
-
+        self.stage_timer.log_summary(self.get_logger().info)
 
     def pointcloud_to_marker_array(self, points, frame_id='camera',colors=None):
         marker_array = MarkerArray()
@@ -884,7 +1009,11 @@ if __name__ == '__main__':
 
     exec_ = SingleThreadedExecutor()
     player_node = BagPlayer(parsed_args.bag_file, play_rate=parsed_args.play_rate)
-    map_node = BuildMapNode(parsed_args.map_save_path, verbose_timer=parsed_args.verbose_timer)
+    map_node = BuildMapNode(
+        parsed_args.map_save_path,
+        verbose_timer=parsed_args.verbose_timer,
+        global_frames_ratio=parsed_args.global_frames_ratio,
+    )
     image_transports_node = ImageTransportsNode()
     exec_.add_node(player_node)
     exec_.add_node(map_node)

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -10,7 +10,7 @@ import sys
 import json
 
 import heapq
-from tinynav.core.math_utils import matrix_to_quat, msg2np, np2msg, estimate_pose, np2tf
+from tinynav.core.math_utils import matrix_to_quat, msg2np, np2msg, estimate_pose, np2tf, rerank_by_pnp_inliers
 from sensor_msgs.msg import Image, CameraInfo
 from message_filters import TimeSynchronizer, Subscriber
 from cv_bridge import CvBridge
@@ -451,38 +451,35 @@ class MapNode(Node):
 
         idx_and_similarity_array = find_loop(query_embedding_normed, self.map_embeddings, self.relocalization_threshold, self.relocalization_loop_top_k)
         max_similarity = np.max([similarity for _, similarity in idx_and_similarity_array]) if len(idx_and_similarity_array) > 0 else 0
-        if len(idx_and_similarity_array) > 0:
-            point_3d_in_world_list = []
-            point_2d_in_keyframe_list = []
-            for idx_in_map, similarity in idx_and_similarity_array:
-                timestamp_in_map = self.map_embeddings_idx_to_timestamp[idx_in_map]
-                reference_keyframe_pose = self.map_poses[timestamp_in_map]
-                reference_depth, _, reference_features, _, _ = self.db.get_depth_embedding_features_images(timestamp_in_map)
-                reference_matched_keypoints, keyframe_matched_keypoints, matches = self.match_keypoints(reference_features, keyframe_features)
-                if len(matches) >= 50:
-                    point_3d_in_world, inliers = self.keypoint_with_depth_to_3d(reference_matched_keypoints, reference_depth, reference_keyframe_pose, self.map_K)
-                    point_3d_in_world_list = point_3d_in_world[inliers]
-                    point_2d_in_keyframe_list = keyframe_matched_keypoints[inliers]
-                else:
-                    print(f"not enough matched features to relocalize, {len(matches)} < 50")
-
-            if len(point_3d_in_world_list) > 80:
-                point_3d_in_world_list = np.array(point_3d_in_world_list)
-                point_2d_in_keyframe_list = np.array(point_2d_in_keyframe_list)
-
-                success, rvec, tvec, inliers = cv2.solvePnPRansac(point_3d_in_world_list, point_2d_in_keyframe_list, self.map_K, None)
-                if success and len(inliers) >= 50:
-                    R, _ = cv2.Rodrigues(rvec)
-                    T = np.eye(4)
-                    T[:3, :3] = R
-                    T[:3, 3] = tvec.reshape(3)
-                    print(f"relocalization pose : {T}")
-                    return True, T, len(inliers) / len(point_2d_in_keyframe_list)
-            else:
-                print(f"not enough landmarks to relocalize, {len(point_3d_in_world_list)}")
-                return False, np.eye(4), -np.inf
-        else:
+        if len(idx_and_similarity_array) == 0:
             print(f"not enough similar embeddings to relocalize, {len(idx_and_similarity_array)}, max_similarity : {max_similarity}")
+            return False, np.eye(4), -np.inf
+
+        pnp_candidates = []
+        for idx_in_map, similarity in idx_and_similarity_array:
+            timestamp_in_map = self.map_embeddings_idx_to_timestamp[idx_in_map]
+            reference_keyframe_pose = self.map_poses[timestamp_in_map]
+            reference_depth, _, reference_features, _, _ = self.db.get_depth_embedding_features_images(timestamp_in_map)
+            reference_matched_keypoints, keyframe_matched_keypoints, matches = self.match_keypoints(reference_features, keyframe_features)
+            if len(matches) < 50:
+                print(f"not enough matched features to relocalize, {len(matches)} < 50")
+                continue
+
+            point_3d_in_world, inliers = self.keypoint_with_depth_to_3d(reference_matched_keypoints, reference_depth, reference_keyframe_pose, self.map_K)
+            point_3d_in_world_list = point_3d_in_world[inliers]
+            point_2d_in_keyframe_list = keyframe_matched_keypoints[inliers]
+            point_count = len(point_2d_in_keyframe_list)
+            if point_count <= 80:
+                print(f"not enough landmarks to relocalize, {point_count}")
+                continue
+            pnp_candidates.append((point_3d_in_world_list, point_2d_in_keyframe_list))
+
+        success, best_pose_in_camera, pose_cov_weight, _, _, _ = rerank_by_pnp_inliers(pnp_candidates, self.map_K)
+        if success:
+            print(f"relocalization pose : {best_pose_in_camera}")
+            return True, best_pose_in_camera, pose_cov_weight
+
+        print("no valid PnP relocalization candidate found")
         return False, np.eye(4), -np.inf
 
     def keypoint_with_depth_to_3d(self, keypoints:np.ndarray, depth:np.ndarray, pose_from_camera_to_world:np.ndarray, K:np.ndarray):

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -270,6 +270,12 @@ class MapNode(Node):
 
         self._save_completed = False
 
+        # Nav timer: decouple target_pose update from keyframe callback
+        self._latest_continuous_odom = None
+        self._current_path_in_map = None
+        self._path_needs_replan = True
+        self._nav_timer = self.create_timer(0.2, self.nav_timer_callback)  # 5Hz
+
     def pois_callback(self, msg: String):
         self.get_logger().info("Received POIs from planner: " + msg.data)
         try:
@@ -294,6 +300,8 @@ class MapNode(Node):
             self._leg_initial_length = None
             self._leg_start_time = None
             self._speed_estimate = None
+            self._path_needs_replan = True
+            self._current_path_in_map = None
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
@@ -310,6 +318,8 @@ class MapNode(Node):
 
     def continuous_odom_callback(self, odom_msg: Odometry):
         self.continuous_odom_recorder.record_odometry_msg(odom_msg)
+        odom, _ = msg2np(odom_msg)
+        self._latest_continuous_odom = odom
 
     def localization_stop_callback(self, msg: Bool):
         if msg.data:
@@ -340,13 +350,7 @@ class MapNode(Node):
         if success:
             self.compute_transform_from_map_to_odom()
             self._try_load_map_pois()
-
-        with Timer(name = "nav path", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            self.try_publish_nav_path(keyframe_image_timestamp_ns)
-            # timer or queue for publish the nav path
-            # and record the map pose
-            # compute the coordinate transform from the map pose to the keyframe pose
-            # publish the nav path from the map pose to the keyframe pose with the cost map
+            self._path_needs_replan = True
 
     def keyframe_mapping_with_timer(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image):
         with Timer(name="Mapping Loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
@@ -603,31 +607,26 @@ class MapNode(Node):
         optimized_parameters = pose_graph_solve(optimized_parameters, relative_pose_constraint, constant_pose_index_dict, max_iteration_num = 1000)
         self.T_from_map_to_odom = optimized_parameters[0]
 
-    def try_publish_nav_path(self, timestamp: int):
-        self.get_logger().info(f"try_publish_nav_path, timestamp: {timestamp}")
+    def nav_timer_callback(self):
+        """Lightweight timer callback (5Hz) for target_pose updates using continuous odom."""
         if self.T_from_map_to_odom is None:
-            self.get_logger().info("Relocalization not successful yet, skip publishing nav path")
             return
-
+        if self._latest_continuous_odom is None:
+            return
         if self.poi_index == -1:
-            self.get_logger().info("No POI found, skip publishing nav path")
             return
-
         if self.poi_index >= len(self.pois):
-            self.get_logger().info("All POIs have been visited, skip publishing nav path")
+            if not self._nav_completed:
+                self._nav_completed = True
+                self.get_logger().info("All POIs have been visited, nav done")
+                self.nav_done_pub.publish(Bool(data=True))
             return
 
-        poi = self.pois[self.poi_index]
-        print(f"poi: {poi}")
-        poi_pose = np.eye(4)
-        poi_pose[:3, 3] = poi
-        self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
-        # get the pose from the map to the odom
-        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self.pose_graph_used_pose[timestamp]
+        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self._latest_continuous_odom
+        pose_in_map_position = pose_in_map[:3, 3]
         self.current_pose_in_map_pub.publish(np2msg(pose_in_map, self.get_clock().now().to_msg(), "world", "map"))
 
-        pose_in_map_position = pose_in_map[:3, 3]
-
+        # Check POI arrival
         while self.poi_index < len(self.pois):
             poi = self.pois[self.poi_index]
             diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
@@ -646,12 +645,10 @@ class MapNode(Node):
                 self.poi_index += 1
                 self._leg_initial_length = None
                 self._leg_start_time = None
+                self._path_needs_replan = True
+                self._current_path_in_map = None
                 dummy_pose = np.eye(4)
-
-                stamp_msg = self.get_clock().now().to_msg()
-                stamp_msg.sec = int(timestamp / 1e9)
-                stamp_msg.nanosec = int(timestamp % 1e9)
-                self.poi_change_pub.publish(np2msg(dummy_pose, stamp_msg, "world", "map"))
+                self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
                 continue
             else:
                 break
@@ -663,11 +660,30 @@ class MapNode(Node):
                 self.nav_done_pub.publish(Bool(data=True))
             return
 
+        # Publish current POI
+        poi = self.pois[self.poi_index]
+        poi_pose = np.eye(4)
+        poi_pose[:3, 3] = poi
+        self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
+
+        # Replan path if needed (heavy, only on relocalization success or POI change)
+        if self._path_needs_replan:
+            self.replan_nav_path(pose_in_map)
+
+        # Publish target_pose from cached path (lightweight)
+        if self._current_path_in_map is not None:
+            self.update_target_pose(pose_in_map)
+
+    def replan_nav_path(self, pose_in_map: np.ndarray):
+        """Heavy: generate nav path via A* on SDF map. Called only when replan is needed."""
         target_poi = self.pois[self.poi_index]
-        with Timer(name = "generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            paths_in_map = self.generate_nav_path_in_map(pose_in_map = pose_in_map, target_poi = target_poi)
+        with Timer(name="generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+            paths_in_map = self.generate_nav_path_in_map(pose_in_map=pose_in_map, target_poi=target_poi)
 
         if paths_in_map is not None:
+            self._current_path_in_map = paths_in_map
+            self._path_needs_replan = False
+
             remaining_length = sum(
                 np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
                 for i in range(len(paths_in_map) - 1)
@@ -677,7 +693,22 @@ class MapNode(Node):
             if self._leg_initial_length is None:
                 self._leg_initial_length = remaining_length
                 self._leg_start_time = now
+        else:
+            self.get_logger().warning("Replan failed: no path found in map")
 
+    def update_target_pose(self, pose_in_map: np.ndarray):
+        """Lightweight: compute and publish target_pose from cached path."""
+        paths_in_map = self._current_path_in_map
+        pose_in_map_position = pose_in_map[:3, 3]
+
+        # Compute remaining length and progress
+        remaining_length = sum(
+            np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
+            for i in range(len(paths_in_map) - 1)
+        ) if len(paths_in_map) > 1 else 0.0
+
+        now = time.time()
+        if self._leg_initial_length is not None:
             covered = self._leg_initial_length - remaining_length
             elapsed = now - self._leg_start_time
             if covered > 0.1 and elapsed > 1.0:
@@ -697,49 +728,48 @@ class MapNode(Node):
             })
             self.nav_progress_pub.publish(progress_msg)
 
-            # use the max_speed to publish the position the robot should be after 5 seconds
-            with Timer(name = "Find target position", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-                max_speed = 0.5
-                if len(paths_in_map) > 1:
-                    accumulated_distance = 0.0
-                    start_point = pose_in_map_position[:3]
-                    target_position = paths_in_map[-1]
-                    for i in range(len(paths_in_map) - 1):
-                        accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
-                        if accumulated_distance > max_speed * 5:
-                            target_position = paths_in_map[i]
-                            break
-                        start_point = paths_in_map[i]
-                else:
-                    target_position = paths_in_map[0]
-                target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
-                pose_in_origin_odom = self.odom[timestamp]
-                T = pose_in_origin_odom @ np.linalg.inv(pose_in_map)
-                target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
-                dummy_pose = np.eye(4)
-                dummy_pose[:3, 3] = target_position_in_odom
-                #logging.info(f"target_position_in_odom: {target_position_in_odom}")
-                print(f"target_position_in_odom: {target_position_in_odom}")
-
-                self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
-                path_msg = Path()
-                path_msg.header.stamp = self.get_clock().now().to_msg()
-                path_msg.header.frame_id = "map"
-                for x, y, z in paths_in_map:
-                    pose = PoseStamped()
-                    pose.header = path_msg.header
-                    pose.pose.position.x = x
-                    pose.pose.position.y = y
-                    pose.pose.position.z = z
-                    pose.pose.orientation.x = 0.0
-                    pose.pose.orientation.y = 0.0
-                    pose.pose.orientation.z = 0.0
-                    pose.pose.orientation.w = 1.0
-                    path_msg.poses.append(pose)
-                self.global_plan_pub.publish(path_msg)
-                self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
+        # Find look-ahead target position
+        max_speed = 0.5
+        if len(paths_in_map) > 1:
+            accumulated_distance = 0.0
+            start_point = pose_in_map_position[:3]
+            target_position = paths_in_map[-1]
+            for i in range(len(paths_in_map) - 1):
+                accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
+                if accumulated_distance > max_speed * 5:
+                    target_position = paths_in_map[i]
+                    break
+                start_point = paths_in_map[i]
         else:
-            logging.info("No path found in map")
+            target_position = paths_in_map[0]
+
+        # Transform target from map frame to odom frame
+        target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
+        T = self._latest_continuous_odom @ np.linalg.inv(pose_in_map)
+        target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
+        dummy_pose = np.eye(4)
+        dummy_pose[:3, 3] = target_position_in_odom
+        print(f"target_position_in_odom: {target_position_in_odom}")
+
+        self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
+
+        # Publish global plan path
+        path_msg = Path()
+        path_msg.header.stamp = self.get_clock().now().to_msg()
+        path_msg.header.frame_id = "map"
+        for x, y, z in paths_in_map:
+            pose = PoseStamped()
+            pose.header = path_msg.header
+            pose.pose.position.x = x
+            pose.pose.position.y = y
+            pose.pose.position.z = z
+            pose.pose.orientation.x = 0.0
+            pose.pose.orientation.y = 0.0
+            pose.pose.orientation.z = 0.0
+            pose.pose.orientation.w = 1.0
+            path_msg.poses.append(pose)
+        self.global_plan_pub.publish(path_msg)
+        self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
 
     def generate_nav_path_in_map(self, pose_in_map: np.ndarray, target_poi: np.ndarray) -> np.ndarray:
         dummy_poi_pose = np.eye(4)

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -705,7 +705,7 @@ class MapNode(Node):
                     start_point = pose_in_map_position[:3]
                     target_position = paths_in_map[-1]
                     for i in range(len(paths_in_map) - 1):
-                        accumulated_distance += np.linalg.norm((paths_in_map[i] - start_point)[:2])
+                        accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
                         if accumulated_distance > max_speed * 5:
                             target_position = paths_in_map[i]
                             break

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -190,6 +190,7 @@ class MapNode(Node):
         self.light_glue_matcher = LightGlueTRT()
         self.dinov2_model = Dinov2TRT()
         self.tinynav_db_path = tinynav_db_path
+        self.tinynav_map_path = tinynav_map_path
 
         self.bridge = CvBridge()
 
@@ -251,6 +252,7 @@ class MapNode(Node):
         self.pois = {}
         self.poi_index = -1
         self._nav_completed = False
+        self._map_pois_loaded = False
         self._leg_initial_length: float | None = None
         self._leg_start_time: float | None = None
         self._speed_estimate: float | None = None
@@ -337,6 +339,7 @@ class MapNode(Node):
         success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
             self.compute_transform_from_map_to_odom()
+            self._try_load_map_pois()
 
         with Timer(name = "nav path", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
             self.try_publish_nav_path(keyframe_image_timestamp_ns)
@@ -560,6 +563,27 @@ class MapNode(Node):
             pass
 
 
+    def _try_load_map_pois(self):
+        if self._map_pois_loaded or self.pois:
+            return
+        self._map_pois_loaded = True
+        pois_path = os.path.join(self.tinynav_map_path, "pois.json")
+        if not os.path.exists(pois_path):
+            return
+        try:
+            with open(pois_path) as f:
+                data = json.load(f)
+            pois_dict = {}
+            keys = sorted([int(key) for key in data.keys()])
+            for index, key in enumerate(keys):
+                pois_dict[index] = np.array(data[str(key)]["position"])
+            self.pois = pois_dict
+            self.poi_index = min(0, len(self.pois) - 1)
+            self._nav_completed = False
+            self.get_logger().info(f"Loaded {len(self.pois)} POIs from map: {pois_path}")
+        except Exception as e:
+            self.get_logger().error(f"Failed to load POIs from {pois_path}: {e}")
+
     def compute_transform_from_map_to_odom(self):
         """
         Solve the optmization problem.
@@ -684,7 +708,7 @@ class MapNode(Node):
                     start_point = pose_in_map_position[:3]
                     target_position = paths_in_map[-1]
                     for i in range(len(paths_in_map) - 1):
-                        accumulated_distance += np.linalg.norm(paths_in_map[i] - start_point)
+                        accumulated_distance += np.linalg.norm((paths_in_map[i] - start_point)[:2])
                         if accumulated_distance > max_speed * 5:
                             target_position = paths_in_map[i]
                             break

--- a/tinynav/core/math_utils.py
+++ b/tinynav/core/math_utils.py
@@ -215,6 +215,53 @@ def process_keypoints(kpts_prev, kpts_curr, idx_valid, depth, K):
     
     return points_3d[:valid_count], points_2d[:valid_count], valid_idx[:valid_count]
 
+def rerank_by_pnp_inliers(
+    pnp_candidates: list[tuple[np.ndarray, np.ndarray]],
+    K: np.ndarray,
+    min_point_count: int = 80,
+    min_inlier_count: int = 50,
+) -> tuple[bool, np.ndarray, float, int, int, int]:
+    """
+    Estimate PnP for each candidate and return the pose with the most inliers.
+
+    Args:
+        pnp_candidates: list of (points_3d, points_2d) pairs.
+        K: camera intrinsic matrix.
+        min_point_count: minimum number of 3D/2D correspondences required.
+        min_inlier_count: minimum number of PnP inliers required.
+
+    Returns:
+        success, pose, inlier_ratio, best_candidate_index, best_inlier_count, best_point_count.
+    """
+    best_pose = None
+    best_candidate_index = -1
+    best_inlier_count = 0
+    best_point_count = 0
+
+    for candidate_index, (points_3d, points_2d) in enumerate(pnp_candidates):
+        point_count = len(points_2d)
+        if point_count <= min_point_count:
+            continue
+
+        success, rvec, tvec, inliers = cv2.solvePnPRansac(points_3d, points_2d, K, None)
+        inlier_count = 0 if inliers is None else len(inliers)
+        if not success or inliers is None or inlier_count < min_inlier_count:
+            continue
+
+        if inlier_count > best_inlier_count:
+            best_candidate_index = candidate_index
+            best_inlier_count = inlier_count
+            best_point_count = point_count
+            best_pose = np.eye(4)
+            R_mat, _ = cv2.Rodrigues(rvec)
+            best_pose[:3, :3] = R_mat
+            best_pose[:3, 3] = tvec.reshape(3)
+
+    if best_pose is None:
+        return False, np.eye(4), -np.inf, -1, 0, 0
+
+    return True, best_pose, best_inlier_count / best_point_count, best_candidate_index, best_inlier_count, best_point_count
+
 @lru_cache_numpy(maxsize=128)
 def estimate_pose(kpts_prev, kpts_curr, depth, K, idx_valid=None):
     """

--- a/tool/path_editor.py
+++ b/tool/path_editor.py
@@ -178,8 +178,6 @@ class PathEditor:
         self.point_handles: dict[tuple[int, int], viser.SceneHandle] = {}
         self.gizmo_handles: dict[tuple[int, int], viser.SceneHandle] = {}
         self.sdf_preview_handle: viser.SceneHandle | None = None
-        # current = active sdf_map.npy; default = original backup; edited = freshly generated from editable paths only.
-        self.preview_source = "current"
         self.status = None
 
     def _load_sdf_file(self, path: Path) -> np.ndarray | None:
@@ -194,13 +192,6 @@ class PathEditor:
 
     def _edited_sdf_map(self) -> np.ndarray:
         return build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
-
-    def _preview_sdf_map(self) -> np.ndarray | None:
-        if self.preview_source == "default":
-            return self.default_sdf_map
-        if self.preview_source == "edited":
-            return self._edited_sdf_map()
-        return self.current_sdf_map
 
     def _ensure_default_backup(self) -> None:
         if self.default_sdf_map_path.exists():
@@ -315,11 +306,6 @@ class PathEditor:
             add_waypoint = self.server.gui.add_button("Add Waypoint To Selected")
             delete_last_waypoint = self.server.gui.add_button("Delete Last Waypoint")
             delete_path = self.server.gui.add_button("Delete Selected Path", color=(255, 80, 80))
-            save_paths = self.server.gui.add_button("Save Paths JSON")
-            show_current_sdf = self.server.gui.add_button("Show Current SDF Map")
-            show_default_sdf = self.server.gui.add_button("Show Default SDF Map")
-            show_edited_sdf = self.server.gui.add_button("Show Edited Path Map")
-            rebuild_preview = self.server.gui.add_button("Rebuild Preview")
             replace_sdf = self.server.gui.add_button("Replace Current SDF Map", color=(80, 200, 80))
             restore_default_sdf = self.server.gui.add_button("Restore Default SDF Map", color=(80, 120, 255))
 
@@ -381,34 +367,6 @@ class PathEditor:
                 selected.value = self.selected_path_id or 0
                 self._set_status(f"Deleted Path_{path_id}")
 
-            @save_paths.on_click
-            def _(_) -> None:
-                _save_json(self.paths_json_path, self.paths)
-                self._set_status(f"Saved {self.paths_json_path}")
-
-            @show_current_sdf.on_click
-            def _(_) -> None:
-                self.preview_source = "current"
-                self._refresh_sdf_preview()
-                self._set_status("Showing current active SDF map")
-
-            @show_default_sdf.on_click
-            def _(_) -> None:
-                self.preview_source = "default"
-                self._refresh_sdf_preview()
-                self._set_status("Showing default SDF map")
-
-            @show_edited_sdf.on_click
-            def _(_) -> None:
-                self.preview_source = "edited"
-                self._refresh_sdf_preview()
-                self._set_status("Showing edited path map only")
-
-            @rebuild_preview.on_click
-            def _(_) -> None:
-                self._refresh_sdf_preview()
-                self._set_status(f"Rebuilt {self.preview_source} preview")
-
             @replace_sdf.on_click
             def _(_) -> None:
                 # Save a permanent default backup before the first replacement, then write a fully new path map.
@@ -420,7 +378,6 @@ class PathEditor:
                     print(f"Backed up active SDF map to {backup_path}")
                 self.current_sdf_map = self._edited_sdf_map()
                 np.save(self.sdf_map_path, self.current_sdf_map)
-                self.preview_source = "current"
                 self._refresh_sdf_preview()
                 self._set_status(f"Replaced active SDF map with edited path map; saved {self.paths_json_path.name}")
 
@@ -435,7 +392,6 @@ class PathEditor:
                     print(f"Backed up active SDF map to {backup_path}")
                 np.save(self.sdf_map_path, self.default_sdf_map)
                 self.current_sdf_map = self.default_sdf_map.copy()
-                self.preview_source = "current"
                 self._refresh_sdf_preview()
                 self._set_status("Restored default SDF map to active sdf_map.npy")
 
@@ -512,9 +468,9 @@ class PathEditor:
         if self.sdf_preview_handle is not None:
             self.sdf_preview_handle.remove()
             self.sdf_preview_handle = None
-        preview_sdf = self._preview_sdf_map()
+        preview_sdf = self.current_sdf_map
         if preview_sdf is None:
-            print(f"No SDF map available for preview source '{self.preview_source}'")
+            print("No active SDF map available for preview")
             return
         traversable_mask = self.occupancy_grid != 2
         mask = np.logical_and.reduce((traversable_mask, np.isfinite(preview_sdf), preview_sdf < self.args.path_radius_m))
@@ -536,7 +492,7 @@ class PathEditor:
             point_shape="rounded",
         )
         print(
-            f"Previewing {len(points)} low-SDF voxels from {self.preview_source} SDF map "
+            f"Previewing {len(points)} low-SDF voxels from active SDF map "
             f"(threshold={self.args.path_radius_m:.3f}m, total={len(indices_all)})"
         )
 

--- a/tool/path_editor.py
+++ b/tool/path_editor.py
@@ -26,11 +26,11 @@ class Args:
     paths_json_name: str = "paths.json"
     """Editable path control-point file saved under tinynav_map_path."""
 
-    sdf_map_name: str = "sdf_map.npy"
-    """Active SDF path-map file used by Tinynav; Replace Current SDF Map overwrites this file."""
+    path_sdf_map_name: str = "sdf_map.npy"
+    """The active/new path map. Tinynav reads this file."""
 
     default_sdf_map_name: str = "sdf_map.default.npy"
-    """Backup of the original/default SDF path-map, used by Restore Default SDF Map."""
+    """The default/original path map. Restore Default Map copies this over the active path map."""
 
     path_radius_m: float = 0.2
     """SDF distance threshold used by map_node; voxels near edited paths become low-SDF corridor."""
@@ -152,7 +152,7 @@ class PathEditor:
         self.args = args
         self.map_dir = args.tinynav_map_path
         self.paths_json_path = self.map_dir / args.paths_json_name
-        self.sdf_map_path = self.map_dir / args.sdf_map_name
+        self.path_sdf_map_path = self.map_dir / args.path_sdf_map_name
         self.default_sdf_map_path = self.map_dir / args.default_sdf_map_name
 
         self.occupancy_grid = np.load(self.map_dir / "occupancy_grid.npy")
@@ -160,11 +160,11 @@ class PathEditor:
         self.origin = self.occupancy_meta[:3].astype(np.float32)
         self.resolution = float(self.occupancy_meta[3])
         self.shape = tuple(int(v) for v in self.occupancy_grid.shape)
-        self.current_sdf_map = self._load_sdf_file(self.sdf_map_path)
+        self.path_sdf_map = self._load_sdf_file(self.path_sdf_map_path)
         self.default_sdf_map = self._load_sdf_file(self.default_sdf_map_path)
         if self.default_sdf_map is None:
-            # Before the first replacement there is no separate backup, so the active file is the default map.
-            self.default_sdf_map = self.current_sdf_map
+            # First run on an old map: sdf_map.npy is still the default map.
+            self.default_sdf_map = self.path_sdf_map
 
         self.paths = _load_json(self.paths_json_path)
         self.path_id_counter = (max(self.paths.keys()) + 1) if self.paths else 0
@@ -193,14 +193,14 @@ class PathEditor:
     def _edited_sdf_map(self) -> np.ndarray:
         return build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
 
-    def _ensure_default_backup(self) -> None:
+    def _ensure_default_map(self) -> None:
         if self.default_sdf_map_path.exists():
             return
-        if self.current_sdf_map is None:
+        if self.path_sdf_map is None:
             return
-        np.save(self.default_sdf_map_path, self.current_sdf_map)
-        self.default_sdf_map = self.current_sdf_map.copy()
-        print(f"Saved default SDF backup to {self.default_sdf_map_path}")
+        shutil.copy2(self.path_sdf_map_path, self.default_sdf_map_path)
+        self.default_sdf_map = self.path_sdf_map.copy()
+        print(f"Created default map: {self.default_sdf_map_path}")
 
     def run(self) -> None:
         self._add_static_map_layers()
@@ -306,8 +306,8 @@ class PathEditor:
             add_waypoint = self.server.gui.add_button("Add Waypoint To Selected")
             delete_last_waypoint = self.server.gui.add_button("Delete Last Waypoint")
             delete_path = self.server.gui.add_button("Delete Selected Path", color=(255, 80, 80))
-            replace_sdf = self.server.gui.add_button("Replace Current SDF Map", color=(80, 200, 80))
-            restore_default_sdf = self.server.gui.add_button("Restore Default SDF Map", color=(80, 120, 255))
+            replace_sdf = self.server.gui.add_button("Build / Replace Path Map", color=(80, 200, 80))
+            restore_default_sdf = self.server.gui.add_button("Restore Default Map", color=(80, 120, 255))
 
             @selected.on_update
             def _(_) -> None:
@@ -369,31 +369,23 @@ class PathEditor:
 
             @replace_sdf.on_click
             def _(_) -> None:
-                # Save a permanent default backup before the first replacement, then write a fully new path map.
+                # Keep exactly two SDF maps: default_sdf_map_path and path_sdf_map_path.
                 _save_json(self.paths_json_path, self.paths)
-                self._ensure_default_backup()
-                if self.sdf_map_path.exists():
-                    backup_path = self.sdf_map_path.with_suffix(f".bak-{time.strftime('%Y%m%d-%H%M%S')}.npy")
-                    shutil.copy2(self.sdf_map_path, backup_path)
-                    print(f"Backed up active SDF map to {backup_path}")
-                self.current_sdf_map = self._edited_sdf_map()
-                np.save(self.sdf_map_path, self.current_sdf_map)
+                self._ensure_default_map()
+                self.path_sdf_map = self._edited_sdf_map()
+                np.save(self.path_sdf_map_path, self.path_sdf_map)
                 self._refresh_sdf_preview()
-                self._set_status(f"Replaced active SDF map with edited path map; saved {self.paths_json_path.name}")
+                self._set_status(f"Built path map: {self.path_sdf_map_path.name}; saved {self.paths_json_path.name}")
 
             @restore_default_sdf.on_click
             def _(_) -> None:
                 if self.default_sdf_map is None:
-                    self._set_status("No default SDF map available to restore")
+                    self._set_status("No default map available to restore")
                     return
-                if self.sdf_map_path.exists():
-                    backup_path = self.sdf_map_path.with_suffix(f".bak-{time.strftime('%Y%m%d-%H%M%S')}.npy")
-                    shutil.copy2(self.sdf_map_path, backup_path)
-                    print(f"Backed up active SDF map to {backup_path}")
-                np.save(self.sdf_map_path, self.default_sdf_map)
-                self.current_sdf_map = self.default_sdf_map.copy()
+                np.save(self.path_sdf_map_path, self.default_sdf_map)
+                self.path_sdf_map = self.default_sdf_map.copy()
                 self._refresh_sdf_preview()
-                self._set_status("Restored default SDF map to active sdf_map.npy")
+                self._set_status(f"Restored default map into {self.path_sdf_map_path.name}")
 
     def _default_new_point(self) -> np.ndarray:
         traversable = np.argwhere(self.occupancy_grid != 2)
@@ -468,9 +460,9 @@ class PathEditor:
         if self.sdf_preview_handle is not None:
             self.sdf_preview_handle.remove()
             self.sdf_preview_handle = None
-        preview_sdf = self.current_sdf_map
+        preview_sdf = self.path_sdf_map
         if preview_sdf is None:
-            print("No active SDF map available for preview")
+            print("No path map available for preview")
             return
         traversable_mask = self.occupancy_grid != 2
         mask = np.logical_and.reduce((traversable_mask, np.isfinite(preview_sdf), preview_sdf < self.args.path_radius_m))
@@ -492,7 +484,7 @@ class PathEditor:
             point_shape="rounded",
         )
         print(
-            f"Previewing {len(points)} low-SDF voxels from active SDF map "
+            f"Previewing {len(points)} low-SDF voxels from path map "
             f"(threshold={self.args.path_radius_m:.3f}m, total={len(indices_all)})"
         )
 

--- a/tool/path_editor.py
+++ b/tool/path_editor.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import tyro
+import viser
+from plyfile import PlyData
+from scipy.ndimage import distance_transform_edt
+
+
+PathPoint = npt.NDArray[np.floating]
+
+
+@dataclass(frozen=True)
+class Args:
+    tinynav_map_path: Path
+    """Tinynav map directory containing occupancy_grid.npy, occupancy_meta.npy and sdf_map.npy."""
+
+    paths_json_name: str = "paths.json"
+    """Editable path control-point file saved under tinynav_map_path."""
+
+    sdf_map_name: str = "sdf_map.npy"
+    """SDF map file to preview and overwrite when Save SDF Map is clicked."""
+
+    path_radius_m: float = 0.2
+    """SDF distance threshold used by map_node; voxels near edited paths become low-SDF corridor."""
+
+    merge_with_existing_sdf: bool = True
+    """If true, save min(existing_sdf, edited_path_sdf); otherwise replace SDF from edited paths."""
+
+    max_preview_points: int = 300_000
+    """Maximum number of low-SDF voxels rendered in the Viser preview."""
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+
+
+def _load_json(path: Path) -> dict[int, dict[str, Any]]:
+    if not path.exists():
+        return {}
+    with path.open("r") as f:
+        raw = json.load(f)
+    paths: dict[int, dict[str, Any]] = {}
+    for key, value in raw.items():
+        path_id = int(key)
+        points = [np.asarray(p, dtype=np.float32) for p in value.get("points", [])]
+        paths[path_id] = {
+            "id": int(value.get("id", path_id)),
+            "name": str(value.get("name", f"Path_{path_id}")),
+            "points": points,
+            "color": tuple(value.get("color", _random_color())),
+        }
+    return paths
+
+
+def _save_json(path: Path, paths: dict[int, dict[str, Any]]) -> None:
+    serializable = {}
+    for path_id, item in paths.items():
+        serializable[str(path_id)] = {
+            "id": int(item["id"]),
+            "name": item["name"],
+            "points": [np.asarray(p).tolist() for p in item["points"]],
+            "color": list(item["color"]),
+        }
+    with path.open("w") as f:
+        json.dump(serializable, f, indent=2)
+
+
+def _random_color() -> tuple[int, int, int]:
+    return tuple(int(x) for x in np.random.randint(40, 255, size=3))
+
+
+def _grid_to_world(indices: np.ndarray, origin: np.ndarray, resolution: float) -> np.ndarray:
+    if len(indices) == 0:
+        return np.empty((0, 3), dtype=np.float32)
+    return origin[None, :] + indices.astype(np.float32) * float(resolution)
+
+
+def _world_to_grid(points: np.ndarray, origin: np.ndarray, resolution: float, shape: tuple[int, int, int]) -> np.ndarray:
+    indices = np.rint((points - origin[None, :]) / float(resolution)).astype(np.int32)
+    max_index = np.asarray(shape, dtype=np.int32) - 1
+    return np.clip(indices, 0, max_index[None, :])
+
+
+def _line_segments_from_points(points: list[PathPoint]) -> np.ndarray:
+    if len(points) < 2:
+        return np.empty((0, 2, 3), dtype=np.float32)
+    pts = np.asarray(points, dtype=np.float32)
+    return np.stack([pts[:-1], pts[1:]], axis=1)
+
+
+def _sample_polyline_voxels(
+    points: list[PathPoint], origin: np.ndarray, resolution: float, shape: tuple[int, int, int]
+) -> np.ndarray:
+    if not points:
+        return np.empty((0, 3), dtype=np.int32)
+    if len(points) == 1:
+        return _world_to_grid(np.asarray(points, dtype=np.float32), origin, resolution, shape)
+
+    sampled: list[np.ndarray] = []
+    for start, end in zip(points[:-1], points[1:]):
+        start_np = np.asarray(start, dtype=np.float32)
+        end_np = np.asarray(end, dtype=np.float32)
+        distance = float(np.linalg.norm(end_np - start_np))
+        steps = max(2, int(np.ceil(distance / max(float(resolution) * 0.5, 1e-6))) + 1)
+        t = np.linspace(0.0, 1.0, steps, dtype=np.float32)[:, None]
+        sampled.append(start_np[None, :] * (1.0 - t) + end_np[None, :] * t)
+    world_points = np.concatenate(sampled, axis=0)
+    indices = _world_to_grid(world_points, origin, resolution, shape)
+    return np.unique(indices, axis=0)
+
+
+def build_sdf_from_paths(
+    paths: dict[int, dict[str, Any]], origin: np.ndarray, resolution: float, shape: tuple[int, int, int]
+) -> np.ndarray:
+    seed_mask = np.ones(shape, dtype=np.uint8)
+    seed_count = 0
+    for item in paths.values():
+        indices = _sample_polyline_voxels(item["points"], origin, resolution, shape)
+        if len(indices) == 0:
+            continue
+        seed_mask[indices[:, 0], indices[:, 1], indices[:, 2]] = 0
+        seed_count += len(indices)
+    if seed_count == 0:
+        return np.full(shape, np.inf, dtype=np.float32)
+    return distance_transform_edt(seed_mask, sampling=(resolution, resolution, resolution)).astype(np.float32)
+
+
+def _load_pointcloud_ply(ply_file_path: Path) -> tuple[np.ndarray, np.ndarray]:
+    plydata = PlyData.read(ply_file_path)
+    v = plydata["vertex"]
+    positions = np.stack([v["x"], v["y"], v["z"]], axis=-1).astype(np.float32)
+    names = v.data.dtype.names or ()
+    if "red" in names:
+        colors = np.stack([v["red"], v["green"], v["blue"]], axis=-1).astype(np.float32) / 255.0
+    elif "r" in names:
+        colors = np.stack([v["r"], v["g"], v["b"]], axis=-1).astype(np.float32) / 255.0
+    else:
+        colors = np.ones((len(v), 3), dtype=np.float32)
+    return positions, colors
+
+
+class PathEditor:
+    def __init__(self, args: Args):
+        self.args = args
+        self.map_dir = args.tinynav_map_path
+        self.paths_json_path = self.map_dir / args.paths_json_name
+        self.sdf_map_path = self.map_dir / args.sdf_map_name
+
+        self.occupancy_grid = np.load(self.map_dir / "occupancy_grid.npy")
+        self.occupancy_meta = np.load(self.map_dir / "occupancy_meta.npy")
+        self.origin = self.occupancy_meta[:3].astype(np.float32)
+        self.resolution = float(self.occupancy_meta[3])
+        self.shape = tuple(int(v) for v in self.occupancy_grid.shape)
+        self.original_sdf_map = np.load(self.sdf_map_path).astype(np.float32) if self.sdf_map_path.exists() else None
+        if self.original_sdf_map is not None and self.original_sdf_map.shape != self.occupancy_grid.shape:
+            raise ValueError(
+                f"{self.sdf_map_path} shape {self.original_sdf_map.shape} does not match "
+                f"occupancy_grid shape {self.occupancy_grid.shape}"
+            )
+
+        self.paths = _load_json(self.paths_json_path)
+        self.path_id_counter = (max(self.paths.keys()) + 1) if self.paths else 0
+        self.selected_path_id: int | None = next(iter(self.paths.keys()), None)
+
+        self.server = viser.ViserServer(host=args.host, port=args.port)
+        self.server.scene.world_axes.visible = True
+        self.server.scene.set_up_direction("+z")
+
+        self.path_line_handles: dict[int, viser.SceneHandle] = {}
+        self.point_handles: dict[tuple[int, int], viser.SceneHandle] = {}
+        self.gizmo_handles: dict[tuple[int, int], viser.SceneHandle] = {}
+        self.sdf_preview_handle: viser.SceneHandle | None = None
+        self.status = None
+
+    def run(self) -> None:
+        self._add_static_map_layers()
+        self._add_optional_pointcloud()
+        self._add_path_editor_ui()
+        self._refresh_all_paths()
+        self._refresh_sdf_preview()
+        print(f"Path editor is running at http://{self.args.host}:{self.args.port}")
+        while True:
+            time.sleep(1.0)
+
+    def _add_static_map_layers(self) -> None:
+        x_y_plane = np.max(self.occupancy_grid, axis=2)
+        z_plane = float(self.origin[2])
+
+        def xy_world(xy_indices: np.ndarray) -> np.ndarray:
+            points = np.zeros((len(xy_indices), 3), dtype=np.float32)
+            points[:, 0] = float(self.origin[0]) + xy_indices[:, 0] * self.resolution
+            points[:, 1] = float(self.origin[1]) + xy_indices[:, 1] * self.resolution
+            points[:, 2] = z_plane
+            return points
+
+        free_indices = np.argwhere(x_y_plane == 1)
+        occupied_indices = np.argwhere(x_y_plane == 2)
+        free_handle = None
+        occupied_handle = None
+        if len(free_indices) > 0:
+            free_handle = self.server.scene.add_point_cloud(
+                "/occupancy_2d/free",
+                points=xy_world(free_indices),
+                colors=np.tile(np.array([[0.2, 0.4, 1.0]], dtype=np.float32), (len(free_indices), 1)),
+                point_size=self.resolution * 0.8,
+                point_shape="rounded",
+            )
+        if len(occupied_indices) > 0:
+            occupied_base = xy_world(occupied_indices)
+            z_levels = np.arange(z_plane + self.resolution * 0.5, z_plane + 0.8, self.resolution, dtype=np.float32)
+            occupied_points = np.repeat(occupied_base, len(z_levels), axis=0)
+            occupied_points[:, 2] = np.tile(z_levels, len(occupied_base))
+            # Light red, matching poi_editor's occupied-column feel without requiring OpenCV.
+            wall_rgb = np.array([1.0, 0.45, 0.45], dtype=np.float32)
+            occupied_handle = self.server.scene.add_point_cloud(
+                "/occupancy_2d/occupied",
+                points=occupied_points,
+                colors=np.tile(wall_rgb[None, :], (len(occupied_points), 1)),
+                point_size=self.resolution * 0.8,
+                point_shape="rounded",
+            )
+
+        with self.server.gui.add_folder("Occupancy 2D Map"):
+            show_free = self.server.gui.add_checkbox("Show Free", initial_value=True)
+            show_occupied = self.server.gui.add_checkbox("Show Occupied", initial_value=True)
+            point_size = self.server.gui.add_slider(
+                "Point Size", min=0.001, max=max(0.1, self.resolution), step=0.001, initial_value=self.resolution * 0.8
+            )
+
+            @show_free.on_update
+            def _(_) -> None:
+                if free_handle is not None:
+                    free_handle.visible = show_free.value
+
+            @show_occupied.on_update
+            def _(_) -> None:
+                if occupied_handle is not None:
+                    occupied_handle.visible = show_occupied.value
+
+            @point_size.on_update
+            def _(_) -> None:
+                if free_handle is not None:
+                    free_handle.point_size = point_size.value
+                if occupied_handle is not None:
+                    occupied_handle.point_size = point_size.value
+
+    def _add_optional_pointcloud(self) -> None:
+        pointcloud_path = self.map_dir / "pointcloud.ply"
+        if not pointcloud_path.exists():
+            return
+        try:
+            points, colors = _load_pointcloud_ply(pointcloud_path)
+        except Exception as exc:
+            print(f"Warning: failed to load {pointcloud_path}: {exc}")
+            return
+        pc_handle = self.server.scene.add_point_cloud(
+            "/0/point_cloud", points=points, colors=colors, point_size=0.01, point_shape="rounded"
+        )
+        with self.server.gui.add_folder("Point Cloud Settings"):
+            show_pc = self.server.gui.add_checkbox("Show Point Cloud", initial_value=True)
+            point_size = self.server.gui.add_slider("Point Size", min=0.001, max=0.1, step=0.001, initial_value=0.01)
+
+            @show_pc.on_update
+            def _(_) -> None:
+                pc_handle.visible = show_pc.value
+
+            @point_size.on_update
+            def _(_) -> None:
+                pc_handle.point_size = point_size.value
+
+    def _add_path_editor_ui(self) -> None:
+        with self.server.gui.add_folder("SDF Path Editor"):
+            self.status = self.server.gui.add_text("Status", initial_value="Ready")
+            selected = self.server.gui.add_number("Selected Path ID", initial_value=self.selected_path_id or 0, step=1)
+            add_path = self.server.gui.add_button("Add Path")
+            add_waypoint = self.server.gui.add_button("Add Waypoint To Selected")
+            delete_last_waypoint = self.server.gui.add_button("Delete Last Waypoint")
+            delete_path = self.server.gui.add_button("Delete Selected Path", color=(255, 80, 80))
+            save_paths = self.server.gui.add_button("Save Paths JSON")
+            rebuild_preview = self.server.gui.add_button("Rebuild SDF Preview")
+            save_sdf = self.server.gui.add_button("Save SDF Map", color=(80, 200, 80))
+
+            @selected.on_update
+            def _(_) -> None:
+                path_id = int(selected.value)
+                self.selected_path_id = path_id if path_id in self.paths else None
+                self._set_status(f"Selected path: {self.selected_path_id}")
+
+            @add_path.on_click
+            def _(_) -> None:
+                path_id = self.path_id_counter
+                self.path_id_counter += 1
+                selected.value = path_id
+                self.selected_path_id = path_id
+                self.paths[path_id] = {
+                    "id": path_id,
+                    "name": f"Path_{path_id}",
+                    "points": [self._default_new_point()],
+                    "color": _random_color(),
+                }
+                self._refresh_path(path_id)
+                self._set_status(f"Added Path_{path_id}")
+
+            @add_waypoint.on_click
+            def _(_) -> None:
+                if self.selected_path_id is None:
+                    self._set_status("No selected path")
+                    return
+                points = self.paths[self.selected_path_id]["points"]
+                if points:
+                    new_point = np.asarray(points[-1], dtype=np.float32) + np.array([self.resolution * 5, 0.0, 0.0], dtype=np.float32)
+                else:
+                    new_point = self._default_new_point()
+                points.append(new_point)
+                self._refresh_path(self.selected_path_id)
+                self._set_status(f"Added waypoint to Path_{self.selected_path_id}")
+
+            @delete_last_waypoint.on_click
+            def _(_) -> None:
+                if self.selected_path_id is None:
+                    self._set_status("No selected path")
+                    return
+                points = self.paths[self.selected_path_id]["points"]
+                if points:
+                    points.pop()
+                self._refresh_path(self.selected_path_id)
+                self._set_status(f"Deleted last waypoint from Path_{self.selected_path_id}")
+
+            @delete_path.on_click
+            def _(_) -> None:
+                if self.selected_path_id is None:
+                    self._set_status("No selected path")
+                    return
+                path_id = self.selected_path_id
+                self._remove_path_handles(path_id)
+                del self.paths[path_id]
+                self.selected_path_id = next(iter(self.paths.keys()), None)
+                selected.value = self.selected_path_id or 0
+                self._set_status(f"Deleted Path_{path_id}")
+
+            @save_paths.on_click
+            def _(_) -> None:
+                _save_json(self.paths_json_path, self.paths)
+                self._set_status(f"Saved {self.paths_json_path}")
+
+            @rebuild_preview.on_click
+            def _(_) -> None:
+                self._refresh_sdf_preview()
+                self._set_status("Rebuilt SDF preview")
+
+            @save_sdf.on_click
+            def _(_) -> None:
+                _save_json(self.paths_json_path, self.paths)
+                edited_sdf = build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
+                if self.args.merge_with_existing_sdf and self.original_sdf_map is not None:
+                    saved_sdf = np.minimum(self.original_sdf_map, edited_sdf).astype(np.float32)
+                else:
+                    saved_sdf = edited_sdf
+                if self.sdf_map_path.exists():
+                    backup_path = self.sdf_map_path.with_suffix(f".bak-{time.strftime('%Y%m%d-%H%M%S')}.npy")
+                    shutil.copy2(self.sdf_map_path, backup_path)
+                    print(f"Backed up existing SDF map to {backup_path}")
+                np.save(self.sdf_map_path, saved_sdf)
+                self.original_sdf_map = saved_sdf
+                self._refresh_sdf_preview()
+                mode = "merged" if self.args.merge_with_existing_sdf else "replaced"
+                self._set_status(f"Saved {mode} SDF map and {self.paths_json_path.name}")
+
+    def _default_new_point(self) -> np.ndarray:
+        traversable = np.argwhere(self.occupancy_grid != 2)
+        if len(traversable) == 0:
+            return self.origin.copy()
+        center_idx = traversable[len(traversable) // 2]
+        return _grid_to_world(center_idx[None, :], self.origin, self.resolution)[0]
+
+    def _refresh_all_paths(self) -> None:
+        for path_id in list(self.paths.keys()):
+            self._refresh_path(path_id)
+
+    def _refresh_path(self, path_id: int) -> None:
+        self._remove_path_handles(path_id)
+        item = self.paths[path_id]
+        color = tuple(int(c) for c in item["color"])
+        points = item["points"]
+        segments = _line_segments_from_points(points)
+        if len(segments) > 0:
+            colors = np.zeros((len(segments), 2, 3), dtype=np.float32)
+            colors[:, :, :] = np.asarray(color, dtype=np.float32) / 255.0
+            self.path_line_handles[path_id] = self.server.scene.add_line_segments(
+                f"/paths/{item['name']}/line", points=segments, colors=colors, line_width=4.0
+            )
+        for point_idx, point in enumerate(points):
+            key = (path_id, point_idx)
+            point_name = f"/paths/{item['name']}/point_{point_idx}"
+            self.point_handles[key] = self.server.scene.add_icosphere(
+                point_name, radius=max(0.05, self.resolution), color=color, position=np.asarray(point, dtype=np.float32)
+            )
+            gizmo = self.server.scene.add_transform_controls(
+                f"{point_name}_gizmo", position=np.asarray(point, dtype=np.float32), wxyz=(1.0, 0.0, 0.0, 0.0)
+            )
+            self.gizmo_handles[key] = gizmo
+
+            @gizmo.on_update
+            def _(event, pid=path_id, pidx=point_idx, handle=self.point_handles[key]) -> None:
+                new_pos = np.asarray(event.target.position, dtype=np.float32)
+                self.paths[pid]["points"][pidx] = new_pos
+                handle.position = new_pos
+                self._refresh_path_line(pid)
+
+    def _refresh_path_line(self, path_id: int) -> None:
+        if path_id in self.path_line_handles:
+            self.path_line_handles[path_id].remove()
+            del self.path_line_handles[path_id]
+        item = self.paths[path_id]
+        segments = _line_segments_from_points(item["points"])
+        if len(segments) == 0:
+            return
+        color = np.asarray(item["color"], dtype=np.float32) / 255.0
+        colors = np.zeros((len(segments), 2, 3), dtype=np.float32)
+        colors[:, :, :] = color
+        self.path_line_handles[path_id] = self.server.scene.add_line_segments(
+            f"/paths/{item['name']}/line", points=segments, colors=colors, line_width=4.0
+        )
+
+    def _remove_path_handles(self, path_id: int) -> None:
+        if path_id in self.path_line_handles:
+            self.path_line_handles[path_id].remove()
+            del self.path_line_handles[path_id]
+        for key in list(self.point_handles.keys()):
+            if key[0] == path_id:
+                self.point_handles[key].remove()
+                del self.point_handles[key]
+        for key in list(self.gizmo_handles.keys()):
+            if key[0] == path_id:
+                self.gizmo_handles[key].remove()
+                del self.gizmo_handles[key]
+
+    def _refresh_sdf_preview(self) -> None:
+        if self.sdf_preview_handle is not None:
+            self.sdf_preview_handle.remove()
+            self.sdf_preview_handle = None
+        edited_sdf = build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
+        if self.args.merge_with_existing_sdf and self.original_sdf_map is not None:
+            preview_sdf = np.minimum(self.original_sdf_map, edited_sdf)
+        else:
+            preview_sdf = edited_sdf
+        traversable_mask = self.occupancy_grid != 2
+        mask = np.logical_and.reduce((traversable_mask, np.isfinite(preview_sdf), preview_sdf < self.args.path_radius_m))
+        indices_all = np.argwhere(mask)
+        if len(indices_all) == 0:
+            return
+        if len(indices_all) > self.args.max_preview_points:
+            stride = int(np.ceil(len(indices_all) / self.args.max_preview_points))
+            indices = indices_all[::stride]
+        else:
+            indices = indices_all
+        points = _grid_to_world(indices, self.origin, self.resolution)
+        colors = np.tile(np.array([[1.0, 0.0, 1.0]], dtype=np.float32), (len(points), 1))
+        self.sdf_preview_handle = self.server.scene.add_point_cloud(
+            "/sdf_path_preview/low_sdf_voxels",
+            points=points,
+            colors=colors,
+            point_size=self.resolution * 0.8,
+            point_shape="rounded",
+        )
+        print(
+            f"Previewing {len(points)} low-SDF voxels "
+            f"(threshold={self.args.path_radius_m:.3f}m, total={len(indices_all)})"
+        )
+
+    def _set_status(self, value: str) -> None:
+        print(value)
+        if self.status is not None:
+            self.status.value = value
+
+
+def main(args: Args) -> None:
+    PathEditor(args).run()
+
+
+if __name__ == "__main__":
+    main(tyro.cli(Args))

--- a/tool/path_editor.py
+++ b/tool/path_editor.py
@@ -118,16 +118,30 @@ def _sample_polyline_voxels(
 
 
 def build_sdf_from_paths(
-    paths: dict[int, dict[str, Any]], origin: np.ndarray, resolution: float, shape: tuple[int, int, int]
+    paths: dict[int, dict[str, Any]], origin: np.ndarray, resolution: float, shape: tuple[int, int, int],
+    seed_radius_m: float = 0.1,
 ) -> np.ndarray:
     seed_mask = np.ones(shape, dtype=np.uint8)
     seed_count = 0
+    # Dilate seeds by seed_radius_m (in voxels).
+    radius_vox = max(1, int(round(seed_radius_m / resolution)))
+    offsets = []
+    for dx in range(-radius_vox, radius_vox + 1):
+        for dy in range(-radius_vox, radius_vox + 1):
+            for dz in range(-radius_vox, radius_vox + 1):
+                if dx * dx + dy * dy + dz * dz <= radius_vox * radius_vox:
+                    offsets.append((dx, dy, dz))
     for item in paths.values():
         indices = _sample_polyline_voxels(item["points"], origin, resolution, shape)
         if len(indices) == 0:
             continue
-        seed_mask[indices[:, 0], indices[:, 1], indices[:, 2]] = 0
-        seed_count += len(indices)
+        for idx in indices:
+            for dx, dy, dz in offsets:
+                nb = (idx[0] + dx, idx[1] + dy, idx[2] + dz)
+                if 0 <= nb[0] < shape[0] and 0 <= nb[1] < shape[1] and 0 <= nb[2] < shape[2]:
+                    if seed_mask[nb[0], nb[1], nb[2]] != 0:
+                        seed_mask[nb[0], nb[1], nb[2]] = 0
+                        seed_count += 1
     if seed_count == 0:
         return np.full(shape, np.inf, dtype=np.float32)
     return distance_transform_edt(seed_mask, sampling=(resolution, resolution, resolution)).astype(np.float32)

--- a/tool/path_editor.py
+++ b/tool/path_editor.py
@@ -27,13 +27,13 @@ class Args:
     """Editable path control-point file saved under tinynav_map_path."""
 
     sdf_map_name: str = "sdf_map.npy"
-    """SDF map file to preview and overwrite when Save SDF Map is clicked."""
+    """Active SDF path-map file used by Tinynav; Replace Current SDF Map overwrites this file."""
+
+    default_sdf_map_name: str = "sdf_map.default.npy"
+    """Backup of the original/default SDF path-map, used by Restore Default SDF Map."""
 
     path_radius_m: float = 0.2
     """SDF distance threshold used by map_node; voxels near edited paths become low-SDF corridor."""
-
-    merge_with_existing_sdf: bool = True
-    """If true, save min(existing_sdf, edited_path_sdf); otherwise replace SDF from edited paths."""
 
     max_preview_points: int = 300_000
     """Maximum number of low-SDF voxels rendered in the Viser preview."""
@@ -153,18 +153,18 @@ class PathEditor:
         self.map_dir = args.tinynav_map_path
         self.paths_json_path = self.map_dir / args.paths_json_name
         self.sdf_map_path = self.map_dir / args.sdf_map_name
+        self.default_sdf_map_path = self.map_dir / args.default_sdf_map_name
 
         self.occupancy_grid = np.load(self.map_dir / "occupancy_grid.npy")
         self.occupancy_meta = np.load(self.map_dir / "occupancy_meta.npy")
         self.origin = self.occupancy_meta[:3].astype(np.float32)
         self.resolution = float(self.occupancy_meta[3])
         self.shape = tuple(int(v) for v in self.occupancy_grid.shape)
-        self.original_sdf_map = np.load(self.sdf_map_path).astype(np.float32) if self.sdf_map_path.exists() else None
-        if self.original_sdf_map is not None and self.original_sdf_map.shape != self.occupancy_grid.shape:
-            raise ValueError(
-                f"{self.sdf_map_path} shape {self.original_sdf_map.shape} does not match "
-                f"occupancy_grid shape {self.occupancy_grid.shape}"
-            )
+        self.current_sdf_map = self._load_sdf_file(self.sdf_map_path)
+        self.default_sdf_map = self._load_sdf_file(self.default_sdf_map_path)
+        if self.default_sdf_map is None:
+            # Before the first replacement there is no separate backup, so the active file is the default map.
+            self.default_sdf_map = self.current_sdf_map
 
         self.paths = _load_json(self.paths_json_path)
         self.path_id_counter = (max(self.paths.keys()) + 1) if self.paths else 0
@@ -178,7 +178,38 @@ class PathEditor:
         self.point_handles: dict[tuple[int, int], viser.SceneHandle] = {}
         self.gizmo_handles: dict[tuple[int, int], viser.SceneHandle] = {}
         self.sdf_preview_handle: viser.SceneHandle | None = None
+        # current = active sdf_map.npy; default = original backup; edited = freshly generated from editable paths only.
+        self.preview_source = "current"
         self.status = None
+
+    def _load_sdf_file(self, path: Path) -> np.ndarray | None:
+        if not path.exists():
+            return None
+        sdf_map = np.load(path).astype(np.float32)
+        if sdf_map.shape != self.occupancy_grid.shape:
+            raise ValueError(
+                f"{path} shape {sdf_map.shape} does not match occupancy_grid shape {self.occupancy_grid.shape}"
+            )
+        return sdf_map
+
+    def _edited_sdf_map(self) -> np.ndarray:
+        return build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
+
+    def _preview_sdf_map(self) -> np.ndarray | None:
+        if self.preview_source == "default":
+            return self.default_sdf_map
+        if self.preview_source == "edited":
+            return self._edited_sdf_map()
+        return self.current_sdf_map
+
+    def _ensure_default_backup(self) -> None:
+        if self.default_sdf_map_path.exists():
+            return
+        if self.current_sdf_map is None:
+            return
+        np.save(self.default_sdf_map_path, self.current_sdf_map)
+        self.default_sdf_map = self.current_sdf_map.copy()
+        print(f"Saved default SDF backup to {self.default_sdf_map_path}")
 
     def run(self) -> None:
         self._add_static_map_layers()
@@ -285,8 +316,12 @@ class PathEditor:
             delete_last_waypoint = self.server.gui.add_button("Delete Last Waypoint")
             delete_path = self.server.gui.add_button("Delete Selected Path", color=(255, 80, 80))
             save_paths = self.server.gui.add_button("Save Paths JSON")
-            rebuild_preview = self.server.gui.add_button("Rebuild SDF Preview")
-            save_sdf = self.server.gui.add_button("Save SDF Map", color=(80, 200, 80))
+            show_current_sdf = self.server.gui.add_button("Show Current SDF Map")
+            show_default_sdf = self.server.gui.add_button("Show Default SDF Map")
+            show_edited_sdf = self.server.gui.add_button("Show Edited Path Map")
+            rebuild_preview = self.server.gui.add_button("Rebuild Preview")
+            replace_sdf = self.server.gui.add_button("Replace Current SDF Map", color=(80, 200, 80))
+            restore_default_sdf = self.server.gui.add_button("Restore Default SDF Map", color=(80, 120, 255))
 
             @selected.on_update
             def _(_) -> None:
@@ -351,28 +386,58 @@ class PathEditor:
                 _save_json(self.paths_json_path, self.paths)
                 self._set_status(f"Saved {self.paths_json_path}")
 
+            @show_current_sdf.on_click
+            def _(_) -> None:
+                self.preview_source = "current"
+                self._refresh_sdf_preview()
+                self._set_status("Showing current active SDF map")
+
+            @show_default_sdf.on_click
+            def _(_) -> None:
+                self.preview_source = "default"
+                self._refresh_sdf_preview()
+                self._set_status("Showing default SDF map")
+
+            @show_edited_sdf.on_click
+            def _(_) -> None:
+                self.preview_source = "edited"
+                self._refresh_sdf_preview()
+                self._set_status("Showing edited path map only")
+
             @rebuild_preview.on_click
             def _(_) -> None:
                 self._refresh_sdf_preview()
-                self._set_status("Rebuilt SDF preview")
+                self._set_status(f"Rebuilt {self.preview_source} preview")
 
-            @save_sdf.on_click
+            @replace_sdf.on_click
             def _(_) -> None:
+                # Save a permanent default backup before the first replacement, then write a fully new path map.
                 _save_json(self.paths_json_path, self.paths)
-                edited_sdf = build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
-                if self.args.merge_with_existing_sdf and self.original_sdf_map is not None:
-                    saved_sdf = np.minimum(self.original_sdf_map, edited_sdf).astype(np.float32)
-                else:
-                    saved_sdf = edited_sdf
+                self._ensure_default_backup()
                 if self.sdf_map_path.exists():
                     backup_path = self.sdf_map_path.with_suffix(f".bak-{time.strftime('%Y%m%d-%H%M%S')}.npy")
                     shutil.copy2(self.sdf_map_path, backup_path)
-                    print(f"Backed up existing SDF map to {backup_path}")
-                np.save(self.sdf_map_path, saved_sdf)
-                self.original_sdf_map = saved_sdf
+                    print(f"Backed up active SDF map to {backup_path}")
+                self.current_sdf_map = self._edited_sdf_map()
+                np.save(self.sdf_map_path, self.current_sdf_map)
+                self.preview_source = "current"
                 self._refresh_sdf_preview()
-                mode = "merged" if self.args.merge_with_existing_sdf else "replaced"
-                self._set_status(f"Saved {mode} SDF map and {self.paths_json_path.name}")
+                self._set_status(f"Replaced active SDF map with edited path map; saved {self.paths_json_path.name}")
+
+            @restore_default_sdf.on_click
+            def _(_) -> None:
+                if self.default_sdf_map is None:
+                    self._set_status("No default SDF map available to restore")
+                    return
+                if self.sdf_map_path.exists():
+                    backup_path = self.sdf_map_path.with_suffix(f".bak-{time.strftime('%Y%m%d-%H%M%S')}.npy")
+                    shutil.copy2(self.sdf_map_path, backup_path)
+                    print(f"Backed up active SDF map to {backup_path}")
+                np.save(self.sdf_map_path, self.default_sdf_map)
+                self.current_sdf_map = self.default_sdf_map.copy()
+                self.preview_source = "current"
+                self._refresh_sdf_preview()
+                self._set_status("Restored default SDF map to active sdf_map.npy")
 
     def _default_new_point(self) -> np.ndarray:
         traversable = np.argwhere(self.occupancy_grid != 2)
@@ -447,11 +512,10 @@ class PathEditor:
         if self.sdf_preview_handle is not None:
             self.sdf_preview_handle.remove()
             self.sdf_preview_handle = None
-        edited_sdf = build_sdf_from_paths(self.paths, self.origin, self.resolution, self.shape)
-        if self.args.merge_with_existing_sdf and self.original_sdf_map is not None:
-            preview_sdf = np.minimum(self.original_sdf_map, edited_sdf)
-        else:
-            preview_sdf = edited_sdf
+        preview_sdf = self._preview_sdf_map()
+        if preview_sdf is None:
+            print(f"No SDF map available for preview source '{self.preview_source}'")
+            return
         traversable_mask = self.occupancy_grid != 2
         mask = np.logical_and.reduce((traversable_mask, np.isfinite(preview_sdf), preview_sdf < self.args.path_radius_m))
         indices_all = np.argwhere(mask)
@@ -472,7 +536,7 @@ class PathEditor:
             point_shape="rounded",
         )
         print(
-            f"Previewing {len(points)} low-SDF voxels "
+            f"Previewing {len(points)} low-SDF voxels from {self.preview_source} SDF map "
             f"(threshold={self.args.path_radius_m:.3f}m, total={len(indices_all)})"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.12, <3.11"
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'darwin'",
@@ -4016,7 +4016,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "fufpy" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", specifier = "==1.9.2" },
     { name = "lerobot", extras = ["lekiwi"], marker = "extra == 'lekiwi'", specifier = "==0.3.3" },
     { name = "lightglue", marker = "extra == '3dgs'", git = "https://github.com/cvg/LightGlue.git?rev=746fac2c042e05d1865315b1413419f1c1e7ba55" },
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- add `tool/path_editor.py` for editing path control points in Viser
- build a fresh SDF path map from edited paths instead of merging with the default map
- keep a two-map workflow: `sdf_map.default.npy` as the default/original map and `sdf_map.npy` as the active path map
- add UI buttons to build/replace the active path map or restore the default map
