### PR TITLE
feat: auto-localization assist — yaw sweep until localized

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -76,6 +76,7 @@ class BackendNode(Ros2NodeManager):
 
         # Planning / localization state (read via get_planning_snapshot)
         self._odom_pose: dict | None = None
+        self._odom_pose_received_at: float | None = None
         self._odom_pose_at_kf: dict | None = None  # odom pose snapshotted at last mapPose update
         self._map_pose: dict | None = None
         self._localized: bool = False
@@ -202,6 +203,7 @@ class BackendNode(Ros2NodeManager):
         with self._lock:
             self.current_pose = pose
             self._odom_pose = pose
+            self._odom_pose_received_at = time.monotonic()
         for cb in self.pose_callbacks:
             try:
                 cb(pose)
@@ -786,7 +788,7 @@ class BackendNode(Ros2NodeManager):
     def _stop_loc_assist(self):
         """Stop the yaw sweep thread if running, publish zero cmd_vel."""
         self._loc_assist_stop_event.set()
-        if self._loc_assist_thread is not None:
+        if self._loc_assist_thread is not None and self._loc_assist_thread is not threading.current_thread():
             self._loc_assist_thread.join(timeout=6.0)
             self._loc_assist_thread = None
         # Ensure robot stops
@@ -808,11 +810,14 @@ class BackendNode(Ros2NodeManager):
         - Turn CCW 80° (net -40° from start), wait dwell_s
         - ... expanding sweep until localized
 
-        Uses angular velocity to turn for a computed duration, then dwells.
-        Stops immediately when localized or stop event is set.
+        The turn amount is closed-loop against SLAM odometry yaw. While turning,
+        publish cmd_vel continuously so downstream controllers do not need to
+        latch a single Twist command.
         """
         dwell_s = 5.0
         angular_speed = 0.4  # rad/s
+        cmd_rate_hz = 10.0
+        yaw_tolerance = math.radians(2.0)
         step_deg = 20.0
         step_rad = math.radians(step_deg)
         stop = self._loc_assist_stop_event
@@ -825,21 +830,119 @@ class BackendNode(Ros2NodeManager):
         direction = 1   # +1 = CW, -1 = CCW
 
         while not stop.is_set():
-            # Turn: angle = turn_index * step_rad
+            # Turn relative to the current odom yaw. Positive angular.z is CCW,
+            # so the previous CW command maps to a negative target delta.
             angle = turn_index * step_rad
-            duration = angle / angular_speed
-            # Publish angular velocity
-            self._publish_cmd_vel(0.0, -direction * angular_speed)
-            if self._wait_or_localized(duration, stop):
+            target_delta = -direction * angle
+            if self._turn_relative_by_odom(
+                target_delta=target_delta,
+                angular_speed=angular_speed,
+                cmd_rate_hz=cmd_rate_hz,
+                yaw_tolerance=yaw_tolerance,
+                stop=stop,
+            ):
                 return
-            # Stop turning
-            self._publish_cmd_vel(0.0, 0.0)
             # Dwell
             if self._wait_or_localized(dwell_s, stop):
                 return
             # Next sweep: increase index, flip direction
             turn_index += 1
             direction *= -1
+
+    @staticmethod
+    def _wrap_angle(angle: float) -> float:
+        """Wrap an angle to [-pi, pi]."""
+        return math.atan2(math.sin(angle), math.cos(angle))
+
+    def _latest_odom_yaw(self, max_age_s: float = 1.0) -> float | None:
+        with self._lock:
+            pose = self._odom_pose
+            received_at = self._odom_pose_received_at
+        if pose is None or received_at is None:
+            return None
+        if time.monotonic() - received_at > max_age_s:
+            return None
+        yaw = pose.get('yaw')
+        return float(yaw) if yaw is not None else None
+
+    def _turn_relative_by_odom(
+        self,
+        target_delta: float,
+        angular_speed: float,
+        cmd_rate_hz: float,
+        yaw_tolerance: float,
+        stop: threading.Event,
+    ) -> bool:
+        """
+        Turn until odometry yaw reaches target_delta relative to the turn start.
+        Returns True if the assist loop should stop (localized or stop event set).
+        """
+        interval = 1.0 / max(cmd_rate_hz, 1.0)
+        max_duration = abs(target_delta) / max(angular_speed, 1e-3) + 3.0
+
+        start_wait = time.monotonic()
+        start_yaw = self._latest_odom_yaw()
+        while start_yaw is None:
+            if self._should_stop_loc_assist(stop):
+                return True
+            # Do not blind-turn without fresh odometry.
+            self._publish_cmd_vel(0.0, 0.0)
+            if time.monotonic() - start_wait > 5.0:
+                self.get_logger().warn('Localization assist waiting for fresh odometry yaw')
+                start_wait = time.monotonic()
+            time.sleep(interval)
+            start_yaw = self._latest_odom_yaw()
+
+        angular_z = math.copysign(abs(angular_speed), target_delta)
+        start_time = time.monotonic()
+        previous_yaw = start_yaw
+        accumulated_delta = 0.0
+
+        while True:
+            if self._should_stop_loc_assist(stop):
+                return True
+
+            current_yaw = self._latest_odom_yaw()
+            if current_yaw is None:
+                # Odometry disappeared; stop rather than continuing open-loop.
+                self._publish_cmd_vel(0.0, 0.0)
+                time.sleep(interval)
+                continue
+
+            accumulated_delta += self._wrap_angle(current_yaw - previous_yaw)
+            previous_yaw = current_yaw
+            remaining = target_delta - accumulated_delta
+            if abs(remaining) <= yaw_tolerance:
+                self._publish_cmd_vel(0.0, 0.0)
+                return False
+
+            # If we overshot, stop this segment instead of commanding a reverse
+            # correction sweep. The next sweep segment will continue the pattern.
+            if math.copysign(1.0, remaining) != math.copysign(1.0, target_delta):
+                self._publish_cmd_vel(0.0, 0.0)
+                return False
+
+            if time.monotonic() - start_time > max_duration:
+                self.get_logger().warn(
+                    f'Localization assist turn timeout: target_delta={target_delta:.3f} '
+                    f'accumulated_delta={accumulated_delta:.3f} remaining={remaining:.3f}'
+                )
+                self._publish_cmd_vel(0.0, 0.0)
+                return False
+
+            self._publish_cmd_vel(0.0, angular_z)
+            time.sleep(interval)
+
+    def _should_stop_loc_assist(self, stop: threading.Event) -> bool:
+        if stop.is_set():
+            self._publish_cmd_vel(0.0, 0.0)
+            return True
+        with self._lock:
+            localized = self._localized
+        if localized:
+            self._publish_cmd_vel(0.0, 0.0)
+            return True
+        return False
 
     def _wait_or_localized(self, duration: float, stop: threading.Event) -> bool:
         """
@@ -849,13 +952,8 @@ class BackendNode(Ros2NodeManager):
         elapsed = 0.0
         interval = 0.1
         while elapsed < duration:
-            if stop.is_set():
-                self._publish_cmd_vel(0.0, 0.0)
+            if self._should_stop_loc_assist(stop):
                 return True
-            with self._lock:
-                if self._localized:
-                    self._publish_cmd_vel(0.0, 0.0)
-                    return True
             time.sleep(interval)
             elapsed += interval
         return False

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -56,6 +56,7 @@ _IMAGE_TOPICS_LOOPER = [
 ]
 _IMAGE_TOPICS_ALL = _IMAGE_TOPICS_REALSENSE  # fallback
 _PREVIEW_MIN_INTERVAL = 0.2  # 5 fps
+_VIO_STATUS_NORMAL = {'TRACKING', 'TRACKING_STATIC'}
 
 
 class BackendNode(Ros2NodeManager):
@@ -162,6 +163,14 @@ class BackendNode(Ros2NodeManager):
         self._loc_assist_thread: threading.Thread | None = None
         self._loc_assist_stop_event = threading.Event()
 
+        # Insight VIO guard: stop nav when VIO loses tracking, then resume the
+        # remaining POI queue after VIO recovers and relocalization succeeds.
+        self._vio_status: str | None = None
+        self._vio_guard_stopped: bool = False
+        self._vio_guard_recovering: bool = False
+        self._vio_resume_poi_refs: list[int | str] = []
+        self._active_nav_poi_refs: list[int | str] = []
+
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
         self._map_handoff_active: bool = False
@@ -171,6 +180,7 @@ class BackendNode(Ros2NodeManager):
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
         self.create_subscription(String, '/mapping/nav_progress', self._on_nav_progress, 10)
+        self.create_subscription(String, '/insight/vio_status', self._on_vio_status, 10)
         self._detect_and_init_sensor()
         self._start_unitree_if_configured()
 
@@ -225,6 +235,92 @@ class BackendNode(Ros2NodeManager):
             self._maybe_start_map_handoff(data)
         except json.JSONDecodeError:
             pass
+
+    def _on_vio_status(self, msg: String):
+        status = msg.data.strip().upper()
+        normal = status in _VIO_STATUS_NORMAL
+
+        with self._lock:
+            previous_status = self._vio_status
+            self._vio_status = status
+            already_stopped = self._vio_guard_stopped
+            recovering = self._vio_guard_recovering
+            nav_running = self._nav_nodes_running
+
+        if normal:
+            if already_stopped and not recovering:
+                self._recover_from_vio_guard_stop(status)
+            return
+
+        if already_stopped or not nav_running:
+            return
+
+        self._stop_for_vio_guard(status, previous_status)
+
+    def _stop_for_vio_guard(self, status: str, previous_status: str | None):
+        resume_refs = self._remaining_nav_poi_refs_for_resume()
+        with self._lock:
+            self._vio_guard_stopped = True
+            self._vio_guard_recovering = False
+            self._vio_resume_poi_refs = resume_refs
+            self._localized = False
+
+        self.get_logger().warn(
+            f'Insight VIO abnormal ({previous_status!r} -> {status!r}); '
+            f'stopping nav nodes, remaining_pois={resume_refs!r}'
+        )
+        self.cmd_stop_nav_nodes()
+        with self._lock:
+            if self.state == 'navigation':
+                self.state = 'idle'
+        self._pub_state()
+
+    def _recover_from_vio_guard_stop(self, status: str):
+        with self._lock:
+            resume_refs = list(self._vio_resume_poi_refs)
+            if not self._vio_guard_stopped or self._vio_guard_recovering:
+                return
+            self._vio_guard_recovering = True
+
+        self.get_logger().info(
+            f'Insight VIO recovered ({status!r}); starting nav nodes before resuming POIs={resume_refs!r}'
+        )
+        self.cmd_start_nav_nodes()
+
+    def _remaining_nav_poi_refs_for_resume(self) -> list[int | str]:
+        with self._lock:
+            refs = list(self._active_nav_poi_refs)
+            progress = dict(self._nav_progress) if self._nav_progress else None
+
+        if not refs:
+            return []
+
+        index = 0
+        if progress:
+            try:
+                index = int(progress.get('poi_index', 0))
+                percent = float(progress.get('percent', 0.0))
+                if percent >= 100.0:
+                    index += 1
+            except (TypeError, ValueError):
+                index = 0
+        index = max(0, min(index, len(refs)))
+        return refs[index:]
+
+    def _resume_vio_pois_after_localized(self):
+        with self._lock:
+            if not self._vio_guard_stopped or not self._vio_guard_recovering:
+                return
+            resume_refs = list(self._vio_resume_poi_refs)
+            self._vio_guard_stopped = False
+            self._vio_guard_recovering = False
+            self._vio_resume_poi_refs = []
+
+        if resume_refs:
+            self.get_logger().info(f'Resuming POIs after VIO recovery localization: {resume_refs!r}')
+            self.cmd_send_pois(resume_refs)
+        else:
+            self.get_logger().info('VIO recovered and localized; no remaining POIs to resume')
 
     def _maybe_start_map_handoff(self, progress: dict):
         """Demo map-collaboration hook.
@@ -788,6 +884,8 @@ class BackendNode(Ros2NodeManager):
             nav_nodes = self._nav_nodes_running
             nav_paused = self._nav_paused
             loc_assist = self._loc_assist_enabled
+            vio_status = self._vio_status
+            vio_guard_stopped = self._vio_guard_stopped
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -801,6 +899,8 @@ class BackendNode(Ros2NodeManager):
             'navNodesRunning': nav_nodes,
             'navPaused': nav_paused,
             'locAssistEnabled': loc_assist,
+            'vioStatus': vio_status,
+            'vioGuardStopped': vio_guard_stopped,
         }
 
     @staticmethod
@@ -1181,10 +1281,19 @@ class BackendNode(Ros2NodeManager):
             nav_running = self._nav_nodes_running
             cmd_vel_proc = self._cmd_vel_proc
             if cmd_vel_proc is not None and cmd_vel_proc.poll() is None:
-                return
-            if cmd_vel_proc is not None:
-                self._cmd_vel_proc = None
-        if not loc_assist or not nav_running:
+                already_running = True
+            else:
+                already_running = False
+                if cmd_vel_proc is not None:
+                    self._cmd_vel_proc = None
+        if not nav_running:
+            self._resume_vio_pois_after_localized()
+            return
+        if already_running:
+            self._resume_vio_pois_after_localized()
+            return
+        if not loc_assist:
+            self._resume_vio_pois_after_localized()
             return
         # Stop the sweep
         self._stop_loc_assist()
@@ -1203,6 +1312,7 @@ class BackendNode(Ros2NodeManager):
                 env=_env,
             )
         self.get_logger().info('Localization achieved — cmd_vel_control started')
+        self._resume_vio_pois_after_localized()
 
     def cmd_bag_start(self):
         if self._sensor_mode == 'looper':
@@ -1419,6 +1529,9 @@ class BackendNode(Ros2NodeManager):
         Items may be integer POI IDs or POI names. The payload is re-indexed as
         a dense queue while preserving each POI's original id/name metadata.
         """
+        with self._lock:
+            self._active_nav_poi_refs = list(poi_ids)
+            self._nav_progress = None
         if not poi_ids:
             self._cmd_pois_pub.publish(String(data='{}'))
         else:
@@ -1461,6 +1574,9 @@ class BackendNode(Ros2NodeManager):
 
     def cmd_nav_start(self, poi_id: str | None = None):
         if poi_id is not None:
+            with self._lock:
+                self._active_nav_poi_refs = [int(poi_id)]
+                self._nav_progress = None
             self._publish_cmd_pois(int(poi_id))
         with self._lock:
             nav_running = self._nav_nodes_running
@@ -1475,6 +1591,11 @@ class BackendNode(Ros2NodeManager):
     def cmd_nav_cancel(self):
         if self.state != 'navigation':
             return
+        with self._lock:
+            self._active_nav_poi_refs = []
+            self._vio_resume_poi_refs = []
+            self._vio_guard_stopped = False
+            self._vio_guard_recovering = False
         with self._lock:
             nav_running = self._nav_nodes_running
         if nav_running:

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -977,11 +977,14 @@ class BackendNode(Ros2NodeManager):
     # Localization assist: yaw sweep until localized                        #
     # ------------------------------------------------------------------ #
 
-    def cmd_set_loc_assist(self, enabled: bool):
-        """Enable or disable the auto-localization assist toggle."""
+    def cmd_set_loc_assist(self, enabled: bool) -> bool:
+        """Enable or disable localization assist before nav nodes start."""
         with self._lock:
+            if self._nav_nodes_running:
+                return False
             self._loc_assist_enabled = enabled
         self.get_logger().info(f'Localization assist {"enabled" if enabled else "disabled"}')
+        return True
 
     def _start_loc_assist(self, env: dict):
         """Start the yaw sweep thread (no cmd_vel_control process)."""

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -956,6 +956,9 @@ class BackendNode(Ros2NodeManager):
 
     def _start_loc_assist(self, env: dict):
         """Start the yaw sweep thread (no cmd_vel_control process)."""
+        if self._loc_assist_thread is not None and self._loc_assist_thread.is_alive():
+            self.get_logger().info('Localization assist sweep already running')
+            return
         self._loc_assist_stop_event.clear()
         self._loc_assist_thread = threading.Thread(
             target=self._loc_assist_loop, daemon=True
@@ -1144,20 +1147,30 @@ class BackendNode(Ros2NodeManager):
         with self._lock:
             loc_assist = self._loc_assist_enabled
             nav_running = self._nav_nodes_running
+            cmd_vel_proc = self._cmd_vel_proc
+            if cmd_vel_proc is not None and cmd_vel_proc.poll() is None:
+                return
+            if cmd_vel_proc is not None:
+                self._cmd_vel_proc = None
         if not loc_assist or not nav_running:
             return
         # Stop the sweep
         self._stop_loc_assist()
-        # Now start cmd_vel_control
-        if self._cmd_vel_proc is None:
-            _env = os.environ.copy()
-            _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
+        # Now start cmd_vel_control. Re-check under the lock because both
+        # /mapping/current_pose_in_map and /map/relocalization can report the
+        # first successful localization close together.
+        _env = os.environ.copy()
+        _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
+        with self._lock:
+            cmd_vel_proc = self._cmd_vel_proc
+            if cmd_vel_proc is not None and cmd_vel_proc.poll() is None:
+                return
             self._cmd_vel_proc = self._launch_proc(
                 'cmd_vel_control',
                 ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py'],
                 env=_env,
             )
-            self.get_logger().info('Localization achieved — cmd_vel_control started')
+        self.get_logger().info('Localization achieved — cmd_vel_control started')
 
     def cmd_bag_start(self):
         if self._sensor_mode == 'looper':

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -170,6 +170,7 @@ class BackendNode(Ros2NodeManager):
         self._vio_guard_recovering: bool = False
         self._vio_resume_poi_refs: list[int | str] = []
         self._active_nav_poi_refs: list[int | str] = []
+        self._vio_status_sub = None
 
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
@@ -180,7 +181,6 @@ class BackendNode(Ros2NodeManager):
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
         self.create_subscription(String, '/mapping/nav_progress', self._on_nav_progress, 10)
-        self.create_subscription(String, '/insight/vio_status', self._on_vio_status, 10)
         self._detect_and_init_sensor()
         self._start_unitree_if_configured()
 
@@ -705,6 +705,12 @@ class BackendNode(Ros2NodeManager):
                 self._sensor_mode = 'realsense'
                 self.get_logger().info('Sensor mode: realsense — launching driver + perception + planning')
 
+            if self._sensor_mode == 'looper' and self._vio_status_sub is None:
+                self._vio_status_sub = self.create_subscription(
+                    String, '/insight/vio_status', self._on_vio_status, 10
+                )
+                self.get_logger().info('Insight VIO guard enabled for looper sensor mode')
+
             if self._sensor_mode in ('looper', 'realsense'):
                 _env = os.environ.copy()
                 _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
@@ -884,8 +890,10 @@ class BackendNode(Ros2NodeManager):
             nav_nodes = self._nav_nodes_running
             nav_paused = self._nav_paused
             loc_assist = self._loc_assist_enabled
-            vio_status = self._vio_status
-            vio_guard_stopped = self._vio_guard_stopped
+            sensor_mode = self._sensor_mode
+            vio_status = self._vio_status if sensor_mode == 'looper' else None
+            vio_guard_enabled = sensor_mode == 'looper'
+            vio_guard_stopped = self._vio_guard_stopped if vio_guard_enabled else False
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -899,6 +907,7 @@ class BackendNode(Ros2NodeManager):
             'navNodesRunning': nav_nodes,
             'navPaused': nav_paused,
             'locAssistEnabled': loc_assist,
+            'vioGuardEnabled': vio_guard_enabled,
             'vioStatus': vio_status,
             'vioGuardStopped': vio_guard_stopped,
         }

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -165,7 +165,8 @@ class BackendNode(Ros2NodeManager):
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
         self._map_handoff_active: bool = False
-        self._handled_map_handoffs: set[tuple[str, int]] = set()
+        self._handled_map_handoffs: set[tuple[str, int | str]] = set()
+        self._nav_done_seq: int = 0
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
@@ -182,9 +183,37 @@ class BackendNode(Ros2NodeManager):
             self._battery = float(msg.data)
 
     def _on_nav_done(self, msg: Bool):
-        if msg.data and self.state == 'navigation' and not self._map_handoff_active:
-            self.state = 'idle'
+        if not msg.data or self.state != 'navigation':
+            return
+
+        # map_node publishes the final 100% nav_progress and nav_done back-to-back,
+        # and ROS does not guarantee cross-topic callback ordering.  If the last
+        # POI is also a nav_flow handoff point, nav_done can arrive first.  Give
+        # the progress callback a short grace window to start the handoff before
+        # marking navigation idle.
+        with self._lock:
+            self._nav_done_seq += 1
+            seq = self._nav_done_seq
+            if self._map_handoff_active:
+                return
+
+        def finalize_if_no_handoff():
+            latest_progress = None
+            with self._lock:
+                if seq != self._nav_done_seq or self._map_handoff_active or self.state != 'navigation':
+                    return
+                latest_progress = dict(self._nav_progress) if self._nav_progress else None
+
+            if latest_progress:
+                self._maybe_start_map_handoff(latest_progress)
+
+            with self._lock:
+                if seq != self._nav_done_seq or self._map_handoff_active or self.state != 'navigation':
+                    return
+                self.state = 'idle'
             self._pub_state()
+
+        threading.Timer(0.3, finalize_if_no_handoff).start()
 
     def _on_nav_progress(self, msg: String):
         try:

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -156,6 +156,11 @@ class BackendNode(Ros2NodeManager):
         self._map_node_proc: subprocess.Popen | None = None
         self._cmd_vel_proc: subprocess.Popen | None = None
 
+        # Auto-localization assist: sweep yaw while waiting for localization
+        self._loc_assist_enabled: bool = False
+        self._loc_assist_thread: threading.Thread | None = None
+        self._loc_assist_stop_event = threading.Event()
+
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
 
@@ -206,10 +211,13 @@ class BackendNode(Ros2NodeManager):
     def _on_pose_in_map(self, msg: Odometry):
         pose = self._odom_to_dict(msg, source='map')
         with self._lock:
+            was_localized = self._localized
             self.current_pose = pose
             self._map_pose = pose
             self._odom_pose_at_kf = self._odom_pose  # freeze odom at this keyframe
             self._localized = True
+        if not was_localized:
+            self._on_localization_achieved()
         for cb in self.pose_callbacks:
             try:
                 cb(pose)
@@ -219,8 +227,11 @@ class BackendNode(Ros2NodeManager):
     def _on_relocalization(self, msg: Odometry):
         pose = self._odom_to_dict(msg, source='map')
         with self._lock:
+            was_localized = self._localized
             self._map_pose = pose
             self._localized = True
+        if not was_localized:
+            self._on_localization_achieved()
 
     def _on_nav_target_pose(self, msg: Odometry):
         with self._lock:
@@ -567,6 +578,7 @@ class BackendNode(Ros2NodeManager):
             battery = self._battery
             nav_nodes = self._nav_nodes_running
             nav_paused = self._nav_paused
+            loc_assist = self._loc_assist_enabled
         bag_files_exist = self.active_bag_path is not None
         map_files_exist = os.path.exists(os.path.join(self.map_path, 'occupancy_grid.npy'))
         return {
@@ -579,6 +591,7 @@ class BackendNode(Ros2NodeManager):
             'rawState': raw,
             'navNodesRunning': nav_nodes,
             'navPaused': nav_paused,
+            'locAssistEnabled': loc_assist,
         }
 
     @staticmethod
@@ -683,16 +696,23 @@ class BackendNode(Ros2NodeManager):
             ],
             env=_env,
         )
-        self._cmd_vel_proc = self._launch_proc(
-            'cmd_vel_control',
-            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py'],
-            env=_env,
-        )
+        with self._lock:
+            loc_assist = self._loc_assist_enabled
+        if loc_assist:
+            # Don't start cmd_vel_control yet; start localization assist sweep
+            self._start_loc_assist(_env)
+        else:
+            self._cmd_vel_proc = self._launch_proc(
+                'cmd_vel_control',
+                ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py'],
+                env=_env,
+            )
         with self._lock:
             self._nav_nodes_running = True
         self.get_logger().info('Nav nodes started')
 
     def cmd_stop_nav_nodes(self):
+        self._stop_loc_assist()
         self._kill_proc(self._map_node_proc)
         self._kill_proc(self._cmd_vel_proc)
         self._map_node_proc = None
@@ -707,6 +727,7 @@ class BackendNode(Ros2NodeManager):
         self.get_logger().info('Nav nodes stopped')
 
     def cmd_restart_nav_nodes(self):
+        self._stop_loc_assist()
         self._kill_proc(self._map_node_proc)
         self._kill_proc(self._planning_proc)
         self._kill_proc(self._cmd_vel_proc)
@@ -742,6 +763,125 @@ class BackendNode(Ros2NodeManager):
         self.state = 'idle'
         self._pub_state()
         self.get_logger().info('Nav nodes restarted (emergency stop)')
+
+    # ------------------------------------------------------------------ #
+    # Localization assist: yaw sweep until localized                        #
+    # ------------------------------------------------------------------ #
+
+    def cmd_set_loc_assist(self, enabled: bool):
+        """Enable or disable the auto-localization assist toggle."""
+        with self._lock:
+            self._loc_assist_enabled = enabled
+        self.get_logger().info(f'Localization assist {"enabled" if enabled else "disabled"}')
+
+    def _start_loc_assist(self, env: dict):
+        """Start the yaw sweep thread (no cmd_vel_control process)."""
+        self._loc_assist_stop_event.clear()
+        self._loc_assist_thread = threading.Thread(
+            target=self._loc_assist_loop, daemon=True
+        )
+        self._loc_assist_thread.start()
+        self.get_logger().info('Localization assist sweep started')
+
+    def _stop_loc_assist(self):
+        """Stop the yaw sweep thread if running, publish zero cmd_vel."""
+        self._loc_assist_stop_event.set()
+        if self._loc_assist_thread is not None:
+            self._loc_assist_thread.join(timeout=6.0)
+            self._loc_assist_thread = None
+        # Ensure robot stops
+        self._publish_cmd_vel(0.0, 0.0)
+
+    def _publish_cmd_vel(self, linear_x: float, angular_z: float):
+        msg = Twist()
+        msg.linear.x = float(linear_x)
+        msg.angular.z = float(angular_z)
+        self._cmd_vel_pub.publish(msg)
+
+    def _loc_assist_loop(self):
+        """
+        Yaw sweep pattern:
+        - Start facing current direction, wait dwell_s
+        - Turn CW 20°, wait dwell_s
+        - Turn CCW 40° (net -20° from start), wait dwell_s
+        - Turn CW 60° (net +40° from start), wait dwell_s
+        - Turn CCW 80° (net -40° from start), wait dwell_s
+        - ... expanding sweep until localized
+
+        Uses angular velocity to turn for a computed duration, then dwells.
+        Stops immediately when localized or stop event is set.
+        """
+        dwell_s = 5.0
+        angular_speed = 0.4  # rad/s
+        step_deg = 20.0
+        step_rad = math.radians(step_deg)
+        stop = self._loc_assist_stop_event
+
+        # Dwell at initial position
+        if self._wait_or_localized(dwell_s, stop):
+            return
+
+        turn_index = 1  # 1, 2, 3, 4, ...
+        direction = 1   # +1 = CW, -1 = CCW
+
+        while not stop.is_set():
+            # Turn: angle = turn_index * step_rad
+            angle = turn_index * step_rad
+            duration = angle / angular_speed
+            # Publish angular velocity
+            self._publish_cmd_vel(0.0, -direction * angular_speed)
+            if self._wait_or_localized(duration, stop):
+                return
+            # Stop turning
+            self._publish_cmd_vel(0.0, 0.0)
+            # Dwell
+            if self._wait_or_localized(dwell_s, stop):
+                return
+            # Next sweep: increase index, flip direction
+            turn_index += 1
+            direction *= -1
+
+    def _wait_or_localized(self, duration: float, stop: threading.Event) -> bool:
+        """
+        Wait for `duration` seconds, checking localization and stop event
+        every 0.1s. Returns True if should stop (localized or event set).
+        """
+        elapsed = 0.0
+        interval = 0.1
+        while elapsed < duration:
+            if stop.is_set():
+                self._publish_cmd_vel(0.0, 0.0)
+                return True
+            with self._lock:
+                if self._localized:
+                    self._publish_cmd_vel(0.0, 0.0)
+                    return True
+            time.sleep(interval)
+            elapsed += interval
+        return False
+
+    def _on_localization_achieved(self):
+        """
+        Called when localization succeeds for the first time.
+        Stops the assist sweep and launches cmd_vel_control.
+        """
+        with self._lock:
+            loc_assist = self._loc_assist_enabled
+            nav_running = self._nav_nodes_running
+        if not loc_assist or not nav_running:
+            return
+        # Stop the sweep
+        self._stop_loc_assist()
+        # Now start cmd_vel_control
+        if self._cmd_vel_proc is None:
+            _env = os.environ.copy()
+            _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
+            self._cmd_vel_proc = self._launch_proc(
+                'cmd_vel_control',
+                ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py'],
+                env=_env,
+            )
+            self.get_logger().info('Localization achieved — cmd_vel_control started')
 
     def cmd_bag_start(self):
         if self._sensor_mode == 'looper':

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -164,6 +164,8 @@ class BackendNode(Ros2NodeManager):
 
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
+        self._map_handoff_active: bool = False
+        self._handled_map_handoffs: set[tuple[str, int]] = set()
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
@@ -180,7 +182,7 @@ class BackendNode(Ros2NodeManager):
             self._battery = float(msg.data)
 
     def _on_nav_done(self, msg: Bool):
-        if msg.data and self.state == 'navigation':
+        if msg.data and self.state == 'navigation' and not self._map_handoff_active:
             self.state = 'idle'
             self._pub_state()
 
@@ -191,8 +193,184 @@ class BackendNode(Ros2NodeManager):
                 self._nav_progress = data
             for cb in self.nav_progress_callbacks:
                 cb(data)
+            self._maybe_start_map_handoff(data)
         except json.JSONDecodeError:
             pass
+
+    def _maybe_start_map_handoff(self, progress: dict):
+        """Demo map-collaboration hook.
+
+        If the active map folder contains map_handoff.json and the current
+        route index has a rule, reaching that route index switches to the
+        target map, waits for relocalization, then sends the next POI list.
+
+        Schema, in the currently active map folder:
+          {
+            "0": {"target_map": "map_...", "poi_list": [1, 2]},
+            "2": {"target_map": "map_other", "poi_list": [0]}
+          }
+
+        Keys are matched against POI name first, then POI id, with the old
+        current-route index behavior kept only as a legacy fallback. poi_list
+        values may be POI IDs or POI names in the target map's pois.json.
+        """
+        try:
+            poi_index = int(progress.get('poi_index'))
+            percent = float(progress.get('percent', 0.0))
+        except (TypeError, ValueError):
+            return
+        poi_id = progress.get('poi_id')
+        try:
+            poi_id = int(poi_id) if poi_id is not None else None
+        except (TypeError, ValueError):
+            poi_id = None
+        poi_name = progress.get('poi_name') if isinstance(progress.get('poi_name'), str) else None
+        if percent < 100.0:
+            return
+
+        active_map = self._active_map_name()
+        if not active_map:
+            return
+        key = (active_map, poi_name or poi_id or poi_index)
+        with self._lock:
+            if self._map_handoff_active or key in self._handled_map_handoffs:
+                return
+
+        rule = self._load_map_handoff_rule(poi_index, poi_id=poi_id, poi_name=poi_name)
+        if rule is None:
+            return
+
+        with self._lock:
+            self._map_handoff_active = True
+            self._handled_map_handoffs.add(key)
+        threading.Thread(
+            target=self._run_map_handoff,
+            args=(active_map, poi_index, rule),
+            daemon=True,
+        ).start()
+
+    def _active_map_name(self) -> str | None:
+        try:
+            if os.path.islink(self.map_path):
+                return os.path.basename(os.path.realpath(self.map_path))
+            if os.path.isdir(self.map_path):
+                return os.path.basename(self.map_path)
+        except OSError:
+            return None
+        return None
+
+    def _load_map_handoff_rule(
+        self,
+        poi_index: int,
+        *,
+        poi_id: int | None = None,
+        poi_name: str | None = None,
+    ) -> dict | None:
+        config_path = None
+        for filename in ('nav_flow.json', 'map_handoff.json'):
+            candidate = os.path.join(self.map_path, filename)
+            if os.path.exists(candidate):
+                config_path = candidate
+                break
+        if config_path is None:
+            return None
+        try:
+            with open(config_path) as f:
+                config = json.load(f)
+        except Exception as e:
+            self.get_logger().error(f'Failed to read {os.path.basename(config_path)}: {e}')
+            return None
+
+        rule = None
+        if poi_name:
+            if isinstance(config.get('by_name'), dict):
+                rule = config['by_name'].get(poi_name)
+            if rule is None:
+                rule = config.get(poi_name)
+        if rule is None and poi_id is not None:
+            if isinstance(config.get('by_id'), dict):
+                rule = config['by_id'].get(str(poi_id))
+            if rule is None:
+                rule = config.get(str(poi_id))
+        if rule is None and isinstance(config.get('by_index'), dict):
+            rule = config['by_index'].get(str(poi_index))
+        if rule is None and isinstance(config.get('handoffs'), dict):
+            rule = config['handoffs'].get(str(poi_index))
+        if rule is None:
+            rule = config.get(str(poi_index))
+        if not isinstance(rule, dict):
+            return None
+        target_map = rule.get('target_map') or rule.get('map')
+        poi_list = rule.get('poi_list', [])
+        if not isinstance(target_map, str) or not re.match(r'^[a-zA-Z0-9_\-]+$', target_map):
+            self.get_logger().error(f'Invalid map handoff target_map: {target_map!r}')
+            return None
+        if not isinstance(poi_list, list) or not all(isinstance(p, (int, str)) for p in poi_list):
+            self.get_logger().error(f'Invalid map handoff poi_list: {poi_list!r}')
+            return None
+        return {'target_map': target_map, 'poi_list': poi_list}
+
+    def _set_active_map_link(self, map_name: str):
+        import shutil
+        root = self.tinynav_db_path
+        src = os.path.join(root, 'maps', map_name)
+        if not os.path.isdir(src):
+            raise FileNotFoundError(f'Map {map_name!r} not found')
+        link = self.map_path
+        if os.path.islink(link) or os.path.isfile(link):
+            os.remove(link)
+        elif os.path.isdir(link):
+            shutil.rmtree(link)
+        os.symlink(src, link)
+
+    def _run_map_handoff(self, source_map: str, poi_index: int, rule: dict):
+        target_map = rule['target_map']
+        poi_list = rule['poi_list']
+        self.get_logger().info(
+            f'Map handoff triggered: {source_map}[{poi_index}] -> {target_map}, poi_list={poi_list}'
+        )
+        try:
+            # Stop current map_node/control hard before changing the active map.
+            self.cmd_stop_nav_nodes()
+            self.state = 'idle'
+            self._pub_state()
+
+            self._set_active_map_link(target_map)
+
+            with self._lock:
+                self._localized = False
+                self._map_pose = None
+                self._global_path = []
+                self._nav_target_pose = None
+                self._nav_progress = None
+
+            self.cmd_start_nav_nodes()
+
+            deadline = time.time() + 60.0
+            while time.time() < deadline:
+                with self._lock:
+                    localized = self._localized
+                if localized:
+                    break
+                time.sleep(0.2)
+            else:
+                self.get_logger().error(f'Map handoff timed out waiting for localization on {target_map}')
+                self.state = 'idle'
+                self._pub_state()
+                return
+
+            if poi_list:
+                self.cmd_send_pois(poi_list)
+            else:
+                self.state = 'idle'
+                self._pub_state()
+        except Exception as e:
+            self.get_logger().error(f'Map handoff failed: {e}')
+            self.state = 'error:map_handoff'
+            self._pub_state()
+        finally:
+            with self._lock:
+                self._map_handoff_active = False
 
     def _on_mapping_percent(self, msg: Float32):
         with self._lock:
@@ -1190,8 +1368,12 @@ class BackendNode(Ros2NodeManager):
         with self._lock:
             self._nav_target_pose = {'x': float(x), 'y': float(y)}
 
-    def cmd_send_pois(self, poi_ids: list[int]):
-        """Publish selected POIs to map_node and transition to navigation state."""
+    def cmd_send_pois(self, poi_ids: list[int | str]):
+        """Publish selected POIs to map_node and transition to navigation state.
+
+        Items may be integer POI IDs or POI names. The payload is re-indexed as
+        a dense queue while preserving each POI's original id/name metadata.
+        """
         if not poi_ids:
             self._cmd_pois_pub.publish(String(data='{}'))
         else:
@@ -1201,14 +1383,27 @@ class BackendNode(Ros2NodeManager):
                 return
             with open(pois_file) as f:
                 all_pois = json.load(f)
+            pois_by_name = {
+                poi.get('name'): poi
+                for poi in all_pois.values()
+                if isinstance(poi, dict) and isinstance(poi.get('name'), str)
+            }
             # Re-index as a dense queue ("0", "1", ...) so downstream
-            # consumers navigate in the same order the UI sent the checked POIs,
+            # consumers navigate in the same order the UI/nav_flow sent POIs,
             # instead of falling back to the original ids / pois.json order.
             payload = {}
-            for pid in poi_ids:
-                key = str(pid)
-                if key in all_pois:
-                    payload[str(len(payload))] = all_pois[key]
+            for poi_ref in poi_ids:
+                poi = None
+                if isinstance(poi_ref, int):
+                    poi = all_pois.get(str(poi_ref))
+                elif isinstance(poi_ref, str):
+                    poi = pois_by_name.get(poi_ref)
+                    if poi is None and poi_ref.isdigit():
+                        poi = all_pois.get(poi_ref)
+                if poi is not None:
+                    payload[str(len(payload))] = poi
+                else:
+                    self.get_logger().warn(f'POI {poi_ref!r} not found in active map')
             self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
         with self._lock:
             nav_running = self._nav_nodes_running

--- a/app/backend/routers/nav.py
+++ b/app/backend/routers/nav.py
@@ -112,3 +112,19 @@ def nav_nodes_disable():
         raise HTTPException(409, 'Nav nodes not running')
     node.cmd_stop_nav_nodes()
     return {'ok': True}
+
+
+@router.post('/loc-assist')
+def nav_loc_assist(req: dict):
+    node = _require_node()
+    enabled = bool(req.get('enabled', False))
+    node.cmd_set_loc_assist(enabled)
+    return {'ok': True, 'enabled': enabled}
+
+
+@router.get('/loc-assist')
+def nav_loc_assist_status():
+    node = _require_node()
+    with node._lock:
+        enabled = node._loc_assist_enabled
+    return {'enabled': enabled}

--- a/app/backend/routers/nav.py
+++ b/app/backend/routers/nav.py
@@ -118,7 +118,11 @@ def nav_nodes_disable():
 def nav_loc_assist(req: dict):
     node = _require_node()
     enabled = bool(req.get('enabled', False))
-    node.cmd_set_loc_assist(enabled)
+    if not node.cmd_set_loc_assist(enabled):
+        raise HTTPException(
+            409,
+            'Turn Nav off before changing Assist; enable Assist before starting Nav',
+        )
     return {'ok': True, 'enabled': enabled}
 
 

--- a/app/frontend/lib/core/models.dart
+++ b/app/frontend/lib/core/models.dart
@@ -36,6 +36,7 @@ class DeviceStatus {
   final String rawState;
   final bool navNodesRunning;
   final bool navPaused;
+  final bool locAssistEnabled;
 
   const DeviceStatus({
     required this.online,
@@ -48,6 +49,7 @@ class DeviceStatus {
     required this.rawState,
     required this.navNodesRunning,
     required this.navPaused,
+    required this.locAssistEnabled,
   });
 
   factory DeviceStatus.fromJson(Map<String, dynamic> json) => DeviceStatus(
@@ -61,6 +63,7 @@ class DeviceStatus {
         rawState: json['rawState'] as String? ?? 'unknown',
         navNodesRunning: json['navNodesRunning'] as bool? ?? false,
         navPaused: json['navPaused'] as bool? ?? false,
+        locAssistEnabled: json['locAssistEnabled'] as bool? ?? false,
       );
 }
 

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -249,6 +249,11 @@ class _OperateTabState extends ConsumerState<OperateTab> {
                 right: 10,
                 child: _NavNodesButton(statusAsync: ref.watch(deviceStatusProvider)),
               ),
+              Positioned(
+                bottom: 50,
+                right: 10,
+                child: _LocAssistToggle(statusAsync: ref.watch(deviceStatusProvider)),
+              ),
             ],
           ),
         ),
@@ -1411,6 +1416,67 @@ class _NavNodesButtonState extends ConsumerState<_NavNodesButton> {
               size: 16,
             ),
       label: Text(running ? 'Nav ON' : 'Nav'),
+    );
+  }
+}
+
+// ── Localization assist toggle ────────────────────────────────────────────────
+
+class _LocAssistToggle extends ConsumerStatefulWidget {
+  final AsyncValue<DeviceStatus> statusAsync;
+  const _LocAssistToggle({required this.statusAsync});
+
+  @override
+  ConsumerState<_LocAssistToggle> createState() => _LocAssistToggleState();
+}
+
+class _LocAssistToggleState extends ConsumerState<_LocAssistToggle> {
+  bool _loading = false;
+
+  Future<void> _toggle(bool currentlyEnabled) async {
+    setState(() => _loading = true);
+    try {
+      await ref.read(dioProvider).post(
+        '/nav/loc-assist',
+        data: {'enabled': !currentlyEnabled},
+      );
+    } on DioException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(e.response?.data?['detail'] ?? e.message ?? 'Error'),
+          backgroundColor: Colors.red,
+        ));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = widget.statusAsync.valueOrNull;
+    final enabled = status?.locAssistEnabled ?? false;
+
+    return FilledButton.icon(
+      onPressed: _loading ? null : () => _toggle(enabled),
+      style: FilledButton.styleFrom(
+        backgroundColor: enabled
+            ? const Color(0xFFFFB74D).withOpacity(0.9)
+            : Colors.black87,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      ),
+      icon: _loading
+          ? const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+            )
+          : Icon(
+              enabled ? Icons.explore : Icons.explore_off_outlined,
+              size: 16,
+            ),
+      label: Text(enabled ? 'Assist ON' : 'Assist'),
     );
   }
 }

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -1433,7 +1433,19 @@ class _LocAssistToggle extends ConsumerStatefulWidget {
 class _LocAssistToggleState extends ConsumerState<_LocAssistToggle> {
   bool _loading = false;
 
-  Future<void> _toggle(bool currentlyEnabled) async {
+  Future<void> _toggle(bool currentlyEnabled, bool navNodesRunning) async {
+    if (navNodesRunning) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Turn Nav off before changing Assist; enable Assist before starting Nav',
+          ),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
     setState(() => _loading = true);
     try {
       await ref.read(dioProvider).post(
@@ -1456,9 +1468,10 @@ class _LocAssistToggleState extends ConsumerState<_LocAssistToggle> {
   Widget build(BuildContext context) {
     final status = widget.statusAsync.valueOrNull;
     final enabled = status?.locAssistEnabled ?? false;
+    final navNodesRunning = status?.navNodesRunning ?? false;
 
     return FilledButton.icon(
-      onPressed: _loading ? null : () => _toggle(enabled),
+      onPressed: _loading ? null : () => _toggle(enabled, navNodesRunning),
       style: FilledButton.styleFrom(
         backgroundColor: enabled
             ? const Color(0xFFFFB74D).withOpacity(0.9)

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -249,6 +249,7 @@ class MapNode(Node):
         self.T_from_map_to_odom = None
 
         self.pois = {}
+        self.poi_meta = {}
         self.poi_index = -1
         self._nav_completed = False
         self._leg_initial_length: float | None = None
@@ -271,19 +272,27 @@ class MapNode(Node):
     def pois_callback(self, msg: String):
         self.get_logger().info("Received POIs from planner: " + msg.data)
         try:
-            self.pois = json.loads(msg.data)
+            raw_pois = json.loads(msg.data)
 
             pois_dict = {}
-            keys = sorted([int (key) for key in self.pois.keys()])
+            poi_meta = {}
+            keys = sorted([int(key) for key in raw_pois.keys()])
             for index, key in enumerate(keys):
-                pois_dict[index] = np.array(self.pois[str(key)]["position"])
+                raw_poi = raw_pois[str(key)]
+                pois_dict[index] = np.array(raw_poi["position"])
+                poi_meta[index] = {
+                    "id": raw_poi.get("id", key),
+                    "name": raw_poi.get("name"),
+                }
             self.pois = pois_dict
+            self.poi_meta = poi_meta
 
             if not self.pois:
                 self.poi_index = -1
                 # Signal planning_node to clear target_pose so it stops publishing paths
                 dummy_pose = np.eye(4)
                 self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
+                self.poi_meta = {}
                 self.get_logger().info("POIs cleared, navigation cancelled")
                 return
 
@@ -296,6 +305,20 @@ class MapNode(Node):
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
             self.pois = {}
+            self.poi_meta = {}
+
+    def _nav_progress_payload(self, *, percent: float, path_remaining_m: float,
+                              path_total_m: float, estimated_remaining_s: float) -> dict:
+        meta = self.poi_meta.get(self.poi_index, {})
+        return {
+            "poi_index": self.poi_index,  # route index in the current command queue
+            "poi_id": meta.get("id"),
+            "poi_name": meta.get("name"),
+            "percent": percent,
+            "path_remaining_m": path_remaining_m,
+            "path_total_m": path_total_m,
+            "estimated_remaining_s": estimated_remaining_s,
+        }
 
     def info_callback(self, msg:CameraInfo):
         if self.K is None:
@@ -609,16 +632,14 @@ class MapNode(Node):
             diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
             diff_position_norm_z = np.linalg.norm(poi[2] - pose_in_map_position[2])
             if diff_position_norm_xy < 0.5 and diff_position_norm_z < 2.0:
-                if self._leg_initial_length is not None:
-                    arrived_msg = String()
-                    arrived_msg.data = json.dumps({
-                        "poi_index": self.poi_index,
-                        "percent": 100.0,
-                        "path_remaining_m": 0.0,
-                        "path_total_m": round(self._leg_initial_length, 2),
-                        "estimated_remaining_s": 0.0,
-                    })
-                    self.nav_progress_pub.publish(arrived_msg)
+                arrived_msg = String()
+                arrived_msg.data = json.dumps(self._nav_progress_payload(
+                    percent=100.0,
+                    path_remaining_m=0.0,
+                    path_total_m=round(self._leg_initial_length or 0.0, 2),
+                    estimated_remaining_s=0.0,
+                ))
+                self.nav_progress_pub.publish(arrived_msg)
                 self.poi_index += 1
                 self._leg_initial_length = None
                 self._leg_start_time = None
@@ -664,13 +685,12 @@ class MapNode(Node):
             estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
 
             progress_msg = String()
-            progress_msg.data = json.dumps({
-                "poi_index": self.poi_index,
-                "percent": round(percent, 1),
-                "path_remaining_m": round(remaining_length, 2),
-                "path_total_m": round(initial, 2),
-                "estimated_remaining_s": round(estimated_remaining_s, 1),
-            })
+            progress_msg.data = json.dumps(self._nav_progress_payload(
+                percent=round(percent, 1),
+                path_remaining_m=round(remaining_length, 2),
+                path_total_m=round(initial, 2),
+                estimated_remaining_s=round(estimated_remaining_s, 1),
+            ))
             self.nav_progress_pub.publish(progress_msg)
 
             # use the max_speed to publish the position the robot should be after 5 seconds


### PR DESCRIPTION
## Summary

When the **Assist** toggle is enabled on the Operate page, pressing Nav ON will:

1. Start  (begins visual relocalization attempts)
2. **NOT** start  — instead run a yaw sweep loop:
   - Dwell 5s at current heading
   - CW 20°, dwell 5s
   - CCW 40° (net −20° from start), dwell 5s
   - CW 60° (net +40° from start), dwell 5s
   - …expanding sweep until localized
3. Once localization succeeds → stop sweep → start `cmd_vel_control` normally

This helps in scenarios where the robot's current view doesn't match any map keyframe, avoiding indefinite waiting.

## Changes

| File | What |
|------|------|
| `app/backend/node_manager.py` | Loc-assist state, sweep thread, auto-stop on localization |
| `app/backend/routers/nav.py` | `POST/GET /nav/loc-assist` endpoints |
| `app/frontend/lib/core/models.dart` | `locAssistEnabled` in DeviceStatus |
| `app/frontend/lib/pages/operate_tab.dart` | `_LocAssistToggle` button widget |

## Testing

- [x] Python AST parse OK
- [x] Dart analyze (only pre-existing info warnings)
- [x] Flutter build web ✓ on Nano (tinynav-dev container)
- [x] Backend import + startup OK
- [ ] Real robot localization test (pending)

## Toggle off = original behavior

When Assist is OFF, Nav ON works exactly as before (map_node + cmd_vel_control start together).