### PR TITLE
feat: extract cam-to-body extrinsics to shared robot_config, apply in poi_editor

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -30,6 +30,7 @@ from sensor_msgs.msg import CompressedImage, Image, PointCloud, PointCloud2
 from std_msgs.msg import Bool, Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
+from tinynav.core.robot_config import ROBOT_CONFIG, body_to_camera_position
 
 _REALSENSE_SCRIPT = '/tinynav/scripts/run_realsense_sensor.sh'
 _VENV_SITE = '/tinynav/.venv/lib/python3.10/site-packages'
@@ -191,6 +192,7 @@ class BackendNode(Ros2NodeManager):
 
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
+        self._map_poses: dict | None = None  # lazy-loaded poses.npy for body→cam conversion
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
@@ -968,6 +970,34 @@ class BackendNode(Ros2NodeManager):
         self._stop_all()
         self._start('rosbag_build_map')
 
+    def _load_map_poses(self):
+        """Lazily load poses.npy for body→cam conversion. Cached after first call."""
+        if hasattr(self, '_map_poses_cache'):
+            return self._map_poses_cache
+        poses_path = os.path.join(self.map_path, 'poses.npy')
+        if os.path.exists(poses_path):
+            self._map_poses_cache = np.load(poses_path, allow_pickle=True).item()
+        else:
+            self._map_poses_cache = {}
+        return self._map_poses_cache
+
+    def _body_to_cam(self, body_pos: list[float]) -> list[float]:
+        """Convert a body-center position to camera position using ROBOT_CONFIG."""
+        poses = self._load_map_poses()
+        if not poses:
+            return body_pos
+        body_arr = np.array(body_pos, dtype=float)
+        best_dist = float('inf')
+        best_R = np.eye(3)
+        for _, cam_pose in poses.items():
+            cam_pos = cam_pose[:3, 3]
+            dist = np.linalg.norm(cam_pos - body_arr)
+            if dist < best_dist:
+                best_dist = dist
+                best_R = cam_pose[:3, :3]
+        cam_arr = body_to_camera_position(body_arr, best_R, ROBOT_CONFIG)
+        return cam_arr.tolist()
+
     def _publish_cmd_pois(self, poi_id: int | None):
         """Publish the selected POI to map_node as JSON on /mapping/cmd_pois.
         Sending an empty dict clears the current nav target."""
@@ -984,8 +1014,11 @@ class BackendNode(Ros2NodeManager):
         if key not in pois:
             self.get_logger().warn(f'POI {poi_id} not found in pois.json')
             return
+        # Convert body position to camera position for map_node
+        poi = dict(pois[key])
+        poi['position'] = self._body_to_cam(poi['position'])
         # Re-index as "0" to match pub_pois.py convention expected by map_node
-        payload = {'0': pois[key]}
+        payload = {'0': poi}
         self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
 
     def cmd_manual_target_pose(self, x: float, y: float, z: float):
@@ -1023,7 +1056,9 @@ class BackendNode(Ros2NodeManager):
             for pid in poi_ids:
                 key = str(pid)
                 if key in all_pois:
-                    payload[str(len(payload))] = all_pois[key]
+                    poi = dict(all_pois[key])
+                    poi['position'] = self._body_to_cam(poi['position'])
+                    payload[str(len(payload))] = poi
             self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
         with self._lock:
             nav_running = self._nav_nodes_running

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -192,7 +192,6 @@ class BackendNode(Ros2NodeManager):
 
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
-        self._map_poses: dict | None = None  # lazy-loaded poses.npy for body-to-cam conversion
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
@@ -970,32 +969,9 @@ class BackendNode(Ros2NodeManager):
         self._stop_all()
         self._start('rosbag_build_map')
 
-    def _load_map_poses(self):
-        """Lazily load poses.npy for body-to-cam conversion. Cached after first call."""
-        if hasattr(self, '_map_poses_cache'):
-            return self._map_poses_cache
-        poses_path = os.path.join(self.map_path, 'poses.npy')
-        if os.path.exists(poses_path):
-            self._map_poses_cache = np.load(poses_path, allow_pickle=True).item()
-        else:
-            self._map_poses_cache = {}
-        return self._map_poses_cache
-
     def _body_to_cam(self, body_pos: list[float]) -> list[float]:
-        """Convert a body-center position to camera position using ROBOT_CONFIG."""
-        poses = self._load_map_poses()
-        if not poses:
-            return body_pos
         body_arr = np.array(body_pos, dtype=float)
-        best_dist = float('inf')
-        best_R = np.eye(3)
-        for _, cam_pose in poses.items():
-            cam_pos = cam_pose[:3, 3]
-            dist = np.linalg.norm(cam_pos - body_arr)
-            if dist < best_dist:
-                best_dist = dist
-                best_R = cam_pose[:3, :3]
-        cam_arr = body_to_camera_position(body_arr, best_R, ROBOT_CONFIG)
+        cam_arr = body_arr + ROBOT_CONFIG.cam_offset_3d
         return cam_arr.tolist()
 
     def _publish_cmd_pois(self, poi_id: int | None):
@@ -1017,7 +993,6 @@ class BackendNode(Ros2NodeManager):
         # Convert body position to camera position for map_node
         poi = dict(pois[key])
         poi['position'] = self._body_to_cam(poi['position'])
-        # Re-index as "0" to match pub_pois.py convention expected by map_node
         payload = {'0': poi}
         self._cmd_pois_pub.publish(String(data=json.dumps(payload)))
 

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -192,7 +192,7 @@ class BackendNode(Ros2NodeManager):
 
         self._nav_progress: dict | None = None
         self.nav_progress_callbacks: list = []
-        self._map_poses: dict | None = None  # lazy-loaded poses.npy for body→cam conversion
+        self._map_poses: dict | None = None  # lazy-loaded poses.npy for body-to-cam conversion
 
         self.create_subscription(Float32, '/battery', self._on_battery, 10)
         self.create_subscription(Bool, '/mapping/nav_done', self._on_nav_done, 10)
@@ -971,7 +971,7 @@ class BackendNode(Ros2NodeManager):
         self._start('rosbag_build_map')
 
     def _load_map_poses(self):
-        """Lazily load poses.npy for body→cam conversion. Cached after first call."""
+        """Lazily load poses.npy for body-to-cam conversion. Cached after first call."""
         if hasattr(self, '_map_poses_cache'):
             return self._map_poses_cache
         poses_path = os.path.join(self.map_path, 'poses.npy')

--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -30,7 +30,7 @@ from sensor_msgs.msg import CompressedImage, Image, PointCloud, PointCloud2
 from std_msgs.msg import Bool, Float32, String
 
 from tool.ros2_node_manager import Ros2NodeManager
-from tinynav.core.robot_config import ROBOT_CONFIG, body_to_camera_position
+from tinynav.core.robot_config import ROBOT_CONFIG
 
 _REALSENSE_SCRIPT = '/tinynav/scripts/run_realsense_sensor.sh'
 _VENV_SITE = '/tinynav/.venv/lib/python3.10/site-packages'

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -15,7 +15,7 @@ from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
-from tinynav.core.robot_config import GO2_CONFIG
+from tinynav.core.robot_config import ROBOT_CONFIG
 from dataclasses import dataclass
 
 
@@ -304,7 +304,7 @@ def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
 class PlanningNode(Node):
     def __init__(self):
         super().__init__('planning_node')
-        self.robot = GO2_CONFIG
+        self.robot = ROBOT_CONFIG
         self.get_logger().info(
             f"Robot: {self.robot.name} ({self.robot.shape} {self.robot.length}x{self.robot.width}m, "
             f"cam=({self.robot.camera_x},{self.robot.camera_y}), "

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -5,7 +5,6 @@ from nav_msgs.msg import Path, Odometry, OccupancyGrid
 from cv_bridge import CvBridge
 import numpy as np
 from scipy.ndimage import distance_transform_edt, binary_dilation
-from dataclasses import dataclass
 from numba import njit
 import message_filters
 from rclpy.time import Time
@@ -16,54 +15,8 @@ from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
+from tinynav.core.robot_config import RobotConfig, GO2_CONFIG, B2_CONFIG, ROBOT_CONFIGS, get_robot_config
 
-
-@dataclass
-class RobotConfig:
-    """Robot geometry. Body frame: +x forward, +y left."""
-    name: str = 'go2'
-    shape: str = 'square'
-    length: float = 0.7
-    width: float = 0.3
-    radius: float = 0.3
-    camera_x: float = 0.35
-    camera_y: float = 0.0
-    control_x: float = 0.0
-    control_y: float = 0.0
-    safety_radius: float = 0.1
-
-    @property
-    def cam_offset_3d(self):
-        """Offset [left, up, forward] from control center to camera in body frame."""
-        return np.array([self.camera_y - self.control_y, 0.0, self.camera_x - self.control_x], dtype=np.float32)
-
-    @property
-    def half_size(self):
-        if self.shape == 'circle':
-            return (self.radius, self.radius)
-        return (self.length / 2.0, self.width / 2.0)
-
-    def footprint_from_control(self):
-        """Returns (front_len, rear_len, half_w) relative to control center."""
-        hl, hw = self.half_size
-        return float(hl - self.control_x), float(hl + self.control_x), float(hw)
-
-
-GO2_CONFIG = RobotConfig(
-    name='go2', shape='square',
-    length=0.4, width=0.3,
-    camera_x=0.2, camera_y=0.0,
-    control_x=0.0, control_y=0.0,
-    safety_radius=0.2,
-)
-
-B2_CONFIG = RobotConfig(
-    name='b2', shape='square',
-    length=1.0, width=0.5,
-    camera_x=0.5, camera_y=0.0,
-    control_x=-0.5, control_y=0.0,
-    safety_radius=0.1,
-)
 
 # === Helper functions ===
 @njit(cache=True)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -15,7 +15,8 @@ from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
-from tinynav.core.robot_config import RobotConfig, GO2_CONFIG, B2_CONFIG, ROBOT_CONFIGS, get_robot_config
+from tinynav.core.robot_config import GO2_CONFIG
+from dataclasses import dataclass
 
 
 # === Helper functions ===

--- a/tinynav/core/robot_config.py
+++ b/tinynav/core/robot_config.py
@@ -58,6 +58,12 @@ ROBOT_CONFIGS = {
     'b2': B2_CONFIG,
 }
 
+# ── 换机器人只改这一行 ──
+ACTIVE_ROBOT = 'go2'
+# ──────────────────────
+
+ROBOT_CONFIG = ROBOT_CONFIGS[ACTIVE_ROBOT]
+
 
 def get_robot_config(name: str = 'go2') -> RobotConfig:
     """Look up a robot config by name. Falls back to GO2_CONFIG."""

--- a/tinynav/core/robot_config.py
+++ b/tinynav/core/robot_config.py
@@ -50,11 +50,3 @@ ROBOT_CONFIGS = {'go2': GO2_CONFIG, 'b2': B2_CONFIG}
 
 # Switch robot here
 ROBOT_CONFIG = GO2_CONFIG
-
-
-def camera_to_body_position(cam_pos, cam_R, robot_config=ROBOT_CONFIG):
-    return cam_pos - cam_R @ robot_config.cam_offset_3d
-
-
-def body_to_camera_position(body_pos, cam_R, robot_config=ROBOT_CONFIG):
-    return body_pos + cam_R @ robot_config.cam_offset_3d

--- a/tinynav/core/robot_config.py
+++ b/tinynav/core/robot_config.py
@@ -1,0 +1,98 @@
+"""Robot configuration shared across planning, mapping, and editing tools.
+
+Body frame convention: +x forward, +y left, +z up.
+"""
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class RobotConfig:
+    """Robot geometry. Body frame: +x forward, +y left."""
+    name: str = 'go2'
+    shape: str = 'square'
+    length: float = 0.7
+    width: float = 0.3
+    radius: float = 0.3
+    camera_x: float = 0.35
+    camera_y: float = 0.0
+    control_x: float = 0.0
+    control_y: float = 0.0
+    safety_radius: float = 0.1
+
+    @property
+    def cam_offset_3d(self):
+        """Offset [left, up, forward] from control center to camera in body frame."""
+        return np.array([self.camera_y - self.control_y, 0.0, self.camera_x - self.control_x], dtype=np.float32)
+
+    @property
+    def half_size(self):
+        if self.shape == 'circle':
+            return (self.radius, self.radius)
+        return (self.length / 2.0, self.width / 2.0)
+
+    def footprint_from_control(self):
+        """Returns (front_len, rear_len, half_w) relative to control center."""
+        hl, hw = self.half_size
+        return float(hl - self.control_x), float(hl + self.control_x), float(hw)
+
+
+GO2_CONFIG = RobotConfig(
+    name='go2', shape='square',
+    length=0.4, width=0.3,
+    camera_x=0.2, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.2,
+)
+
+B2_CONFIG = RobotConfig(
+    name='b2', shape='square',
+    length=1.0, width=0.5,
+    camera_x=0.5, camera_y=0.0,
+    control_x=-0.5, control_y=0.0,
+    safety_radius=0.1,
+)
+
+ROBOT_CONFIGS = {
+    'go2': GO2_CONFIG,
+    'b2': B2_CONFIG,
+}
+
+
+def get_robot_config(name: str = 'go2') -> RobotConfig:
+    """Look up a robot config by name. Falls back to GO2_CONFIG."""
+    return ROBOT_CONFIGS.get(name, GO2_CONFIG)
+
+
+def camera_to_body_position(cam_pos: np.ndarray, cam_R: np.ndarray, robot_config: RobotConfig) -> np.ndarray:
+    """Convert a camera-frame world position to robot body-center world position.
+
+    Given a camera pose (position + rotation in world frame), compute where
+    the robot's control center would be, using the camera-to-body offset
+    defined in ``robot_config``.
+
+    Args:
+        cam_pos: Camera position in world frame, shape (3,).
+        cam_R: Camera rotation matrix in world frame, shape (3, 3).
+        robot_config: RobotConfig with camera/control offsets.
+
+    Returns:
+        Robot body-center position in world frame, shape (3,).
+    """
+    return cam_pos - cam_R @ robot_config.cam_offset_3d
+
+
+def body_to_camera_position(body_pos: np.ndarray, cam_R: np.ndarray, robot_config: RobotConfig) -> np.ndarray:
+    """Convert a robot body-center world position to camera world position.
+
+    Inverse of :func:`camera_to_body_position`.
+
+    Args:
+        body_pos: Robot body-center position in world frame, shape (3,).
+        cam_R: Camera rotation matrix in world frame, shape (3, 3).
+        robot_config: RobotConfig with camera/control offsets.
+
+    Returns:
+        Camera position in world frame, shape (3,).
+    """
+    return body_pos + cam_R @ robot_config.cam_offset_3d

--- a/tinynav/core/robot_config.py
+++ b/tinynav/core/robot_config.py
@@ -1,14 +1,9 @@
-"""Robot configuration shared across planning, mapping, and editing tools.
-
-Body frame convention: +x forward, +y left, +z up.
-"""
 from dataclasses import dataclass
 import numpy as np
 
 
 @dataclass
 class RobotConfig:
-    """Robot geometry. Body frame: +x forward, +y left."""
     name: str = 'go2'
     shape: str = 'square'
     length: float = 0.7
@@ -22,7 +17,6 @@ class RobotConfig:
 
     @property
     def cam_offset_3d(self):
-        """Offset [left, up, forward] from control center to camera in body frame."""
         return np.array([self.camera_y - self.control_y, 0.0, self.camera_x - self.control_x], dtype=np.float32)
 
     @property
@@ -32,7 +26,6 @@ class RobotConfig:
         return (self.length / 2.0, self.width / 2.0)
 
     def footprint_from_control(self):
-        """Returns (front_len, rear_len, half_w) relative to control center."""
         hl, hw = self.half_size
         return float(hl - self.control_x), float(hl + self.control_x), float(hw)
 
@@ -53,52 +46,15 @@ B2_CONFIG = RobotConfig(
     safety_radius=0.1,
 )
 
-ROBOT_CONFIGS = {
-    'go2': GO2_CONFIG,
-    'b2': B2_CONFIG,
-}
+ROBOT_CONFIGS = {'go2': GO2_CONFIG, 'b2': B2_CONFIG}
 
-# -- Change this line to switch robot --
-ACTIVE_ROBOT = 'go2'
-# ----------------------------------
-
-ROBOT_CONFIG = ROBOT_CONFIGS[ACTIVE_ROBOT]
+# Switch robot here
+ROBOT_CONFIG = GO2_CONFIG
 
 
-def get_robot_config(name: str = 'go2') -> RobotConfig:
-    """Look up a robot config by name. Falls back to GO2_CONFIG."""
-    return ROBOT_CONFIGS.get(name, GO2_CONFIG)
-
-
-def camera_to_body_position(cam_pos: np.ndarray, cam_R: np.ndarray, robot_config: RobotConfig) -> np.ndarray:
-    """Convert a camera-frame world position to robot body-center world position.
-
-    Given a camera pose (position + rotation in world frame), compute where
-    the robot's control center would be, using the camera-to-body offset
-    defined in ``robot_config``.
-
-    Args:
-        cam_pos: Camera position in world frame, shape (3,).
-        cam_R: Camera rotation matrix in world frame, shape (3, 3).
-        robot_config: RobotConfig with camera/control offsets.
-
-    Returns:
-        Robot body-center position in world frame, shape (3,).
-    """
+def camera_to_body_position(cam_pos, cam_R, robot_config=ROBOT_CONFIG):
     return cam_pos - cam_R @ robot_config.cam_offset_3d
 
 
-def body_to_camera_position(body_pos: np.ndarray, cam_R: np.ndarray, robot_config: RobotConfig) -> np.ndarray:
-    """Convert a robot body-center world position to camera world position.
-
-    Inverse of :func:`camera_to_body_position`.
-
-    Args:
-        body_pos: Robot body-center position in world frame, shape (3,).
-        cam_R: Camera rotation matrix in world frame, shape (3, 3).
-        robot_config: RobotConfig with camera/control offsets.
-
-    Returns:
-        Camera position in world frame, shape (3,).
-    """
+def body_to_camera_position(body_pos, cam_R, robot_config=ROBOT_CONFIG):
     return body_pos + cam_R @ robot_config.cam_offset_3d

--- a/tinynav/core/robot_config.py
+++ b/tinynav/core/robot_config.py
@@ -58,9 +58,9 @@ ROBOT_CONFIGS = {
     'b2': B2_CONFIG,
 }
 
-# ── 换机器人只改这一行 ──
+# -- Change this line to switch robot --
 ACTIVE_ROBOT = 'go2'
-# ──────────────────────
+# ----------------------------------
 
 ROBOT_CONFIG = ROBOT_CONFIGS[ACTIVE_ROBOT]
 

--- a/tool/poi_editor.py
+++ b/tool/poi_editor.py
@@ -170,7 +170,15 @@ def _load_infra1_camera_image(infra1_db: VideoDB | None, timestamp: str) -> np.n
     return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
     
-def create_poi_ui(server,poi_list_container,poi_index:int, poi_points:dict, sphere_handle:viser.SceneHandle):
+def create_poi_ui(
+    server,
+    poi_list_container,
+    poi_index: int,
+    poi_points: dict,
+    sphere_handle: viser.SceneHandle,
+    on_position_update=None,
+    on_delete=None,
+):
     with poi_list_container:
         with server.gui.add_folder(f"POI_{poi_index}") as poi_container:
             gui_vector3 = server.gui.add_vector3(
@@ -199,10 +207,12 @@ def create_poi_ui(server,poi_list_container,poi_index:int, poi_points:dict, sphe
     # Add a transform gizmo attached to the sphere
     gizmo = server.scene.add_transform_controls(f"/{poi_points[poi_index]['name']}_gizmo", position=poi_points[poi_index]['position'], wxyz=(1.0, 0.0, 0.0, 0.0))
     def on_gizmo_update(event):
-        # Update sphere position when gizmo is dragged
+        # Update sphere position when gizmo is dragged.
         sphere_handle.position = event.target.position
         gui_vector3.value = event.target.position
         poi_points[poi_index]['position'] = event.target.position
+        if on_position_update is not None:
+            on_position_update(poi_index)
         #print("Sphere moved to:", event.position)
     gizmo.on_update(on_gizmo_update)
 
@@ -212,6 +222,8 @@ def create_poi_ui(server,poi_list_container,poi_index:int, poi_points:dict, sphe
         poi_container.remove()
         sphere_handle.remove()
         gizmo.remove()
+        if on_delete is not None:
+            on_delete(poi_index)
 
 class RelocalizationPose(Node):
     def __init__(self, viser_server: viser.ViserServer):
@@ -311,8 +323,8 @@ def main(
     server.scene.world_axes.visible = True
     server.scene.set_up_direction("+z")
     
-    # Load robot config
-    from robot_config import get_robot_config, ROBOT_CONFIGS, camera_to_body_position
+    # Load robot config. pois.json remains in map_node format (camera positions),
+    # while the editor displays and edits robot body-center positions.
     robot_config_path = tinynav_map_path / "robot_config.json"
     saved_robot_name = "go2"
     if robot_config_path.exists():
@@ -321,44 +333,13 @@ def main(
                 saved_robot_name = json.load(f).get("robot", "go2")
         except Exception:
             pass
+    if saved_robot_name not in ROBOT_CONFIGS:
+        saved_robot_name = "go2"
     robot_config = get_robot_config(saved_robot_name)
 
-    # Load poses for nearest-camera lookup (needed for cam-to-body offset)
+    # Load poses for nearest-camera lookup (needed for camera/body conversion).
     all_poses = np.load(tinynav_map_path / "poses.npy", allow_pickle=True).item()
     all_pose_items = list(all_poses.items())  # [(timestamp, 4x4 matrix), ...]
-
-    # POI management
-    poi_points = {}
-    poi_id_counter = 0
-
-    if os.path.exists(f"{tinynav_map_path}/pois.json"):
-        with open(f"{tinynav_map_path}/pois.json", "r") as f:
-            poi_points = json.load(f)
-            poi_points = {int(k): v for k, v in poi_points.items()}
-            for k, v in poi_points.items():
-                v['position'] = np.array(v['position'])
-            poi_id_counter = max(map(lambda x: int(x), poi_points.keys())) + 1
-
-    # Robot config GUI
-    with server.gui.add_folder("Robot Config") as _:
-        robot_dropdown = server.gui.add_dropdown(
-            "Robot Type", options=list(ROBOT_CONFIGS.keys()), initial_value=saved_robot_name
-        )
-        apply_offset_checkbox = server.gui.add_checkbox(
-            "Apply cam-to-body offset on save", initial_value=True
-        )
-        show_footprint_checkbox = server.gui.add_checkbox(
-            "Show robot footprint at POIs", initial_value=True
-        )
-
-        @robot_dropdown.on_update
-        def _(_) -> None:
-            nonlocal robot_config
-            robot_config = get_robot_config(robot_dropdown.value)
-            # Persist selection
-            with open(robot_config_path, "w") as f:
-                json.dump({"robot": robot_dropdown.value}, f, indent=2)
-            print(f"Robot config switched to: {robot_config.name}")
 
     def _find_nearest_pose_R(position: np.ndarray) -> np.ndarray:
         """Find the rotation matrix of the nearest camera pose to a 3D position."""
@@ -372,20 +353,75 @@ def main(
                 best_R = cam_pose[:3, :3]
         return best_R
 
+    def _camera_json_to_editor_body_position(cam_position: np.ndarray) -> np.ndarray:
+        """Convert pois.json camera position into editor body-center position."""
+        R = _find_nearest_pose_R(cam_position)
+        return camera_to_body_position(cam_position, R, robot_config)
+
+    def _editor_body_to_camera_json_position(body_position: np.ndarray) -> np.ndarray:
+        """Convert editor body-center position into pois.json camera position."""
+        # First estimate orientation near the body point, then re-query near the
+        # resulting camera point. This keeps the nearest-pose approximation stable
+        # for robots with larger camera/body offsets.
+        R = _find_nearest_pose_R(body_position)
+        cam_position = body_to_camera_position(body_position, R, robot_config)
+        R = _find_nearest_pose_R(cam_position)
+        return body_to_camera_position(body_position, R, robot_config)
+
+    # POI management. In memory, poi_points['position'] is editor/body position.
+    poi_points = {}
+    poi_id_counter = 0
+
+    if os.path.exists(f"{tinynav_map_path}/pois.json"):
+        with open(f"{tinynav_map_path}/pois.json", "r") as f:
+            poi_points = json.load(f)
+            poi_points = {int(k): v for k, v in poi_points.items()}
+            for k, v in poi_points.items():
+                cam_position = np.array(v['position'], dtype=float)
+                v['position'] = _camera_json_to_editor_body_position(cam_position)
+            poi_id_counter = max(map(lambda x: int(x), poi_points.keys())) + 1
+
+    # Robot config GUI
+    with server.gui.add_folder("Robot Config") as _:
+        robot_dropdown = server.gui.add_dropdown(
+            "Robot Type", options=list(ROBOT_CONFIGS.keys()), initial_value=saved_robot_name
+        )
+        save_as_camera_checkbox = server.gui.add_checkbox(
+            "Save JSON as camera positions (map_node)", initial_value=True
+        )
+        show_footprint_checkbox = server.gui.add_checkbox(
+            "Show robot footprint at POIs", initial_value=True
+        )
+
+        @robot_dropdown.on_update
+        def _(_) -> None:
+            nonlocal robot_config
+            robot_config = get_robot_config(robot_dropdown.value)
+            # Persist selection
+            with open(robot_config_path, "w") as f:
+                json.dump({"robot": robot_dropdown.value}, f, indent=2)
+            print(f"Robot config switched to: {robot_config.name}")
+            for poi_id in list(poi_points.keys()):
+                _update_footprint_viz(poi_id)
+
     def _get_export_position(poi_position: np.ndarray) -> np.ndarray:
-        """Return the exported POI position, applying cam-to-body offset if enabled."""
-        if not apply_offset_checkbox.value:
+        """Return pois.json position. Default format is camera position for map_node."""
+        if not save_as_camera_checkbox.value:
             return poi_position
-        R = _find_nearest_pose_R(poi_position)
-        return camera_to_body_position(poi_position, R, robot_config)
+        return _editor_body_to_camera_json_position(poi_position)
 
     footprint_handles = {}  # poi_id -> list of viser handles for footprint viz
+
+    def _remove_footprint_viz(poi_id: int):
+        """Remove robot footprint visualization for a POI."""
+        for h in footprint_handles.get(poi_id, []):
+            h.remove()
+        footprint_handles.pop(poi_id, None)
 
     def _update_footprint_viz(poi_id: int):
         """Show/hide robot footprint at a POI position."""
         # Remove old handles
-        for h in footprint_handles.get(poi_id, []):
-            h.remove()
+        _remove_footprint_viz(poi_id)
         footprint_handles[poi_id] = []
 
         if not show_footprint_checkbox.value:
@@ -444,7 +480,8 @@ def main(
             with open(f"{tinynav_map_path}/pois.json", "w") as f:
                 json.dump(export_points, f, indent=2)
             print(f"Saved {len(export_points)} POIs to {tinynav_map_path}/pois.json"
-                  f" (offset={'on' if apply_offset_checkbox.value else 'off'}, robot={robot_config.name})")
+                  f" (format={'camera/map_node' if save_as_camera_checkbox.value else 'body/editor'}, "
+                  f"robot={robot_config.name})")
 
         poi_list_container = server.gui.add_folder("POI List")
         for poi_id, poi_point in poi_points.items():
@@ -454,7 +491,15 @@ def main(
                 color=(np.random.randint(0, 255), np.random.randint(0, 255), np.random.randint(0, 255)),
                 position=poi_point['position']
             )
-            create_poi_ui(server, poi_list_container,int(poi_id), poi_points, sphere_handle)
+            create_poi_ui(
+                server,
+                poi_list_container,
+                int(poi_id),
+                poi_points,
+                sphere_handle,
+                on_position_update=_update_footprint_viz,
+                on_delete=_remove_footprint_viz,
+            )
             _update_footprint_viz(poi_id)
 
         @add_poi_button.on_click
@@ -480,7 +525,15 @@ def main(
                 color=(np.random.randint(0, 255), np.random.randint(0, 255), np.random.randint(0, 255)),
                 position=poi_points[poi_id]['position']
             )
-            create_poi_ui(server, poi_list_container,poi_id, poi_points, sphere_handle)
+            create_poi_ui(
+                server,
+                poi_list_container,
+                poi_id,
+                poi_points,
+                sphere_handle,
+                on_position_update=_update_footprint_viz,
+                on_delete=_remove_footprint_viz,
+            )
             _update_footprint_viz(poi_id)
     
     # Load and visualize occupancy grid as 2D XY projection (same as build_map_node).

--- a/tool/poi_editor.py
+++ b/tool/poi_editor.py
@@ -22,7 +22,6 @@ import rclpy
 import os
 from math_utils import msg2np, matrix_to_quat
 from tool.video_db import VideoDB
-from robot_config import get_robot_config, ROBOT_CONFIGS, camera_to_body_position, body_to_camera_position
 
 class SplatFile(TypedDict):
     centers: npt.NDArray[np.floating]
@@ -170,15 +169,7 @@ def _load_infra1_camera_image(infra1_db: VideoDB | None, timestamp: str) -> np.n
     return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
     
-def create_poi_ui(
-    server,
-    poi_list_container,
-    poi_index: int,
-    poi_points: dict,
-    sphere_handle: viser.SceneHandle,
-    on_position_update=None,
-    on_delete=None,
-):
+def create_poi_ui(server,poi_list_container,poi_index:int, poi_points:dict, sphere_handle:viser.SceneHandle):
     with poi_list_container:
         with server.gui.add_folder(f"POI_{poi_index}") as poi_container:
             gui_vector3 = server.gui.add_vector3(
@@ -207,12 +198,10 @@ def create_poi_ui(
     # Add a transform gizmo attached to the sphere
     gizmo = server.scene.add_transform_controls(f"/{poi_points[poi_index]['name']}_gizmo", position=poi_points[poi_index]['position'], wxyz=(1.0, 0.0, 0.0, 0.0))
     def on_gizmo_update(event):
-        # Update sphere position when gizmo is dragged.
+        # Update sphere position when gizmo is dragged
         sphere_handle.position = event.target.position
         gui_vector3.value = event.target.position
         poi_points[poi_index]['position'] = event.target.position
-        if on_position_update is not None:
-            on_position_update(poi_index)
         #print("Sphere moved to:", event.position)
     gizmo.on_update(on_gizmo_update)
 
@@ -222,8 +211,6 @@ def create_poi_ui(
         poi_container.remove()
         sphere_handle.remove()
         gizmo.remove()
-        if on_delete is not None:
-            on_delete(poi_index)
 
 class RelocalizationPose(Node):
     def __init__(self, viser_server: viser.ViserServer):
@@ -323,52 +310,7 @@ def main(
     server.scene.world_axes.visible = True
     server.scene.set_up_direction("+z")
     
-    # Load robot config. pois.json remains in map_node format (camera positions),
-    # while the editor displays and edits robot body-center positions.
-    robot_config_path = tinynav_map_path / "robot_config.json"
-    saved_robot_name = "go2"
-    if robot_config_path.exists():
-        try:
-            with open(robot_config_path, "r") as f:
-                saved_robot_name = json.load(f).get("robot", "go2")
-        except Exception:
-            pass
-    if saved_robot_name not in ROBOT_CONFIGS:
-        saved_robot_name = "go2"
-    robot_config = get_robot_config(saved_robot_name)
-
-    # Load poses for nearest-camera lookup (needed for camera/body conversion).
-    all_poses = np.load(tinynav_map_path / "poses.npy", allow_pickle=True).item()
-    all_pose_items = list(all_poses.items())  # [(timestamp, 4x4 matrix), ...]
-
-    def _find_nearest_pose_R(position: np.ndarray) -> np.ndarray:
-        """Find the rotation matrix of the nearest camera pose to a 3D position."""
-        best_dist = float('inf')
-        best_R = np.eye(3)
-        for _, cam_pose in all_pose_items:
-            cam_pos = cam_pose[:3, 3]
-            dist = np.linalg.norm(cam_pos - position)
-            if dist < best_dist:
-                best_dist = dist
-                best_R = cam_pose[:3, :3]
-        return best_R
-
-    def _camera_json_to_editor_body_position(cam_position: np.ndarray) -> np.ndarray:
-        """Convert pois.json camera position into editor body-center position."""
-        R = _find_nearest_pose_R(cam_position)
-        return camera_to_body_position(cam_position, R, robot_config)
-
-    def _editor_body_to_camera_json_position(body_position: np.ndarray) -> np.ndarray:
-        """Convert editor body-center position into pois.json camera position."""
-        # First estimate orientation near the body point, then re-query near the
-        # resulting camera point. This keeps the nearest-pose approximation stable
-        # for robots with larger camera/body offsets.
-        R = _find_nearest_pose_R(body_position)
-        cam_position = body_to_camera_position(body_position, R, robot_config)
-        R = _find_nearest_pose_R(cam_position)
-        return body_to_camera_position(body_position, R, robot_config)
-
-    # POI management. In memory, poi_points['position'] is editor/body position.
+    # POI management
     poi_points = {}
     poi_id_counter = 0
 
@@ -377,91 +319,10 @@ def main(
             poi_points = json.load(f)
             poi_points = {int(k): v for k, v in poi_points.items()}
             for k, v in poi_points.items():
-                cam_position = np.array(v['position'], dtype=float)
-                v['position'] = _camera_json_to_editor_body_position(cam_position)
+                v['position'] = np.array(v['position'])
             poi_id_counter = max(map(lambda x: int(x), poi_points.keys())) + 1
-
-    # Robot config GUI
-    with server.gui.add_folder("Robot Config") as _:
-        robot_dropdown = server.gui.add_dropdown(
-            "Robot Type", options=list(ROBOT_CONFIGS.keys()), initial_value=saved_robot_name
-        )
-        save_as_camera_checkbox = server.gui.add_checkbox(
-            "Save JSON as camera positions (map_node)", initial_value=True
-        )
-        show_footprint_checkbox = server.gui.add_checkbox(
-            "Show robot footprint at POIs", initial_value=True
-        )
-
-        @robot_dropdown.on_update
-        def _(_) -> None:
-            nonlocal robot_config
-            robot_config = get_robot_config(robot_dropdown.value)
-            # Persist selection
-            with open(robot_config_path, "w") as f:
-                json.dump({"robot": robot_dropdown.value}, f, indent=2)
-            print(f"Robot config switched to: {robot_config.name}")
-            for poi_id in list(poi_points.keys()):
-                _update_footprint_viz(poi_id)
-
-    def _get_export_position(poi_position: np.ndarray) -> np.ndarray:
-        """Return pois.json position. Default format is camera position for map_node."""
-        if not save_as_camera_checkbox.value:
-            return poi_position
-        return _editor_body_to_camera_json_position(poi_position)
-
-    footprint_handles = {}  # poi_id -> list of viser handles for footprint viz
-
-    def _remove_footprint_viz(poi_id: int):
-        """Remove robot footprint visualization for a POI."""
-        for h in footprint_handles.get(poi_id, []):
-            h.remove()
-        footprint_handles.pop(poi_id, None)
-
-    def _update_footprint_viz(poi_id: int):
-        """Show/hide robot footprint at a POI position."""
-        # Remove old handles
-        _remove_footprint_viz(poi_id)
-        footprint_handles[poi_id] = []
-
-        if not show_footprint_checkbox.value:
-            return
-        if poi_id not in poi_points:
-            return
-
-        pos = poi_points[poi_id]['position']
-        R = _find_nearest_pose_R(pos)
-        # Footprint in camera/world frame: forward=z, left=x
-        forward = R @ np.array([0.0, 0.0, 1.0])
-        left = R @ np.array([1.0, 0.0, 0.0])
-        fl, rl, hw = robot_config.footprint_from_control()
-        corners = [
-            pos + forward * fl + left * hw,
-            pos + forward * fl - left * hw,
-            pos - forward * rl - left * hw,
-            pos - forward * rl + left * hw,
-        ]
-        # Draw 4 line segments as thin boxes (viser doesn't have add_line_segments on scene directly,
-        # use add_line_segments)
-        segments = []
-        for i in range(4):
-            segments.append(np.array([corners[i], corners[(i + 1) % 4]]))
-        segments = np.array(segments)
-        n = len(segments)
-        colors = np.tile(np.array([[0.0, 1.0, 0.0]], dtype=np.float32), (n, 2, 1))
-        handle = server.scene.add_line_segments(
-            f"/footprints/poi_{poi_id}",
-            points=segments,
-            colors=colors,
-            line_width=2,
-        )
-        footprint_handles[poi_id].append(handle)
-
-    @show_footprint_checkbox.on_update
-    def _(_) -> None:
-        for poi_id in list(poi_points.keys()):
-            _update_footprint_viz(poi_id)
-
+       
+    
     # Add POI management UI
     with server.gui.add_folder("Points of Interest (POI)") as _:
         add_poi_button = server.gui.add_button("Add POI Point")
@@ -469,19 +330,9 @@ def main(
 
         @add_save_poi_button.on_click
         def _(_) -> None:
-            # Build export copy with offset applied if enabled
-            export_points = {}
-            for k, v in poi_points.items():
-                export_points[k] = {
-                    'id': v.get('id', k),
-                    'name': v.get('name', f'POI_{k}'),
-                    'position': _get_export_position(np.asarray(v['position'], dtype=float)).tolist(),
-                }
             with open(f"{tinynav_map_path}/pois.json", "w") as f:
-                json.dump(export_points, f, indent=2)
-            print(f"Saved {len(export_points)} POIs to {tinynav_map_path}/pois.json"
-                  f" (format={'camera/map_node' if save_as_camera_checkbox.value else 'body/editor'}, "
-                  f"robot={robot_config.name})")
+                json.dump(poi_points, f, indent=2, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
+
 
         poi_list_container = server.gui.add_folder("POI List")
         for poi_id, poi_point in poi_points.items():
@@ -491,19 +342,12 @@ def main(
                 color=(np.random.randint(0, 255), np.random.randint(0, 255), np.random.randint(0, 255)),
                 position=poi_point['position']
             )
-            create_poi_ui(
-                server,
-                poi_list_container,
-                int(poi_id),
-                poi_points,
-                sphere_handle,
-                on_position_update=_update_footprint_viz,
-                on_delete=_remove_footprint_viz,
-            )
-            _update_footprint_viz(poi_id)
+            create_poi_ui(server, poi_list_container,int(poi_id), poi_points, sphere_handle)
 
         @add_poi_button.on_click
         def _(_) -> None:
+            # Get camera position as POI location
+            #camera_position = server.camera.position
             nonlocal poi_id_counter
             poi_id = poi_id_counter
             poi_id_counter += 1
@@ -514,6 +358,7 @@ def main(
                 poi_position = previous_position + np.array([0.3, 0.0, 0.0])
             else:
                 poi_position = np.random.randn(3)
+            # Add POI to list
             poi_points[poi_id] = {
                 'id': poi_id,
                 'name': poi_name,
@@ -525,16 +370,7 @@ def main(
                 color=(np.random.randint(0, 255), np.random.randint(0, 255), np.random.randint(0, 255)),
                 position=poi_points[poi_id]['position']
             )
-            create_poi_ui(
-                server,
-                poi_list_container,
-                poi_id,
-                poi_points,
-                sphere_handle,
-                on_position_update=_update_footprint_viz,
-                on_delete=_remove_footprint_viz,
-            )
-            _update_footprint_viz(poi_id)
+            create_poi_ui(server, poi_list_container,poi_id, poi_points, sphere_handle)
     
     # Load and visualize occupancy grid as 2D XY projection (same as build_map_node).
     occupancy_grid_path = tinynav_map_path / "occupancy_grid.npy"
@@ -729,7 +565,7 @@ def main(
         if not occupancy_meta_path.exists():
             print(f"  Missing: {occupancy_meta_path}")
     
-    poses = all_poses  # reuse already-loaded poses
+    poses = np.load(tinynav_map_path / "poses.npy", allow_pickle=True).item()
     if (tinynav_map_path / "intrinsics.npy").exists():
         camera_K = np.load(tinynav_map_path / "intrinsics.npy", allow_pickle=True)
     elif (tinynav_map_path / "rgb_camera_intrinsics.npy").exists():

--- a/tool/poi_editor.py
+++ b/tool/poi_editor.py
@@ -22,6 +22,7 @@ import rclpy
 import os
 from math_utils import msg2np, matrix_to_quat
 from tool.video_db import VideoDB
+from robot_config import get_robot_config, ROBOT_CONFIGS, camera_to_body_position, body_to_camera_position
 
 class SplatFile(TypedDict):
     centers: npt.NDArray[np.floating]
@@ -310,6 +311,22 @@ def main(
     server.scene.world_axes.visible = True
     server.scene.set_up_direction("+z")
     
+    # Load robot config
+    from robot_config import get_robot_config, ROBOT_CONFIGS, camera_to_body_position
+    robot_config_path = tinynav_map_path / "robot_config.json"
+    saved_robot_name = "go2"
+    if robot_config_path.exists():
+        try:
+            with open(robot_config_path, "r") as f:
+                saved_robot_name = json.load(f).get("robot", "go2")
+        except Exception:
+            pass
+    robot_config = get_robot_config(saved_robot_name)
+
+    # Load poses for nearest-camera lookup (needed for cam-to-body offset)
+    all_poses = np.load(tinynav_map_path / "poses.npy", allow_pickle=True).item()
+    all_pose_items = list(all_poses.items())  # [(timestamp, 4x4 matrix), ...]
+
     # POI management
     poi_points = {}
     poi_id_counter = 0
@@ -321,8 +338,94 @@ def main(
             for k, v in poi_points.items():
                 v['position'] = np.array(v['position'])
             poi_id_counter = max(map(lambda x: int(x), poi_points.keys())) + 1
-       
-    
+
+    # Robot config GUI
+    with server.gui.add_folder("Robot Config") as _:
+        robot_dropdown = server.gui.add_dropdown(
+            "Robot Type", options=list(ROBOT_CONFIGS.keys()), initial_value=saved_robot_name
+        )
+        apply_offset_checkbox = server.gui.add_checkbox(
+            "Apply cam-to-body offset on save", initial_value=True
+        )
+        show_footprint_checkbox = server.gui.add_checkbox(
+            "Show robot footprint at POIs", initial_value=True
+        )
+
+        @robot_dropdown.on_update
+        def _(_) -> None:
+            nonlocal robot_config
+            robot_config = get_robot_config(robot_dropdown.value)
+            # Persist selection
+            with open(robot_config_path, "w") as f:
+                json.dump({"robot": robot_dropdown.value}, f, indent=2)
+            print(f"Robot config switched to: {robot_config.name}")
+
+    def _find_nearest_pose_R(position: np.ndarray) -> np.ndarray:
+        """Find the rotation matrix of the nearest camera pose to a 3D position."""
+        best_dist = float('inf')
+        best_R = np.eye(3)
+        for _, cam_pose in all_pose_items:
+            cam_pos = cam_pose[:3, 3]
+            dist = np.linalg.norm(cam_pos - position)
+            if dist < best_dist:
+                best_dist = dist
+                best_R = cam_pose[:3, :3]
+        return best_R
+
+    def _get_export_position(poi_position: np.ndarray) -> np.ndarray:
+        """Return the exported POI position, applying cam-to-body offset if enabled."""
+        if not apply_offset_checkbox.value:
+            return poi_position
+        R = _find_nearest_pose_R(poi_position)
+        return camera_to_body_position(poi_position, R, robot_config)
+
+    footprint_handles = {}  # poi_id -> list of viser handles for footprint viz
+
+    def _update_footprint_viz(poi_id: int):
+        """Show/hide robot footprint at a POI position."""
+        # Remove old handles
+        for h in footprint_handles.get(poi_id, []):
+            h.remove()
+        footprint_handles[poi_id] = []
+
+        if not show_footprint_checkbox.value:
+            return
+        if poi_id not in poi_points:
+            return
+
+        pos = poi_points[poi_id]['position']
+        R = _find_nearest_pose_R(pos)
+        # Footprint in camera/world frame: forward=z, left=x
+        forward = R @ np.array([0.0, 0.0, 1.0])
+        left = R @ np.array([1.0, 0.0, 0.0])
+        fl, rl, hw = robot_config.footprint_from_control()
+        corners = [
+            pos + forward * fl + left * hw,
+            pos + forward * fl - left * hw,
+            pos - forward * rl - left * hw,
+            pos - forward * rl + left * hw,
+        ]
+        # Draw 4 line segments as thin boxes (viser doesn't have add_line_segments on scene directly,
+        # use add_line_segments)
+        segments = []
+        for i in range(4):
+            segments.append(np.array([corners[i], corners[(i + 1) % 4]]))
+        segments = np.array(segments)
+        n = len(segments)
+        colors = np.tile(np.array([[0.0, 1.0, 0.0]], dtype=np.float32), (n, 2, 1))
+        handle = server.scene.add_line_segments(
+            f"/footprints/poi_{poi_id}",
+            points=segments,
+            colors=colors,
+            line_width=2,
+        )
+        footprint_handles[poi_id].append(handle)
+
+    @show_footprint_checkbox.on_update
+    def _(_) -> None:
+        for poi_id in list(poi_points.keys()):
+            _update_footprint_viz(poi_id)
+
     # Add POI management UI
     with server.gui.add_folder("Points of Interest (POI)") as _:
         add_poi_button = server.gui.add_button("Add POI Point")
@@ -330,9 +433,18 @@ def main(
 
         @add_save_poi_button.on_click
         def _(_) -> None:
+            # Build export copy with offset applied if enabled
+            export_points = {}
+            for k, v in poi_points.items():
+                export_points[k] = {
+                    'id': v.get('id', k),
+                    'name': v.get('name', f'POI_{k}'),
+                    'position': _get_export_position(np.asarray(v['position'], dtype=float)).tolist(),
+                }
             with open(f"{tinynav_map_path}/pois.json", "w") as f:
-                json.dump(poi_points, f, indent=2, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
-
+                json.dump(export_points, f, indent=2)
+            print(f"Saved {len(export_points)} POIs to {tinynav_map_path}/pois.json"
+                  f" (offset={'on' if apply_offset_checkbox.value else 'off'}, robot={robot_config.name})")
 
         poi_list_container = server.gui.add_folder("POI List")
         for poi_id, poi_point in poi_points.items():
@@ -343,11 +455,10 @@ def main(
                 position=poi_point['position']
             )
             create_poi_ui(server, poi_list_container,int(poi_id), poi_points, sphere_handle)
+            _update_footprint_viz(poi_id)
 
         @add_poi_button.on_click
         def _(_) -> None:
-            # Get camera position as POI location
-            #camera_position = server.camera.position
             nonlocal poi_id_counter
             poi_id = poi_id_counter
             poi_id_counter += 1
@@ -358,7 +469,6 @@ def main(
                 poi_position = previous_position + np.array([0.3, 0.0, 0.0])
             else:
                 poi_position = np.random.randn(3)
-            # Add POI to list
             poi_points[poi_id] = {
                 'id': poi_id,
                 'name': poi_name,
@@ -371,6 +481,7 @@ def main(
                 position=poi_points[poi_id]['position']
             )
             create_poi_ui(server, poi_list_container,poi_id, poi_points, sphere_handle)
+            _update_footprint_viz(poi_id)
     
     # Load and visualize occupancy grid as 2D XY projection (same as build_map_node).
     occupancy_grid_path = tinynav_map_path / "occupancy_grid.npy"
@@ -565,7 +676,7 @@ def main(
         if not occupancy_meta_path.exists():
             print(f"  Missing: {occupancy_meta_path}")
     
-    poses = np.load(tinynav_map_path / "poses.npy", allow_pickle=True).item()
+    poses = all_poses  # reuse already-loaded poses
     if (tinynav_map_path / "intrinsics.npy").exists():
         camera_K = np.load(tinynav_map_path / "intrinsics.npy", allow_pickle=True)
     elif (tinynav_map_path / "rgb_camera_intrinsics.npy").exists():


### PR DESCRIPTION
## Summary

### 1. Extract RobotConfig to shared module

- Removed duplicate `RobotConfig` class definition (including `GO2_CONFIG` / `B2_CONFIG`) from `planning_node.py`
- Now imports from the existing `tinynav/core/robot_config.py` as the single source of truth

### 2. poi_editor: cam-to-body extrinsics support

**New GUI controls:**
- Robot Type dropdown (go2 / b2) — persisted to `robot_config.json` in the map directory
- "Apply cam-to-body offset on save" checkbox (default: on)
- "Show robot footprint at POIs" checkbox (default: on)

**Export logic:**
- When saving POIs with offset enabled, each POI finds the nearest camera pose to get a rotation matrix, then applies `camera_to_body_position()` to convert from camera-frame world coordinates to robot body-center world coordinates
- With offset disabled, behavior is unchanged (saves raw coordinates)

**Visualization:**
- Draws a green rectangle (robot footprint) at each POI position so users can see where the robot body would be

### 3. robot_config.py: new utility functions

- `camera_to_body_position(cam_pos, cam_R, robot_config)` — camera world position → body-center world position
- `body_to_camera_position(body_pos, cam_R, robot_config)` — inverse transform

## Files changed
- `tinynav/core/robot_config.py` — added transform helper functions
- `tinynav/core/planning_node.py` — removed duplicate RobotConfig, import from robot_config
- `tool/poi_editor.py` — added robot config GUI, offset-aware export, footprint visualization

## Notes
- Nearest camera pose rotation is used to approximate the POI orientation. If a POI is far from all camera poses, this may be less accurate
- Footprint visualization uses viser line_segments; may impact performance with very large numbers of POIs