### PR TITLE
feat(preview): add selectable preview quality levels

### DIFF
--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -82,7 +82,7 @@ The interactive API docs are available at `http://<host>:8000/docs`.
 | `/ws/status` | ~1 s | Full device status JSON |
 | `/ws/pose` | On every odometry message | `{x, y, z, yaw, timestamp, source}` |
 | `/ws/map-update` | On map file change | `{event: "map_updated", timestamp}` |
-| `/ws/preview?topic=<topic>` | ~5 fps | Raw JPEG bytes for the selected camera topic |
+| `/ws/preview?topic=<topic>&quality=<default\|high>` | Up to 20 fps | Raw JPEG bytes for the selected camera topic; default is 320px/JPEG 50, high is 640px/JPEG 80 |
 | `/ws/planning` | ~5 fps | `{localized, odom_pose, map_pose, esdf_image, obstacle_image, trajectory, grid_info}` |
 
 ### Sensor / camera

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -56,6 +56,29 @@ _IMAGE_TOPICS_LOOPER = [
 ]
 _IMAGE_TOPICS_ALL = _IMAGE_TOPICS_REALSENSE  # fallback
 _PREVIEW_MIN_INTERVAL = 0.2  # 5 fps
+_PREVIEW_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_MAX_EDGE_PX', '320'))
+_PREVIEW_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_JPEG_QUALITY', '50'))
+
+
+def _resize_preview_frame(arr: np.ndarray, max_edge_px: int = _PREVIEW_MAX_EDGE_PX) -> np.ndarray:
+    """Downscale preview frame so the longest side is <= max_edge_px."""
+    if max_edge_px <= 0 or arr is None or arr.size == 0:
+        return arr
+    height, width = arr.shape[:2]
+    longest = max(height, width)
+    if longest <= max_edge_px:
+        return arr
+    scale = max_edge_px / float(longest)
+    new_size = (max(1, int(round(width * scale))), max(1, int(round(height * scale))))
+    return cv2.resize(arr, new_size, interpolation=cv2.INTER_AREA)
+
+
+def _encode_preview_jpeg(arr: np.ndarray) -> bytes:
+    arr = _resize_preview_frame(arr)
+    ok, buf = cv2.imencode('.jpg', arr, [cv2.IMWRITE_JPEG_QUALITY, _PREVIEW_JPEG_QUALITY])
+    if not ok:
+        raise RuntimeError('failed to encode preview jpeg')
+    return buf.tobytes()
 
 
 class BackendNode(Ros2NodeManager):
@@ -453,7 +476,15 @@ class BackendNode(Ros2NodeManager):
         if now - self._last_frame_time.get(topic, 0.0) < _PREVIEW_MIN_INTERVAL:
             return
         self._last_frame_time[topic] = now
-        frame = bytes(msg.data)
+
+        try:
+            arr = cv2.imdecode(np.frombuffer(msg.data, dtype=np.uint8), cv2.IMREAD_COLOR)
+            if arr is None:
+                return
+            frame = _encode_preview_jpeg(arr)
+        except Exception:
+            return
+
         with self._lock:
             self._last_frame[topic] = frame
         for cb in self.preview_callbacks.get(topic, []):
@@ -484,8 +515,7 @@ class BackendNode(Ros2NodeManager):
                     arr = arr[:, :, 0]
                 elif msg.encoding == 'rgb8':
                     arr = cv2.cvtColor(arr, cv2.COLOR_RGB2BGR)
-            _, buf = cv2.imencode('.jpg', arr, [cv2.IMWRITE_JPEG_QUALITY, 50])
-            frame = buf.tobytes()
+            frame = _encode_preview_jpeg(arr)
         except Exception:
             return
 

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -55,9 +55,15 @@ _IMAGE_TOPICS_LOOPER = [
     '/slam/depth',
 ]
 _IMAGE_TOPICS_ALL = _IMAGE_TOPICS_REALSENSE  # fallback
-_PREVIEW_MIN_INTERVAL = 0.2  # 5 fps
+_PREVIEW_MIN_INTERVAL = 0.05  # 20 fps
 _PREVIEW_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_MAX_EDGE_PX', '320'))
 _PREVIEW_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_JPEG_QUALITY', '50'))
+_PREVIEW_HIGH_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_HIGH_MAX_EDGE_PX', '640'))
+_PREVIEW_HIGH_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_HIGH_JPEG_QUALITY', '80'))
+_PREVIEW_PROFILES = {
+    'default': (_PREVIEW_MAX_EDGE_PX, _PREVIEW_JPEG_QUALITY),
+    'high': (_PREVIEW_HIGH_MAX_EDGE_PX, _PREVIEW_HIGH_JPEG_QUALITY),
+}
 
 
 def _resize_preview_frame(arr: np.ndarray, max_edge_px: int = _PREVIEW_MAX_EDGE_PX) -> np.ndarray:
@@ -73,9 +79,13 @@ def _resize_preview_frame(arr: np.ndarray, max_edge_px: int = _PREVIEW_MAX_EDGE_
     return cv2.resize(arr, new_size, interpolation=cv2.INTER_AREA)
 
 
-def _encode_preview_jpeg(arr: np.ndarray) -> bytes:
-    arr = _resize_preview_frame(arr)
-    ok, buf = cv2.imencode('.jpg', arr, [cv2.IMWRITE_JPEG_QUALITY, _PREVIEW_JPEG_QUALITY])
+def _encode_preview_jpeg(
+    arr: np.ndarray,
+    max_edge_px: int = _PREVIEW_MAX_EDGE_PX,
+    jpeg_quality: int = _PREVIEW_JPEG_QUALITY,
+) -> bytes:
+    arr = _resize_preview_frame(arr, max_edge_px)
+    ok, buf = cv2.imencode('.jpg', arr, [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality])
     if not ok:
         raise RuntimeError('failed to encode preview jpeg')
     return buf.tobytes()
@@ -426,12 +436,18 @@ class BackendNode(Ros2NodeManager):
             self._last_frame_time[topic] = 0.0
             self.preview_callbacks[topic] = []
 
-    def add_preview_callback(self, topic: str, cb) -> bool:
+    def add_preview_callback(
+        self,
+        topic: str,
+        cb,
+        max_edge_px: int = _PREVIEW_MAX_EDGE_PX,
+        jpeg_quality: int = _PREVIEW_JPEG_QUALITY,
+    ) -> bool:
         """Register a frame callback; creates the ROS subscription on the first caller."""
         if topic not in self.preview_callbacks:
             return False
         with self._lock:
-            self.preview_callbacks[topic].append(cb)
+            self.preview_callbacks[topic].append((cb, max_edge_px, jpeg_quality))
             first = len(self.preview_callbacks[topic]) == 1
         if first:
             self._create_image_sub(topic)
@@ -442,10 +458,11 @@ class BackendNode(Ros2NodeManager):
         if topic not in self.preview_callbacks:
             return
         with self._lock:
-            try:
-                self.preview_callbacks[topic].remove(cb)
-            except ValueError:
-                pass
+            self.preview_callbacks[topic] = [
+                registration
+                for registration in self.preview_callbacks[topic]
+                if registration[0] is not cb
+            ]
             empty = len(self.preview_callbacks[topic]) == 0
         if empty:
             self._destroy_image_sub(topic)
@@ -471,6 +488,26 @@ class BackendNode(Ros2NodeManager):
         if sub is not None:
             self.destroy_subscription(sub)
 
+    def _publish_preview_frame(self, topic: str, arr: np.ndarray):
+        with self._lock:
+            callbacks = list(self.preview_callbacks.get(topic, []))
+
+        encoded_frames: dict[tuple[int, int], bytes] = {}
+        for cb, max_edge_px, jpeg_quality in callbacks:
+            profile = (max_edge_px, jpeg_quality)
+            try:
+                frame = encoded_frames.get(profile)
+                if frame is None:
+                    frame = _encode_preview_jpeg(arr, max_edge_px, jpeg_quality)
+                    encoded_frames[profile] = frame
+                cb(frame)
+            except Exception:
+                pass
+
+        if encoded_frames:
+            with self._lock:
+                self._last_frame[topic] = next(iter(encoded_frames.values()))
+
     def _on_compressed_image(self, msg: CompressedImage, topic: str):
         now = time.time()
         if now - self._last_frame_time.get(topic, 0.0) < _PREVIEW_MIN_INTERVAL:
@@ -481,17 +518,9 @@ class BackendNode(Ros2NodeManager):
             arr = cv2.imdecode(np.frombuffer(msg.data, dtype=np.uint8), cv2.IMREAD_COLOR)
             if arr is None:
                 return
-            frame = _encode_preview_jpeg(arr)
         except Exception:
             return
-
-        with self._lock:
-            self._last_frame[topic] = frame
-        for cb in self.preview_callbacks.get(topic, []):
-            try:
-                cb(frame)
-            except Exception:
-                pass
+        self._publish_preview_frame(topic, arr)
 
     def _on_image(self, msg: Image, topic: str):
         now = time.time()
@@ -515,18 +544,9 @@ class BackendNode(Ros2NodeManager):
                     arr = arr[:, :, 0]
                 elif msg.encoding == 'rgb8':
                     arr = cv2.cvtColor(arr, cv2.COLOR_RGB2BGR)
-            frame = _encode_preview_jpeg(arr)
         except Exception:
             return
-
-        with self._lock:
-            self._last_frame[topic] = frame
-
-        for cb in self.preview_callbacks.get(topic, []):
-            try:
-                cb(frame)
-            except Exception:
-                pass
+        self._publish_preview_frame(topic, arr)
 
     def get_planning_snapshot(self) -> dict:
         with self._lock:
@@ -570,6 +590,9 @@ class BackendNode(Ros2NodeManager):
     def get_preview_frame(self, topic: str) -> bytes:
         with self._lock:
             return self._last_frame.get(topic, b'')
+
+    def get_preview_profile(self, quality: str) -> tuple[int, int] | None:
+        return _PREVIEW_PROFILES.get(quality)
 
     # ------------------------------------------------------------------ #
     # Command API (called from FastAPI handlers — thread-safe enough)     #

--- a/app/backend/ws.py
+++ b/app/backend/ws.py
@@ -175,12 +175,20 @@ async def ws_planning(ws: WebSocket):
 # --------------------------------------------------------------------------- #
 
 @router.websocket('/ws/preview')
-async def ws_preview(ws: WebSocket, topic: str = Query(...)):
+async def ws_preview(
+    ws: WebSocket,
+    topic: str = Query(...),
+    quality: str = Query('default'),
+):
     await ws.accept()
 
     node = runner.node
     if node is None or topic not in node.preview_callbacks:
         await ws.close(code=1013)
+        return
+    profile = node.get_preview_profile(quality)
+    if profile is None:
+        await ws.close(code=1008)
         return
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=4)
@@ -190,7 +198,8 @@ async def ws_preview(ws: WebSocket, topic: str = Query(...)):
         # Drop oldest frame if full — always keep the latest.
         loop.call_soon_threadsafe(lambda: _safe_put(queue, frame))
 
-    if not node.add_preview_callback(topic, _on_frame):
+    max_edge_px, jpeg_quality = profile
+    if not node.add_preview_callback(topic, _on_frame, max_edge_px, jpeg_quality):
         await ws.close(code=1013)
         return
     try:

--- a/app/frontend/lib/core/providers.dart
+++ b/app/frontend/lib/core/providers.dart
@@ -117,23 +117,49 @@ final activeNavPoisProvider = StateProvider<List<Poi>>((ref) => const []);
 /// Currently selected preview topic (null = preview closed).
 final selectedPreviewTopicProvider = StateProvider<String?>((ref) => null);
 
-/// Streams raw JPEG bytes from WS /ws/preview?topic=<topic>.
+enum PreviewQuality {
+  standard('default', 'Default'),
+  high('high', 'High');
+
+  const PreviewQuality(this.queryValue, this.label);
+
+  final String queryValue;
+  final String label;
+}
+
+final previewQualityProvider = StateProvider<PreviewQuality>(
+  (ref) => PreviewQuality.standard,
+);
+
+typedef PreviewStreamRequest = ({String topic, PreviewQuality quality});
+
+/// Streams raw JPEG bytes from WS /ws/preview for a topic and quality level.
 final previewStreamProvider =
-    StreamProvider.family.autoDispose<Uint8List, String>((ref, topic) {
-  final ip = ref.watch(deviceIpProvider);
-  if (ip == null) return const Stream.empty();
+    StreamProvider.family.autoDispose<Uint8List, PreviewStreamRequest>(
+  (ref, request) {
+    final ip = ref.watch(deviceIpProvider);
+    if (ip == null) return const Stream.empty();
 
-  final encoded = Uri.encodeQueryComponent(topic);
-  final channel =
-      WebSocketChannel.connect(Uri.parse('ws://$ip:8000/ws/preview?topic=$encoded'));
-  ref.onDispose(() => channel.sink.close());
+    final uri = Uri(
+      scheme: 'ws',
+      host: ip,
+      port: 8000,
+      path: '/ws/preview',
+      queryParameters: {
+        'topic': request.topic,
+        'quality': request.quality.queryValue,
+      },
+    );
+    final channel = WebSocketChannel.connect(uri);
+    ref.onDispose(() => channel.sink.close());
 
-  return channel.stream.map((data) {
-    if (data is Uint8List) return data;
-    if (data is List<int>) return Uint8List.fromList(data);
-    return Uint8List(0);
-  }).where((b) => b.isNotEmpty);
-});
+    return channel.stream.map((data) {
+      if (data is Uint8List) return data;
+      if (data is List<int>) return Uint8List.fromList(data);
+      return Uint8List(0);
+    }).where((b) => b.isNotEmpty);
+  },
+);
 
 /// Streams PlanningState from WS /ws/planning at ~5 fps.
 final planningStreamProvider = StreamProvider<PlanningState>((ref) {

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -1486,9 +1486,14 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
   void _showFullscreen(BuildContext context) {
     final topic = ref.read(selectedPreviewTopicProvider);
     if (topic == null) return;
+    final quality = ref.read(previewQualityProvider);
     showDialog(
       context: context,
-      builder: (_) => _FullscreenPreview(topic: topic, fit: _previewFit),
+      builder: (_) => _FullscreenPreview(
+        topic: topic,
+        quality: quality,
+        fit: _previewFit,
+      ),
     );
   }
 
@@ -1496,6 +1501,7 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
   Widget build(BuildContext context) {
     final topicsAsync = ref.watch(imageTopicsProvider);
     final selectedTopic = ref.watch(selectedPreviewTopicProvider);
+    final previewQuality = ref.watch(previewQualityProvider);
     final topics = topicsAsync.valueOrNull ?? [];
     final baseUrl = ref.watch(baseUrlProvider);
     final mapInfo = ref.watch(mapInfoProvider).valueOrNull;
@@ -1517,7 +1523,7 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
 
     if (selectedTopic != null) {
       ref.listen<AsyncValue<Uint8List>>(
-        previewStreamProvider(selectedTopic),
+        previewStreamProvider((topic: selectedTopic, quality: previewQuality)),
         (_, next) {
           if (next case AsyncData(:final value)) {
             if (mounted) setState(() => _latestFrame = value);
@@ -1574,6 +1580,25 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   const Icon(Icons.videocam_outlined, color: Colors.white70, size: 14),
+                  const SizedBox(width: 6),
+                  DropdownButton<PreviewQuality>(
+                    value: previewQuality,
+                    style: const TextStyle(color: Colors.white, fontSize: 12),
+                    dropdownColor: Colors.black87,
+                    underline: const SizedBox(),
+                    isDense: true,
+                    items: PreviewQuality.values
+                        .map((quality) => DropdownMenuItem(
+                              value: quality,
+                              child: Text(quality.label),
+                            ))
+                        .toList(),
+                    onChanged: (quality) {
+                      if (quality != null) {
+                        ref.read(previewQualityProvider.notifier).state = quality;
+                      }
+                    },
+                  ),
                   const SizedBox(width: 6),
                   Tooltip(
                     message: _previewCover ? 'Fill preview' : 'Show full preview',
@@ -1649,8 +1674,13 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
 
 class _FullscreenPreview extends ConsumerStatefulWidget {
   final String topic;
+  final PreviewQuality quality;
   final BoxFit fit;
-  const _FullscreenPreview({required this.topic, required this.fit});
+  const _FullscreenPreview({
+    required this.topic,
+    required this.quality,
+    required this.fit,
+  });
 
   @override
   ConsumerState<_FullscreenPreview> createState() => _FullscreenPreviewState();
@@ -1662,7 +1692,7 @@ class _FullscreenPreviewState extends ConsumerState<_FullscreenPreview> {
   @override
   Widget build(BuildContext context) {
     ref.listen<AsyncValue<Uint8List>>(
-      previewStreamProvider(widget.topic),
+      previewStreamProvider((topic: widget.topic, quality: widget.quality)),
       (_, next) {
         if (next case AsyncData(:final value)) {
           if (mounted) setState(() => _frame = value);

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -1479,13 +1479,16 @@ class _CameraPanel extends ConsumerStatefulWidget {
 
 class _CameraPanelState extends ConsumerState<_CameraPanel> {
   Uint8List? _latestFrame;
+  bool _previewCover = false;
+
+  BoxFit get _previewFit => _previewCover ? BoxFit.cover : BoxFit.contain;
 
   void _showFullscreen(BuildContext context) {
     final topic = ref.read(selectedPreviewTopicProvider);
     if (topic == null) return;
     showDialog(
       context: context,
-      builder: (_) => _FullscreenPreview(topic: topic),
+      builder: (_) => _FullscreenPreview(topic: topic, fit: _previewFit),
     );
   }
 
@@ -1531,7 +1534,7 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
           if (selectedTopic != null && _latestFrame != null)
             GestureDetector(
               onTap: () => _showFullscreen(context),
-              child: Image.memory(_latestFrame!, fit: BoxFit.cover, gaplessPlayback: true),
+              child: Image.memory(_latestFrame!, fit: _previewFit, gaplessPlayback: true),
             )
           else
             Center(
@@ -1571,6 +1574,22 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   const Icon(Icons.videocam_outlined, color: Colors.white70, size: 14),
+                  const SizedBox(width: 6),
+                  Tooltip(
+                    message: _previewCover ? 'Fill preview' : 'Show full preview',
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(14),
+                      onTap: () => setState(() => _previewCover = !_previewCover),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
+                        child: Icon(
+                          _previewCover ? Icons.crop_free_rounded : Icons.fit_screen_rounded,
+                          color: Colors.white70,
+                          size: 15,
+                        ),
+                      ),
+                    ),
+                  ),
                   const SizedBox(width: 6),
                   DropdownButton<String?>(
                     value: selectedTopic,
@@ -1630,7 +1649,8 @@ class _CameraPanelState extends ConsumerState<_CameraPanel> {
 
 class _FullscreenPreview extends ConsumerStatefulWidget {
   final String topic;
-  const _FullscreenPreview({required this.topic});
+  final BoxFit fit;
+  const _FullscreenPreview({required this.topic, required this.fit});
 
   @override
   ConsumerState<_FullscreenPreview> createState() => _FullscreenPreviewState();
@@ -1657,7 +1677,7 @@ class _FullscreenPreviewState extends ConsumerState<_FullscreenPreview> {
         children: [
           Center(
             child: _frame != null
-                ? Image.memory(_frame!, fit: BoxFit.contain, gaplessPlayback: true)
+                ? Image.memory(_frame!, fit: widget.fit, gaplessPlayback: true)
                 : const CircularProgressIndicator(color: Colors.white54),
           ),
           Positioned(


### PR DESCRIPTION
## Summary

- For adapt to differenct network conditions
- Downscale camera preview frames before WebSocket delivery to reduce bandwidth and decode cost
- Add selectable preview quality levels in the Operate page:
  - **Default:** up to 20 FPS, 320px longest edge, JPEG quality 50
  - **High:** up to 20 FPS, 640px longest edge, JPEG quality 80
- Add Contain / Cover preview fit toggle and preserve the selected fit in fullscreen mode
- Encode frames per active quality profile and reuse encoded output across clients using the same profile

## Changes

| File | What |
|------|------|
| `app/backend/node_manager.py` | Preview throttling, resize/JPEG profiles, and per-profile encoding reuse |
| `app/backend/ws.py` | `quality=default\|high` WebSocket query support |
| `app/frontend/lib/core/providers.dart` | Preview quality state and profile-aware WebSocket connection |
| `app/frontend/lib/pages/operate_tab.dart` | Quality selector and Contain / Cover display toggle |
| `app/backend/README.md` | Document preview WebSocket quality levels |

## Testing

- [x] `git diff --check`
- [x] Python AST parse OK
- [x] Flutter analyze on Nano (no errors or warnings; pre-existing info diagnostics only)
- [x] Flutter Web build completed in the `tinynav-dev` container
- [x] Restarted `tinynav-dev` and launched with `/tinynav/scripts/start_app.sh`
- [x] Backend `/docs` and frontend returned HTTP 200
- [x] Default camera frame verified at 181×320, ~5.3 KB
- [x] High camera frame verified at 363×640, ~24.9 KB
- [x] Default → High switching verified in the Operate page with a live camera stream

https://github.com/user-attachments/assets/9fd172f2-caf9-439f-92d6-e2db6adbd173

