### PR TITLE
fix: remove auto standup on boot

### DIFF
--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -27,10 +27,7 @@ class Ros2UnitreeManagerNode(Node):
         self.sport_client.SetTimeout(10.0)
         self.sport_client.Init()
         self.sport_client.SwitchGait(1)
-        # 启动时执行一次站立
-        self.sport_client.StandUp()
-        self.sport_client.BalanceStand()
-        self._robot_status = RobotStatus.STANDUP
+        self._robot_status = RobotStatus.SITTING
         self.battery = 0.0
         self.last_twist_time = None
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
Remove the automatic `StandUp()` and `BalanceStand()` calls from `Ros2UnitreeManagerNode.__init__`. The robot will no longer stand up automatically on startup. The initial robot status remains `STANDUP` and all other behavior is unchanged.