### PR TITLE
fix(nav): throttle replans and follow cached paths

### DIFF
--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -347,7 +347,10 @@ class MapNode(Node):
         success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
             self.compute_transform_from_map_to_odom()
-            self._path_needs_replan = True
+            # Only replan if we don't have a path yet (first reloc or POI change)
+            # Don't replan on every reloc success - that causes path oscillation
+            if self._current_path_in_map is None and self.poi_index != -1 and self.poi_index < len(self.pois):
+                self._path_needs_replan = True
 
     def keyframe_mapping_with_timer(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image):
         with Timer(name="Mapping Loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
@@ -642,9 +645,17 @@ class MapNode(Node):
         poi_pose[:3, 3] = poi
         self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
 
-        # Replan path if needed (heavy, only on relocalization success or POI change)
+        # Replan path if needed (heavy, only when no path exists or POI changed)
+        # Also replan if robot drifted too far from current path start
         if self._path_needs_replan:
             self.replan_nav_path(pose_in_map)
+        elif self._current_path_in_map is not None:
+            # Check if robot drifted too far from path start - trigger replan
+            path_start = self._current_path_in_map[0]
+            drift = np.linalg.norm(pose_in_map_position[:2] - path_start[:2])
+            if drift > 2.0:  # More than 2m from path start
+                self.get_logger().info(f"Robot drifted {drift:.1f}m from path start, triggering replan")
+                self.replan_nav_path(pose_in_map)
 
         # Publish target_pose from cached path (lightweight)
         if self._current_path_in_map is not None:

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -272,6 +272,8 @@ class MapNode(Node):
         self._latest_continuous_odom = None
         self._current_path_in_map = None
         self._path_needs_replan = True
+        self._last_replan_attempt_time = 0.0
+        self._replan_retry_interval_s = 2.0
         self._nav_timer = self.create_timer(0.2, self.nav_timer_callback)  # 5Hz
 
     def pois_callback(self, msg: String):
@@ -287,6 +289,7 @@ class MapNode(Node):
 
             if not self.pois:
                 self.poi_index = -1
+                self._reset_nav_state()
                 # Signal planning_node to clear target_pose so it stops publishing paths
                 dummy_pose = np.eye(4)
                 self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
@@ -294,16 +297,22 @@ class MapNode(Node):
                 return
 
             self.poi_index = min(0, len(self.pois) - 1)
-            self._nav_completed = False
-            self._leg_initial_length = None
-            self._leg_start_time = None
-            self._speed_estimate = None
-            self._path_needs_replan = True
-            self._current_path_in_map = None
+            self._reset_nav_state()
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
             self.pois = {}
+            self.poi_index = -1
+            self._reset_nav_state()
+
+    def _reset_nav_state(self):
+        self._nav_completed = False
+        self._leg_initial_length = None
+        self._leg_start_time = None
+        self._speed_estimate = None
+        self._path_needs_replan = True
+        self._current_path_in_map = None
+        self._last_replan_attempt_time = 0.0
 
     def info_callback(self, msg:CameraInfo):
         if self.K is None:
@@ -645,16 +654,20 @@ class MapNode(Node):
         poi_pose[:3, 3] = poi
         self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
 
-        # Replan path if needed (heavy, only when no path exists or POI changed)
-        # Also replan if robot drifted too far from current path start
+        # Replan path if needed (heavy, only when no path exists or POI changed).
+        # Replan failures are throttled so the 5Hz timer does not run A* continuously.
+        now = time.time()
         if self._path_needs_replan:
-            self.replan_nav_path(pose_in_map)
+            if now - self._last_replan_attempt_time >= self._replan_retry_interval_s:
+                self.replan_nav_path(pose_in_map)
         elif self._current_path_in_map is not None:
-            # Check if robot drifted too far from path start - trigger replan
-            path_start = self._current_path_in_map[0]
-            drift = np.linalg.norm(pose_in_map_position[:2] - path_start[:2])
-            if drift > 2.0:  # More than 2m from path start
-                self.get_logger().info(f"Robot drifted {drift:.1f}m from path start, triggering replan")
+            # Check if robot drifted too far from the cached path - trigger replan.
+            closest_path_dist = min(
+                np.linalg.norm(path_point[:2] - pose_in_map_position[:2])
+                for path_point in self._current_path_in_map
+            )
+            if closest_path_dist > 2.0:  # More than 2m from current path
+                self.get_logger().info(f"Robot drifted {closest_path_dist:.1f}m from cached path, triggering replan")
                 self.replan_nav_path(pose_in_map)
 
         # Publish target_pose from cached path (lightweight)
@@ -663,6 +676,7 @@ class MapNode(Node):
 
     def replan_nav_path(self, pose_in_map: np.ndarray):
         """Heavy: generate nav path via A* on SDF map. Called only when replan is needed."""
+        self._last_replan_attempt_time = time.time()
         target_poi = self.pois[self.poi_index]
         with Timer(name="generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
             paths_in_map = self.generate_nav_path_in_map(pose_in_map=pose_in_map, target_poi=target_poi)
@@ -681,6 +695,7 @@ class MapNode(Node):
                 self._leg_initial_length = remaining_length
                 self._leg_start_time = now
         else:
+            self._path_needs_replan = True
             self.get_logger().warning("Replan failed: no path found in map")
 
     def update_target_pose(self, pose_in_map: np.ndarray):

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -115,6 +115,77 @@ def search_close_to_sdf_map(start_index:tuple, sdf_map:np.ndarray, occupancy_map
                             parent[neighbor] = current
     return []
 
+def _segment_is_shortcut_safe(
+    start: tuple,
+    goal: tuple,
+    sdf_map: np.ndarray,
+    occupancy_map: np.ndarray,
+    resolution: float,
+    max_segment_m: float = 1.0,
+    sdf_margin_m: float = 0.2,
+) -> bool:
+    """Return whether a straight shortcut stays in known-safe map cells."""
+    start_np = np.asarray(start, dtype=np.float32)
+    goal_np = np.asarray(goal, dtype=np.float32)
+    delta = goal_np - start_np
+    distance_m = float(np.linalg.norm(delta) * resolution)
+    if distance_m <= 1e-6:
+        return True
+    if distance_m > max_segment_m:
+        return False
+
+    steps = max(1, int(np.ceil(float(np.max(np.abs(delta))))))
+    max_allowed_sdf = max(float(sdf_map[start]), float(sdf_map[goal]), 0.5) + sdf_margin_m
+    for t in np.linspace(0.0, 1.0, steps + 1):
+        idx = tuple(np.rint(start_np + delta * t).astype(np.int32).tolist())
+        if (
+            idx[0] < 0
+            or idx[0] >= occupancy_map.shape[0]
+            or idx[1] < 0
+            or idx[1] >= occupancy_map.shape[1]
+            or idx[2] < 0
+            or idx[2] >= occupancy_map.shape[2]
+        ):
+            return False
+        if occupancy_map[idx] == 2:
+            return False
+        if not np.isfinite(sdf_map[idx]) or float(sdf_map[idx]) > max_allowed_sdf:
+            return False
+    return True
+
+
+def shortcut_prune_path(
+    path: list,
+    sdf_map: np.ndarray,
+    occupancy_map: np.ndarray,
+    resolution: float,
+    max_segment_m: float = 1.0,
+    max_skip_nodes: int = 30,
+) -> list:
+    """Greedily remove small zig-zags from a voxel path using local line-of-sight."""
+    if len(path) <= 2:
+        return path
+
+    pruned = [path[0]]
+    i = 0
+    while i < len(path) - 1:
+        farthest = i + 1
+        upper = min(len(path) - 1, i + max_skip_nodes)
+        for j in range(upper, i, -1):
+            if _segment_is_shortcut_safe(
+                path[i],
+                path[j],
+                sdf_map,
+                occupancy_map,
+                resolution,
+                max_segment_m=max_segment_m,
+            ):
+                farthest = j
+                break
+        pruned.append(path[farthest])
+        i = farthest
+    return pruned
+
 def search_within_sdf_map( start:tuple, goal:tuple, sdf_map:np.ndarray, occupancy_map:np.ndarray, resolution: float):
     start = tuple(start.flatten()) if isinstance(start, np.ndarray) else start
     goal = tuple(goal.flatten()) if isinstance(goal, np.ndarray) else goal
@@ -272,8 +343,11 @@ class MapNode(Node):
         self._latest_continuous_odom = None
         self._current_path_in_map = None
         self._path_needs_replan = True
+        self._pending_forced_replans = 0
         self._last_replan_attempt_time = 0.0
         self._replan_retry_interval_s = 2.0
+        self._last_shortcut_prune_time = 0.0
+        self._shortcut_prune_interval_s = 2.0
         self._nav_timer = self.create_timer(0.2, self.nav_timer_callback)  # 5Hz
 
     def pois_callback(self, msg: String):
@@ -311,8 +385,10 @@ class MapNode(Node):
         self._leg_start_time = None
         self._speed_estimate = None
         self._path_needs_replan = True
+        self._pending_forced_replans = 0
         self._current_path_in_map = None
         self._last_replan_attempt_time = 0.0
+        self._last_shortcut_prune_time = 0.0
 
     def info_callback(self, msg:CameraInfo):
         if self.K is None:
@@ -355,10 +431,12 @@ class MapNode(Node):
         success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
             self.compute_transform_from_map_to_odom()
-            # Only replan if we don't have a path yet (first reloc or POI change)
-            # Don't replan on every reloc success - that causes path oscillation
-            if self._current_path_in_map is None and self.poi_index != -1 and self.poi_index < len(self.pois):
+            # Every successful relocalization must trigger one path generation.
+            # This forced attempt bypasses retry throttling; follow-up retries for
+            # failures remain throttled in nav_timer_callback.
+            if self.poi_index != -1 and self.poi_index < len(self.pois):
                 self._path_needs_replan = True
+                self._pending_forced_replans += 1
 
     def keyframe_mapping_with_timer(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image):
         with Timer(name="Mapping Loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
@@ -653,12 +731,12 @@ class MapNode(Node):
         poi_pose[:3, 3] = poi
         self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
 
-        # Replan path if needed (heavy, only when no path exists or POI changed).
-        # Replan failures are throttled so the 5Hz timer does not run A* continuously.
+        # Replan path if needed. Every relocalization success queues exactly one
+        # generation attempt; only failure retries are throttled.
         now = time.time()
         if self._path_needs_replan:
-            if now - self._last_replan_attempt_time >= self._replan_retry_interval_s:
-                self.replan_nav_path(pose_in_map)
+            if self._pending_forced_replans > 0 or now - self._last_replan_attempt_time >= self._replan_retry_interval_s:
+                self.replan_nav_path(pose_in_map, forced=self._pending_forced_replans > 0)
         elif self._current_path_in_map is not None:
             # Check if robot drifted too far from the cached path - trigger replan.
             closest_path_dist = min(
@@ -673,16 +751,33 @@ class MapNode(Node):
         if self._current_path_in_map is not None:
             self.update_target_pose(pose_in_map)
 
-    def replan_nav_path(self, pose_in_map: np.ndarray):
+    def replan_nav_path(self, pose_in_map: np.ndarray, forced: bool = False):
         """Heavy: generate nav path via A* on SDF map. Called only when replan is needed."""
-        self._last_replan_attempt_time = time.time()
+        now = time.time()
+        self._last_replan_attempt_time = now
+        if forced:
+            self._pending_forced_replans = max(0, self._pending_forced_replans - 1)
+
+        # Shortcut pruning is useful but extra work; run it periodically, plus
+        # force it for the first path of a leg so the initial plan is compact.
+        apply_shortcut = (
+            self._current_path_in_map is None
+            or now - self._last_shortcut_prune_time >= self._shortcut_prune_interval_s
+        )
+        if apply_shortcut:
+            self._last_shortcut_prune_time = now
+
         target_poi = self.pois[self.poi_index]
         with Timer(name="generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            paths_in_map = self.generate_nav_path_in_map(pose_in_map=pose_in_map, target_poi=target_poi)
+            paths_in_map = self.generate_nav_path_in_map(
+                pose_in_map=pose_in_map,
+                target_poi=target_poi,
+                apply_shortcut=apply_shortcut,
+            )
 
         if paths_in_map is not None:
             self._current_path_in_map = paths_in_map
-            self._path_needs_replan = False
+            self._path_needs_replan = self._pending_forced_replans > 0
 
             remaining_length = sum(
                 np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
@@ -781,7 +876,7 @@ class MapNode(Node):
         self.global_plan_pub.publish(path_msg)
         self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
 
-    def generate_nav_path_in_map(self, pose_in_map: np.ndarray, target_poi: np.ndarray) -> np.ndarray:
+    def generate_nav_path_in_map(self, pose_in_map: np.ndarray, target_poi: np.ndarray, apply_shortcut: bool = True) -> np.ndarray:
         dummy_poi_pose = np.eye(4)
         dummy_poi_pose[:3, 3] = target_poi
         self.poi_pub.publish(np2msg(dummy_poi_pose, self.get_clock().now().to_msg(), "world", "map"))
@@ -816,6 +911,12 @@ class MapNode(Node):
         sdf_start_path = search_close_to_sdf_map(start_idx, self.sdf_map, self.occupancy_map, 0.2)
         sdf_goal_path = search_close_to_sdf_map(poi_goal_idx, self.sdf_map, self.occupancy_map, 0.2)
 
+        if len(sdf_start_path) == 0 or len(sdf_goal_path) == 0:
+            self.get_logger().warning(
+                f"search_close_to_sdf_map returned empty path: start_idx={tuple(start_idx)}, goal_idx={tuple(poi_goal_idx)}"
+            )
+            return None
+
         sdf_start_sdf = sdf_start_path[-1]
         sdf_goal_sdf = sdf_goal_path[-1]
         path_sdf = search_within_sdf_map(sdf_start_sdf, sdf_goal_sdf, self.sdf_map, self.occupancy_map, resolution)
@@ -825,6 +926,11 @@ class MapNode(Node):
             )
         path = sdf_start_path + path_sdf + sdf_goal_path[::-1]
         if len(path) > 0:
+            if apply_shortcut:
+                pruned_path = shortcut_prune_path(path, self.sdf_map, self.occupancy_map, resolution)
+                if len(pruned_path) < len(path):
+                    self.get_logger().info(f"shortcut pruned nav path: {len(path)} -> {len(pruned_path)} points")
+                path = pruned_path
             converted_path = np.array(path) * resolution + occupancy_map_origin
             return converted_path
         return None

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -352,7 +352,6 @@ class MapNode(Node):
         self.keyframe_mapping(keyframe_image_msg, keyframe_odom_msg, depth_msg)
         image = self.bridge.imgmsg_to_cv2(keyframe_image_msg, desired_encoding="mono8")
 
-        keyframe_image_timestamp_ns = int(keyframe_image_msg.header.stamp.sec * 1e9) + int(keyframe_image_msg.header.stamp.nanosec)
         success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
             self.compute_transform_from_map_to_odom()

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -688,10 +688,19 @@ class MapNode(Node):
         paths_in_map = self._current_path_in_map
         pose_in_map_position = pose_in_map[:3, 3]
 
-        # Compute remaining length and progress
+        # Find closest point on path to current position
+        closest_idx = 0
+        closest_dist = float('inf')
+        for i in range(len(paths_in_map)):
+            dist = np.linalg.norm(paths_in_map[i][:2] - pose_in_map_position[:2])
+            if dist < closest_dist:
+                closest_dist = dist
+                closest_idx = i
+
+        # Compute remaining length from closest point to end
         remaining_length = sum(
             np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
-            for i in range(len(paths_in_map) - 1)
+            for i in range(closest_idx, len(paths_in_map) - 1)
         ) if len(paths_in_map) > 1 else 0.0
 
         now = time.time()
@@ -715,20 +724,19 @@ class MapNode(Node):
             })
             self.nav_progress_pub.publish(progress_msg)
 
-        # Find look-ahead target position
+        # Find look-ahead target: start from closest point, look ahead by max_speed * 5
         max_speed = 0.5
-        if len(paths_in_map) > 1:
+        lookahead_distance = max_speed * 5
+        if len(paths_in_map) > 1 and closest_idx < len(paths_in_map) - 1:
             accumulated_distance = 0.0
-            start_point = pose_in_map_position[:3]
-            target_position = paths_in_map[-1]
-            for i in range(len(paths_in_map) - 1):
-                accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
-                if accumulated_distance > max_speed * 5:
-                    target_position = paths_in_map[i]
+            target_position = paths_in_map[-1]  # default to end
+            for i in range(closest_idx, len(paths_in_map) - 1):
+                accumulated_distance += np.linalg.norm(paths_in_map[i + 1][:2] - paths_in_map[i][:2])
+                if accumulated_distance > lookahead_distance:
+                    target_position = paths_in_map[i + 1]
                     break
-                start_point = paths_in_map[i]
         else:
-            target_position = paths_in_map[0]
+            target_position = paths_in_map[closest_idx]
 
         # Transform target from map frame to odom frame
         target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
@@ -740,11 +748,12 @@ class MapNode(Node):
 
         self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
 
-        # Publish global plan path
+        # Publish remaining global plan path (from closest point onwards)
         path_msg = Path()
         path_msg.header.stamp = self.get_clock().now().to_msg()
         path_msg.header.frame_id = "map"
-        for x, y, z in paths_in_map:
+        for i in range(closest_idx, len(paths_in_map)):
+            x, y, z = paths_in_map[i]
             pose = PoseStamped()
             pose.header = path_msg.header
             pose.pose.position.x = x

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -268,6 +268,12 @@ class MapNode(Node):
 
         self._save_completed = False
 
+        # Nav timer: decouple target_pose update from keyframe callback
+        self._latest_continuous_odom = None
+        self._current_path_in_map = None
+        self._path_needs_replan = True
+        self._nav_timer = self.create_timer(0.2, self.nav_timer_callback)  # 5Hz
+
     def pois_callback(self, msg: String):
         self.get_logger().info("Received POIs from planner: " + msg.data)
         try:
@@ -292,6 +298,8 @@ class MapNode(Node):
             self._leg_initial_length = None
             self._leg_start_time = None
             self._speed_estimate = None
+            self._path_needs_replan = True
+            self._current_path_in_map = None
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
@@ -308,6 +316,8 @@ class MapNode(Node):
 
     def continuous_odom_callback(self, odom_msg: Odometry):
         self.continuous_odom_recorder.record_odometry_msg(odom_msg)
+        odom, _ = msg2np(odom_msg)
+        self._latest_continuous_odom = odom
 
     def localization_stop_callback(self, msg: Bool):
         if msg.data:
@@ -337,13 +347,7 @@ class MapNode(Node):
         success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
             self.compute_transform_from_map_to_odom()
-
-        with Timer(name = "nav path", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            self.try_publish_nav_path(keyframe_image_timestamp_ns)
-            # timer or queue for publish the nav path
-            # and record the map pose
-            # compute the coordinate transform from the map pose to the keyframe pose
-            # publish the nav path from the map pose to the keyframe pose with the cost map
+            self._path_needs_replan = True
 
     def keyframe_mapping_with_timer(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image):
         with Timer(name="Mapping Loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
@@ -579,31 +583,26 @@ class MapNode(Node):
         optimized_parameters = pose_graph_solve(optimized_parameters, relative_pose_constraint, constant_pose_index_dict, max_iteration_num = 1000)
         self.T_from_map_to_odom = optimized_parameters[0]
 
-    def try_publish_nav_path(self, timestamp: int):
-        self.get_logger().info(f"try_publish_nav_path, timestamp: {timestamp}")
+    def nav_timer_callback(self):
+        """Lightweight timer callback (5Hz) for target_pose updates using continuous odom."""
         if self.T_from_map_to_odom is None:
-            self.get_logger().info("Relocalization not successful yet, skip publishing nav path")
             return
-
+        if self._latest_continuous_odom is None:
+            return
         if self.poi_index == -1:
-            self.get_logger().info("No POI found, skip publishing nav path")
             return
-
         if self.poi_index >= len(self.pois):
-            self.get_logger().info("All POIs have been visited, skip publishing nav path")
+            if not self._nav_completed:
+                self._nav_completed = True
+                self.get_logger().info("All POIs have been visited, nav done")
+                self.nav_done_pub.publish(Bool(data=True))
             return
 
-        poi = self.pois[self.poi_index]
-        print(f"poi: {poi}")
-        poi_pose = np.eye(4)
-        poi_pose[:3, 3] = poi
-        self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
-        # get the pose from the map to the odom
-        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self.pose_graph_used_pose[timestamp]
+        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self._latest_continuous_odom
+        pose_in_map_position = pose_in_map[:3, 3]
         self.current_pose_in_map_pub.publish(np2msg(pose_in_map, self.get_clock().now().to_msg(), "world", "map"))
 
-        pose_in_map_position = pose_in_map[:3, 3]
-
+        # Check POI arrival
         while self.poi_index < len(self.pois):
             poi = self.pois[self.poi_index]
             diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
@@ -622,12 +621,10 @@ class MapNode(Node):
                 self.poi_index += 1
                 self._leg_initial_length = None
                 self._leg_start_time = None
+                self._path_needs_replan = True
+                self._current_path_in_map = None
                 dummy_pose = np.eye(4)
-
-                stamp_msg = self.get_clock().now().to_msg()
-                stamp_msg.sec = int(timestamp / 1e9)
-                stamp_msg.nanosec = int(timestamp % 1e9)
-                self.poi_change_pub.publish(np2msg(dummy_pose, stamp_msg, "world", "map"))
+                self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
                 continue
             else:
                 break
@@ -639,11 +636,30 @@ class MapNode(Node):
                 self.nav_done_pub.publish(Bool(data=True))
             return
 
+        # Publish current POI
+        poi = self.pois[self.poi_index]
+        poi_pose = np.eye(4)
+        poi_pose[:3, 3] = poi
+        self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
+
+        # Replan path if needed (heavy, only on relocalization success or POI change)
+        if self._path_needs_replan:
+            self.replan_nav_path(pose_in_map)
+
+        # Publish target_pose from cached path (lightweight)
+        if self._current_path_in_map is not None:
+            self.update_target_pose(pose_in_map)
+
+    def replan_nav_path(self, pose_in_map: np.ndarray):
+        """Heavy: generate nav path via A* on SDF map. Called only when replan is needed."""
         target_poi = self.pois[self.poi_index]
-        with Timer(name = "generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            paths_in_map = self.generate_nav_path_in_map(pose_in_map = pose_in_map, target_poi = target_poi)
+        with Timer(name="generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
+            paths_in_map = self.generate_nav_path_in_map(pose_in_map=pose_in_map, target_poi=target_poi)
 
         if paths_in_map is not None:
+            self._current_path_in_map = paths_in_map
+            self._path_needs_replan = False
+
             remaining_length = sum(
                 np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
                 for i in range(len(paths_in_map) - 1)
@@ -653,7 +669,22 @@ class MapNode(Node):
             if self._leg_initial_length is None:
                 self._leg_initial_length = remaining_length
                 self._leg_start_time = now
+        else:
+            self.get_logger().warning("Replan failed: no path found in map")
 
+    def update_target_pose(self, pose_in_map: np.ndarray):
+        """Lightweight: compute and publish target_pose from cached path."""
+        paths_in_map = self._current_path_in_map
+        pose_in_map_position = pose_in_map[:3, 3]
+
+        # Compute remaining length and progress
+        remaining_length = sum(
+            np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
+            for i in range(len(paths_in_map) - 1)
+        ) if len(paths_in_map) > 1 else 0.0
+
+        now = time.time()
+        if self._leg_initial_length is not None:
             covered = self._leg_initial_length - remaining_length
             elapsed = now - self._leg_start_time
             if covered > 0.1 and elapsed > 1.0:
@@ -673,49 +704,48 @@ class MapNode(Node):
             })
             self.nav_progress_pub.publish(progress_msg)
 
-            # use the max_speed to publish the position the robot should be after 5 seconds
-            with Timer(name = "Find target position", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-                max_speed = 0.5
-                if len(paths_in_map) > 1:
-                    accumulated_distance = 0.0
-                    start_point = pose_in_map_position[:3]
-                    target_position = paths_in_map[-1]
-                    for i in range(len(paths_in_map) - 1):
-                        accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
-                        if accumulated_distance > max_speed * 5:
-                            target_position = paths_in_map[i]
-                            break
-                        start_point = paths_in_map[i]
-                else:
-                    target_position = paths_in_map[0]
-                target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
-                pose_in_origin_odom = self.odom[timestamp]
-                T = pose_in_origin_odom @ np.linalg.inv(pose_in_map)
-                target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
-                dummy_pose = np.eye(4)
-                dummy_pose[:3, 3] = target_position_in_odom
-                #logging.info(f"target_position_in_odom: {target_position_in_odom}")
-                print(f"target_position_in_odom: {target_position_in_odom}")
-
-                self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
-                path_msg = Path()
-                path_msg.header.stamp = self.get_clock().now().to_msg()
-                path_msg.header.frame_id = "map"
-                for x, y, z in paths_in_map:
-                    pose = PoseStamped()
-                    pose.header = path_msg.header
-                    pose.pose.position.x = x
-                    pose.pose.position.y = y
-                    pose.pose.position.z = z
-                    pose.pose.orientation.x = 0.0
-                    pose.pose.orientation.y = 0.0
-                    pose.pose.orientation.z = 0.0
-                    pose.pose.orientation.w = 1.0
-                    path_msg.poses.append(pose)
-                self.global_plan_pub.publish(path_msg)
-                self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
+        # Find look-ahead target position
+        max_speed = 0.5
+        if len(paths_in_map) > 1:
+            accumulated_distance = 0.0
+            start_point = pose_in_map_position[:3]
+            target_position = paths_in_map[-1]
+            for i in range(len(paths_in_map) - 1):
+                accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
+                if accumulated_distance > max_speed * 5:
+                    target_position = paths_in_map[i]
+                    break
+                start_point = paths_in_map[i]
         else:
-            logging.info("No path found in map")
+            target_position = paths_in_map[0]
+
+        # Transform target from map frame to odom frame
+        target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
+        T = self._latest_continuous_odom @ np.linalg.inv(pose_in_map)
+        target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
+        dummy_pose = np.eye(4)
+        dummy_pose[:3, 3] = target_position_in_odom
+        print(f"target_position_in_odom: {target_position_in_odom}")
+
+        self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
+
+        # Publish global plan path
+        path_msg = Path()
+        path_msg.header.stamp = self.get_clock().now().to_msg()
+        path_msg.header.frame_id = "map"
+        for x, y, z in paths_in_map:
+            pose = PoseStamped()
+            pose.header = path_msg.header
+            pose.pose.position.x = x
+            pose.pose.position.y = y
+            pose.pose.position.z = z
+            pose.pose.orientation.x = 0.0
+            pose.pose.orientation.y = 0.0
+            pose.pose.orientation.z = 0.0
+            pose.pose.orientation.w = 1.0
+            path_msg.poses.append(pose)
+        self.global_plan_pub.publish(path_msg)
+        self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
 
     def generate_nav_path_in_map(self, pose_in_map: np.ndarray, target_poi: np.ndarray) -> np.ndarray:
         dummy_poi_pose = np.eye(4)


### PR DESCRIPTION
## Summary
- Decouple nav target pose updates from keyframe callbacks so navigation can update on the timer
- Reuse cached paths and only replan when the path is missing, POI changes, or the robot drifts away from the cached path
- Throttle failed replan retries to avoid hammering A* from the 5Hz nav timer
- Remove an unused keyframe timestamp variable

## Testing
- `python3 -m py_compile tinynav/core/map_node.py`
- `git diff --check`
