### PR TITLE
feat(nav): decouple navigation from keyframe to 2Hz timer with latest odom

### DIFF
--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -73,80 +73,6 @@ def transform_point_cloud(point_cloud: np.ndarray, T: np.ndarray) -> np.ndarray:
     transformed_points = homogeneous_points @ T.T
     return transformed_points[:, :3]
 
-def _line_of_sight(p0: np.ndarray, p1: np.ndarray, occupancy_map: np.ndarray) -> bool:
-    """Bresenham 3-D line check: True if no occupied cell between p0 and p1 (voxel coords)."""
-    x0, y0, z0 = int(p0[0]), int(p0[1]), int(p0[2])
-    x1, y1, z1 = int(p1[0]), int(p1[1]), int(p1[2])
-    dx, dy, dz = abs(x1 - x0), abs(y1 - y0), abs(z1 - z0)
-    sx = 1 if x1 > x0 else -1
-    sy = 1 if y1 > y0 else -1
-    sz = 1 if z1 > z0 else -1
-    if dx >= dy and dx >= dz:
-        ey, ez = 2 * dy - dx, 2 * dz - dx
-        for _ in range(dx + 1):
-            if occupancy_map[x0, y0, z0] == 2:
-                return False
-            if ey >= 0:
-                y0 += sy; ey -= 2 * dx
-            if ez >= 0:
-                z0 += sz; ez -= 2 * dx
-            x0 += sx; ey += 2 * dy; ez += 2 * dz
-    elif dy >= dx and dy >= dz:
-        ex, ez = 2 * dx - dy, 2 * dz - dy
-        for _ in range(dy + 1):
-            if occupancy_map[x0, y0, z0] == 2:
-                return False
-            if ex >= 0:
-                x0 += sx; ex -= 2 * dy
-            if ez >= 0:
-                z0 += sz; ez -= 2 * dy
-            y0 += sy; ex += 2 * dx; ez += 2 * dz
-    else:
-        ex, ey = 2 * dx - dz, 2 * dy - dz
-        for _ in range(dz + 1):
-            if occupancy_map[x0, y0, z0] == 2:
-                return False
-            if ex >= 0:
-                x0 += sx; ex -= 2 * dz
-            if ey >= 0:
-                y0 += sy; ey -= 2 * dz
-            z0 += sz; ex += 2 * dx; ey += 2 * dy
-    return True
-
-
-def _shortcut_path(path_world: np.ndarray, occupancy_map: np.ndarray,
-                   occupancy_origin: np.ndarray, resolution: float) -> np.ndarray:
-    """Greedy shortcutting: skip waypoints when line-of-sight is clear."""
-    if len(path_world) <= 2:
-        return path_world
-    voxels = np.round((path_world - occupancy_origin) / resolution).astype(np.int32)
-    result = [0]
-    i = 0
-    while i < len(voxels) - 1:
-        j = len(voxels) - 1
-        while j > i + 1:
-            if _line_of_sight(voxels[i], voxels[j], occupancy_map):
-                break
-            j -= 1
-        result.append(j)
-        i = j
-    return path_world[result]
-
-
-def _chaikin_smooth(path: np.ndarray, iterations: int = 2) -> np.ndarray:
-    """Chaikin corner-cutting: iteratively insert 1/4 and 3/4 points."""
-    for _ in range(iterations):
-        if len(path) <= 2:
-            break
-        new_path = [path[0]]
-        for i in range(len(path) - 1):
-            new_path.append(0.75 * path[i] + 0.25 * path[i + 1])
-            new_path.append(0.25 * path[i] + 0.75 * path[i + 1])
-        new_path.append(path[-1])
-        path = np.array(new_path)
-    return path
-
-
 def heuristic(start, goal, resolution):
     vec_start = np.array(start)
     vec_goal = np.array(goal)
@@ -719,7 +645,7 @@ class MapNode(Node):
         if not needs_replan:
             paths = self.cached_nav_path_in_map
             closest_idx = int(np.argmin(np.linalg.norm(paths[:, :2] - pos[:2], axis=1)))
-            if np.linalg.norm(paths[closest_idx, :2] - pos[:2]) > 1.0:
+            if np.linalg.norm(paths[closest_idx, :2] - pos[:2]) > 0.5:
                 needs_replan = True
 
         if needs_replan:
@@ -826,8 +752,6 @@ class MapNode(Node):
         path = sdf_start_path + path_sdf + sdf_goal_path[::-1]
         if len(path) > 0:
             converted_path = np.array(path) * resolution + occupancy_map_origin
-            converted_path = _shortcut_path(converted_path, self.occupancy_map, occupancy_map_origin, resolution)
-            converted_path = _chaikin_smooth(converted_path)
             return converted_path
         return None
 

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -341,7 +341,6 @@ class MapNode(Node):
         self.keyframe_mapping(keyframe_image_msg, keyframe_odom_msg, depth_msg)
         image = self.bridge.imgmsg_to_cv2(keyframe_image_msg, desired_encoding="mono8")
 
-        keyframe_image_timestamp_ns = int(keyframe_image_msg.header.stamp.sec * 1e9) + int(keyframe_image_msg.header.stamp.nanosec)
         success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
             self.compute_transform_from_map_to_odom()

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -73,6 +73,80 @@ def transform_point_cloud(point_cloud: np.ndarray, T: np.ndarray) -> np.ndarray:
     transformed_points = homogeneous_points @ T.T
     return transformed_points[:, :3]
 
+def _line_of_sight(p0: np.ndarray, p1: np.ndarray, occupancy_map: np.ndarray) -> bool:
+    """Bresenham 3-D line check: True if no occupied cell between p0 and p1 (voxel coords)."""
+    x0, y0, z0 = int(p0[0]), int(p0[1]), int(p0[2])
+    x1, y1, z1 = int(p1[0]), int(p1[1]), int(p1[2])
+    dx, dy, dz = abs(x1 - x0), abs(y1 - y0), abs(z1 - z0)
+    sx = 1 if x1 > x0 else -1
+    sy = 1 if y1 > y0 else -1
+    sz = 1 if z1 > z0 else -1
+    if dx >= dy and dx >= dz:
+        ey, ez = 2 * dy - dx, 2 * dz - dx
+        for _ in range(dx + 1):
+            if occupancy_map[x0, y0, z0] == 2:
+                return False
+            if ey >= 0:
+                y0 += sy; ey -= 2 * dx
+            if ez >= 0:
+                z0 += sz; ez -= 2 * dx
+            x0 += sx; ey += 2 * dy; ez += 2 * dz
+    elif dy >= dx and dy >= dz:
+        ex, ez = 2 * dx - dy, 2 * dz - dy
+        for _ in range(dy + 1):
+            if occupancy_map[x0, y0, z0] == 2:
+                return False
+            if ex >= 0:
+                x0 += sx; ex -= 2 * dy
+            if ez >= 0:
+                z0 += sz; ez -= 2 * dy
+            y0 += sy; ex += 2 * dx; ez += 2 * dz
+    else:
+        ex, ey = 2 * dx - dz, 2 * dy - dz
+        for _ in range(dz + 1):
+            if occupancy_map[x0, y0, z0] == 2:
+                return False
+            if ex >= 0:
+                x0 += sx; ex -= 2 * dz
+            if ey >= 0:
+                y0 += sy; ey -= 2 * dz
+            z0 += sz; ex += 2 * dx; ey += 2 * dy
+    return True
+
+
+def _shortcut_path(path_world: np.ndarray, occupancy_map: np.ndarray,
+                   occupancy_origin: np.ndarray, resolution: float) -> np.ndarray:
+    """Greedy shortcutting: skip waypoints when line-of-sight is clear."""
+    if len(path_world) <= 2:
+        return path_world
+    voxels = np.round((path_world - occupancy_origin) / resolution).astype(np.int32)
+    result = [0]
+    i = 0
+    while i < len(voxels) - 1:
+        j = len(voxels) - 1
+        while j > i + 1:
+            if _line_of_sight(voxels[i], voxels[j], occupancy_map):
+                break
+            j -= 1
+        result.append(j)
+        i = j
+    return path_world[result]
+
+
+def _chaikin_smooth(path: np.ndarray, iterations: int = 2) -> np.ndarray:
+    """Chaikin corner-cutting: iteratively insert 1/4 and 3/4 points."""
+    for _ in range(iterations):
+        if len(path) <= 2:
+            break
+        new_path = [path[0]]
+        for i in range(len(path) - 1):
+            new_path.append(0.75 * path[i] + 0.25 * path[i + 1])
+            new_path.append(0.25 * path[i] + 0.75 * path[i + 1])
+        new_path.append(path[-1])
+        path = np.array(new_path)
+    return path
+
+
 def heuristic(start, goal, resolution):
     vec_start = np.array(start)
     vec_goal = np.array(goal)
@@ -752,6 +826,8 @@ class MapNode(Node):
         path = sdf_start_path + path_sdf + sdf_goal_path[::-1]
         if len(path) > 0:
             converted_path = np.array(path) * resolution + occupancy_map_origin
+            converted_path = _shortcut_path(converted_path, self.occupancy_map, occupancy_map_origin, resolution)
+            converted_path = _chaikin_smooth(converted_path)
             return converted_path
         return None
 

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -218,6 +218,7 @@ class MapNode(Node):
         self.continuous_odom_recorder = OdomPoseRecorder(tinynav_db_path, "localization")
 
         self.odom = {}
+        self.latest_odom_pose = None
         self.pose_graph_used_pose = {}
         self.relative_pose_constraint = []
         self.last_keyframe_timestamp = None
@@ -254,6 +255,8 @@ class MapNode(Node):
         self._leg_initial_length: float | None = None
         self._leg_start_time: float | None = None
         self._speed_estimate: float | None = None
+        self.cached_nav_path_in_map = None
+        self.cached_nav_path_poi_index = -1
 
         self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
         self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
@@ -267,6 +270,7 @@ class MapNode(Node):
         self.tf_broadcaster = TransformBroadcaster(self)
 
         self._save_completed = False
+        self.nav_target_timer = self.create_timer(0.5, self.nav_target_timer_callback)
 
     def pois_callback(self, msg: String):
         self.get_logger().info("Received POIs from planner: " + msg.data)
@@ -281,6 +285,7 @@ class MapNode(Node):
 
             if not self.pois:
                 self.poi_index = -1
+                self.cached_nav_path_in_map = None
                 # Signal planning_node to clear target_pose so it stops publishing paths
                 dummy_pose = np.eye(4)
                 self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
@@ -292,6 +297,8 @@ class MapNode(Node):
             self._leg_initial_length = None
             self._leg_start_time = None
             self._speed_estimate = None
+            self.cached_nav_path_in_map = None
+            self.cached_nav_path_poi_index = -1
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
@@ -308,6 +315,7 @@ class MapNode(Node):
 
     def continuous_odom_callback(self, odom_msg: Odometry):
         self.continuous_odom_recorder.record_odometry_msg(odom_msg)
+        self.latest_odom_pose, _ = msg2np(odom_msg)
 
     def localization_stop_callback(self, msg: Bool):
         if msg.data:
@@ -599,123 +607,135 @@ class MapNode(Node):
         poi_pose[:3, 3] = poi
         self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
         # get the pose from the map to the odom
-        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self.pose_graph_used_pose[timestamp]
+        odom_pose = self.latest_odom_pose if self.latest_odom_pose is not None else self.pose_graph_used_pose[timestamp]
+        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ odom_pose
         self.current_pose_in_map_pub.publish(np2msg(pose_in_map, self.get_clock().now().to_msg(), "world", "map"))
-
-        pose_in_map_position = pose_in_map[:3, 3]
-
-        while self.poi_index < len(self.pois):
-            poi = self.pois[self.poi_index]
-            diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
-            diff_position_norm_z = np.linalg.norm(poi[2] - pose_in_map_position[2])
-            if diff_position_norm_xy < 0.5 and diff_position_norm_z < 2.0:
-                if self._leg_initial_length is not None:
-                    arrived_msg = String()
-                    arrived_msg.data = json.dumps({
-                        "poi_index": self.poi_index,
-                        "percent": 100.0,
-                        "path_remaining_m": 0.0,
-                        "path_total_m": round(self._leg_initial_length, 2),
-                        "estimated_remaining_s": 0.0,
-                    })
-                    self.nav_progress_pub.publish(arrived_msg)
-                self.poi_index += 1
-                self._leg_initial_length = None
-                self._leg_start_time = None
-                dummy_pose = np.eye(4)
-
-                stamp_msg = self.get_clock().now().to_msg()
-                stamp_msg.sec = int(timestamp / 1e9)
-                stamp_msg.nanosec = int(timestamp % 1e9)
-                self.poi_change_pub.publish(np2msg(dummy_pose, stamp_msg, "world", "map"))
-                continue
-            else:
-                break
-
-        if self.poi_index >= len(self.pois):
-            if not self._nav_completed:
-                self._nav_completed = True
-                self.get_logger().info("All POIs have been visited, nav done")
-                self.nav_done_pub.publish(Bool(data=True))
-            return
 
         target_poi = self.pois[self.poi_index]
         with Timer(name = "generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
             paths_in_map = self.generate_nav_path_in_map(pose_in_map = pose_in_map, target_poi = target_poi)
 
         if paths_in_map is not None:
-            remaining_length = sum(
-                np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
-                for i in range(len(paths_in_map) - 1)
-            ) if len(paths_in_map) > 1 else 0.0
+            self.cached_nav_path_in_map = paths_in_map
+            self.cached_nav_path_poi_index = self.poi_index
 
-            now = time.time()
-            if self._leg_initial_length is None:
-                self._leg_initial_length = remaining_length
-                self._leg_start_time = now
-
-            covered = self._leg_initial_length - remaining_length
-            elapsed = now - self._leg_start_time
-            if covered > 0.1 and elapsed > 1.0:
-                self._speed_estimate = covered / elapsed
-
-            initial = self._leg_initial_length
-            percent = max(0.0, min(100.0, covered / initial * 100.0)) if initial > 0 else 0.0
-            estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
-
-            progress_msg = String()
-            progress_msg.data = json.dumps({
-                "poi_index": self.poi_index,
-                "percent": round(percent, 1),
-                "path_remaining_m": round(remaining_length, 2),
-                "path_total_m": round(initial, 2),
-                "estimated_remaining_s": round(estimated_remaining_s, 1),
-            })
-            self.nav_progress_pub.publish(progress_msg)
-
-            # use the max_speed to publish the position the robot should be after 5 seconds
-            with Timer(name = "Find target position", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-                max_speed = 0.5
-                if len(paths_in_map) > 1:
-                    accumulated_distance = 0.0
-                    start_point = pose_in_map_position[:3]
-                    target_position = paths_in_map[-1]
-                    for i in range(len(paths_in_map) - 1):
-                        accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
-                        if accumulated_distance > max_speed * 5:
-                            target_position = paths_in_map[i]
-                            break
-                        start_point = paths_in_map[i]
-                else:
-                    target_position = paths_in_map[0]
-                target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
-                pose_in_origin_odom = self.odom[timestamp]
-                T = pose_in_origin_odom @ np.linalg.inv(pose_in_map)
-                target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
-                dummy_pose = np.eye(4)
-                dummy_pose[:3, 3] = target_position_in_odom
-                #logging.info(f"target_position_in_odom: {target_position_in_odom}")
-                print(f"target_position_in_odom: {target_position_in_odom}")
-
-                self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
-                path_msg = Path()
-                path_msg.header.stamp = self.get_clock().now().to_msg()
-                path_msg.header.frame_id = "map"
-                for x, y, z in paths_in_map:
-                    pose = PoseStamped()
-                    pose.header = path_msg.header
-                    pose.pose.position.x = x
-                    pose.pose.position.y = y
-                    pose.pose.position.z = z
-                    pose.pose.orientation.x = 0.0
-                    pose.pose.orientation.y = 0.0
-                    pose.pose.orientation.z = 0.0
-                    pose.pose.orientation.w = 1.0
-                    path_msg.poses.append(pose)
-                self.global_plan_pub.publish(path_msg)
-                self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
+            path_msg = Path()
+            path_msg.header.stamp = self.get_clock().now().to_msg()
+            path_msg.header.frame_id = "map"
+            for x, y, z in paths_in_map:
+                pose = PoseStamped()
+                pose.header = path_msg.header
+                pose.pose.position.x = x
+                pose.pose.position.y = y
+                pose.pose.position.z = z
+                pose.pose.orientation.x = 0.0
+                pose.pose.orientation.y = 0.0
+                pose.pose.orientation.z = 0.0
+                pose.pose.orientation.w = 1.0
+                path_msg.poses.append(pose)
+            self.global_plan_pub.publish(path_msg)
         else:
+            self.cached_nav_path_in_map = None
+            self.cached_nav_path_poi_index = -1
             logging.info("No path found in map")
+
+    def nav_target_timer_callback(self):
+        if (
+            self.poi_index < 0
+            or self.poi_index >= len(self.pois)
+            or self.T_from_map_to_odom is None
+            or self.latest_odom_pose is None
+        ):
+            return
+
+        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self.latest_odom_pose
+        self.current_pose_in_map_pub.publish(np2msg(pose_in_map, self.get_clock().now().to_msg(), "world", "map"))
+
+        poi = self.pois[self.poi_index]
+        pose_in_map_position = pose_in_map[:3, 3]
+        diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
+        diff_position_norm_z = np.linalg.norm(poi[2] - pose_in_map_position[2])
+        if diff_position_norm_xy < 0.5 and diff_position_norm_z < 2.0:
+            if self._leg_initial_length is not None:
+                arrived_msg = String()
+                arrived_msg.data = json.dumps({
+                    "poi_index": self.poi_index,
+                    "percent": 100.0,
+                    "path_remaining_m": 0.0,
+                    "path_total_m": round(self._leg_initial_length, 2),
+                    "estimated_remaining_s": 0.0,
+                })
+                self.nav_progress_pub.publish(arrived_msg)
+            self.poi_index += 1
+            self._leg_initial_length = None
+            self._leg_start_time = None
+            self._speed_estimate = None
+            self.cached_nav_path_in_map = None
+            self.cached_nav_path_poi_index = -1
+
+            dummy_pose = np.eye(4)
+            self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
+            if self.poi_index >= len(self.pois) and not self._nav_completed:
+                self._nav_completed = True
+                self.get_logger().info("All POIs have been visited, nav done")
+                self.nav_done_pub.publish(Bool(data=True))
+            return
+
+        if self.cached_nav_path_in_map is None or self.cached_nav_path_poi_index != self.poi_index:
+            return
+
+        paths_in_map = self.cached_nav_path_in_map
+        closest_idx = int(np.argmin(np.linalg.norm(paths_in_map[:, :2] - pose_in_map_position[:2], axis=1)))
+
+        remaining_length = sum(
+            np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
+            for i in range(closest_idx, len(paths_in_map) - 1)
+        ) if closest_idx < len(paths_in_map) - 1 else 0.0
+
+        now = time.time()
+        if self._leg_initial_length is None:
+            self._leg_initial_length = remaining_length
+            self._leg_start_time = now
+
+        covered = self._leg_initial_length - remaining_length
+        elapsed = now - self._leg_start_time
+        if covered > 0.1 and elapsed > 1.0:
+            self._speed_estimate = covered / elapsed
+
+        initial = self._leg_initial_length
+        percent = max(0.0, min(100.0, covered / initial * 100.0)) if initial > 0 else 0.0
+        estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
+
+        progress_msg = String()
+        progress_msg.data = json.dumps({
+            "poi_index": self.poi_index,
+            "percent": round(percent, 1),
+            "path_remaining_m": round(remaining_length, 2),
+            "path_total_m": round(initial, 2),
+            "estimated_remaining_s": round(estimated_remaining_s, 1),
+        })
+        self.nav_progress_pub.publish(progress_msg)
+
+        max_speed = 0.5
+        accumulated_distance = 0.0
+        start_point = pose_in_map_position[:3]
+        target_position = paths_in_map[-1]
+        for i in range(closest_idx, len(paths_in_map) - 1):
+            accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
+            if accumulated_distance > max_speed * 5:
+                target_position = paths_in_map[i]
+                break
+            start_point = paths_in_map[i]
+
+        target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
+        T = self.latest_odom_pose @ np.linalg.inv(pose_in_map)
+        target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
+        dummy_pose = np.eye(4)
+        dummy_pose[:3, 3] = target_position_in_odom
+        self.get_logger().debug(f"target_position_in_odom: {target_position_in_odom}")
+
+        self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
+        self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
 
     def generate_nav_path_in_map(self, pose_in_map: np.ndarray, target_poi: np.ndarray) -> np.ndarray:
         dummy_poi_pose = np.eye(4)

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -346,12 +346,6 @@ class MapNode(Node):
         if success:
             self.compute_transform_from_map_to_odom()
 
-        with Timer(name = "nav path", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            self.try_publish_nav_path(keyframe_image_timestamp_ns)
-            # timer or queue for publish the nav path
-            # and record the map pose
-            # compute the coordinate transform from the map pose to the keyframe pose
-            # publish the nav path from the map pose to the keyframe pose with the cost map
 
     def keyframe_mapping_with_timer(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image):
         with Timer(name="Mapping Loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
@@ -587,57 +581,19 @@ class MapNode(Node):
         optimized_parameters = pose_graph_solve(optimized_parameters, relative_pose_constraint, constant_pose_index_dict, max_iteration_num = 1000)
         self.T_from_map_to_odom = optimized_parameters[0]
 
-    def try_publish_nav_path(self, timestamp: int):
-        self.get_logger().info(f"try_publish_nav_path, timestamp: {timestamp}")
-        if self.T_from_map_to_odom is None:
-            self.get_logger().info("Relocalization not successful yet, skip publishing nav path")
-            return
-
-        if self.poi_index == -1:
-            self.get_logger().info("No POI found, skip publishing nav path")
-            return
-
-        if self.poi_index >= len(self.pois):
-            self.get_logger().info("All POIs have been visited, skip publishing nav path")
-            return
-
-        poi = self.pois[self.poi_index]
-        print(f"poi: {poi}")
-        poi_pose = np.eye(4)
-        poi_pose[:3, 3] = poi
-        self.poi_pub.publish(np2msg(poi_pose, self.get_clock().now().to_msg(), "world", "map"))
-        # get the pose from the map to the odom
-        odom_pose = self.latest_odom_pose if self.latest_odom_pose is not None else self.pose_graph_used_pose[timestamp]
-        pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ odom_pose
-        self.current_pose_in_map_pub.publish(np2msg(pose_in_map, self.get_clock().now().to_msg(), "world", "map"))
-
-        target_poi = self.pois[self.poi_index]
-        with Timer(name = "generate nav path in map", text="[{name}] Elapsed time: {milliseconds:.0f} ms", logger=self.timer_logger):
-            paths_in_map = self.generate_nav_path_in_map(pose_in_map = pose_in_map, target_poi = target_poi)
-
-        if paths_in_map is not None:
-            self.cached_nav_path_in_map = paths_in_map
-            self.cached_nav_path_poi_index = self.poi_index
-
-            path_msg = Path()
-            path_msg.header.stamp = self.get_clock().now().to_msg()
-            path_msg.header.frame_id = "map"
-            for x, y, z in paths_in_map:
-                pose = PoseStamped()
-                pose.header = path_msg.header
-                pose.pose.position.x = x
-                pose.pose.position.y = y
-                pose.pose.position.z = z
-                pose.pose.orientation.x = 0.0
-                pose.pose.orientation.y = 0.0
-                pose.pose.orientation.z = 0.0
-                pose.pose.orientation.w = 1.0
-                path_msg.poses.append(pose)
-            self.global_plan_pub.publish(path_msg)
-        else:
-            self.cached_nav_path_in_map = None
-            self.cached_nav_path_poi_index = -1
-            logging.info("No path found in map")
+    def _publish_global_plan(self, paths_in_map: np.ndarray):
+        path_msg = Path()
+        path_msg.header.stamp = self.get_clock().now().to_msg()
+        path_msg.header.frame_id = "map"
+        for x, y, z in paths_in_map:
+            pose = PoseStamped()
+            pose.header = path_msg.header
+            pose.pose.position.x = x
+            pose.pose.position.y = y
+            pose.pose.position.z = z
+            pose.pose.orientation.w = 1.0
+            path_msg.poses.append(pose)
+        self.global_plan_pub.publish(path_msg)
 
     def nav_target_timer_callback(self):
         if (
@@ -646,51 +602,70 @@ class MapNode(Node):
             or self.T_from_map_to_odom is None
             or self.latest_odom_pose is None
         ):
+            self.get_logger().info(
+                f"[nav_timer] skip: poi_index={self.poi_index}, "
+                f"n_pois={len(self.pois)}, "
+                f"T={'set' if self.T_from_map_to_odom is not None else 'None'}, "
+                f"odom={'set' if self.latest_odom_pose is not None else 'None'}"
+            )
             return
 
         pose_in_map = np.linalg.inv(self.T_from_map_to_odom) @ self.latest_odom_pose
         self.current_pose_in_map_pub.publish(np2msg(pose_in_map, self.get_clock().now().to_msg(), "world", "map"))
 
         poi = self.pois[self.poi_index]
-        pose_in_map_position = pose_in_map[:3, 3]
-        diff_position_norm_xy = np.linalg.norm(poi[:2] - pose_in_map_position[:2])
-        diff_position_norm_z = np.linalg.norm(poi[2] - pose_in_map_position[2])
-        if diff_position_norm_xy < 0.5 and diff_position_norm_z < 2.0:
+        pos = pose_in_map[:3, 3]
+
+        if np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0:
             if self._leg_initial_length is not None:
-                arrived_msg = String()
-                arrived_msg.data = json.dumps({
+                self.nav_progress_pub.publish(String(data=json.dumps({
                     "poi_index": self.poi_index,
                     "percent": 100.0,
                     "path_remaining_m": 0.0,
                     "path_total_m": round(self._leg_initial_length, 2),
                     "estimated_remaining_s": 0.0,
-                })
-                self.nav_progress_pub.publish(arrived_msg)
+                })))
             self.poi_index += 1
             self._leg_initial_length = None
             self._leg_start_time = None
             self._speed_estimate = None
             self.cached_nav_path_in_map = None
             self.cached_nav_path_poi_index = -1
-
-            dummy_pose = np.eye(4)
-            self.poi_change_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "map"))
+            self.poi_change_pub.publish(np2msg(np.eye(4), self.get_clock().now().to_msg(), "world", "map"))
             if self.poi_index >= len(self.pois) and not self._nav_completed:
                 self._nav_completed = True
                 self.get_logger().info("All POIs have been visited, nav done")
                 self.nav_done_pub.publish(Bool(data=True))
             return
 
-        if self.cached_nav_path_in_map is None or self.cached_nav_path_poi_index != self.poi_index:
-            return
+        needs_replan = (
+            self.cached_nav_path_in_map is None
+            or self.cached_nav_path_poi_index != self.poi_index
+        )
+        if not needs_replan:
+            paths = self.cached_nav_path_in_map
+            closest_idx = int(np.argmin(np.linalg.norm(paths[:, :2] - pos[:2], axis=1)))
+            if np.linalg.norm(paths[closest_idx, :2] - pos[:2]) > 1.0:
+                needs_replan = True
 
-        paths_in_map = self.cached_nav_path_in_map
-        closest_idx = int(np.argmin(np.linalg.norm(paths_in_map[:, :2] - pose_in_map_position[:2], axis=1)))
+        if needs_replan:
+            paths = self.generate_nav_path_in_map(pose_in_map=pose_in_map, target_poi=poi)
+            if paths is not None:
+                self.cached_nav_path_in_map = paths
+                self.cached_nav_path_poi_index = self.poi_index
+            else:
+                self.cached_nav_path_in_map = None
+                self.cached_nav_path_poi_index = -1
+                return
+
+        paths = self.cached_nav_path_in_map
+        self._publish_global_plan(paths)
+        closest_idx = int(np.argmin(np.linalg.norm(paths[:, :2] - pos[:2], axis=1)))
 
         remaining_length = sum(
-            np.linalg.norm(paths_in_map[i + 1] - paths_in_map[i])
-            for i in range(closest_idx, len(paths_in_map) - 1)
-        ) if closest_idx < len(paths_in_map) - 1 else 0.0
+            np.linalg.norm(paths[i + 1] - paths[i])
+            for i in range(closest_idx, len(paths) - 1)
+        ) if closest_idx < len(paths) - 1 else 0.0
 
         now = time.time()
         if self._leg_initial_length is None:
@@ -706,34 +681,29 @@ class MapNode(Node):
         percent = max(0.0, min(100.0, covered / initial * 100.0)) if initial > 0 else 0.0
         estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
 
-        progress_msg = String()
-        progress_msg.data = json.dumps({
+        self.nav_progress_pub.publish(String(data=json.dumps({
             "poi_index": self.poi_index,
             "percent": round(percent, 1),
             "path_remaining_m": round(remaining_length, 2),
             "path_total_m": round(initial, 2),
             "estimated_remaining_s": round(estimated_remaining_s, 1),
-        })
-        self.nav_progress_pub.publish(progress_msg)
+        })))
 
         max_speed = 0.5
         accumulated_distance = 0.0
-        start_point = pose_in_map_position[:3]
-        target_position = paths_in_map[-1]
-        for i in range(closest_idx, len(paths_in_map) - 1):
-            accumulated_distance += np.linalg.norm(paths_in_map[i][:2] - start_point[:2])
+        start_point = pos[:3]
+        target_position = paths[-1]
+        for i in range(closest_idx, len(paths) - 1):
+            accumulated_distance += np.linalg.norm(paths[i][:2] - start_point[:2])
             if accumulated_distance > max_speed * 5:
-                target_position = paths_in_map[i]
+                target_position = paths[i]
                 break
-            start_point = paths_in_map[i]
+            start_point = paths[i]
 
-        target_position_in_map = np.array([target_position[0], target_position[1], target_position[2]])
         T = self.latest_odom_pose @ np.linalg.inv(pose_in_map)
-        target_position_in_odom = T[:3, :3] @ target_position_in_map + T[:3, 3]
+        target_position_in_odom = T[:3, :3] @ target_position + T[:3, 3]
         dummy_pose = np.eye(4)
         dummy_pose[:3, 3] = target_position_in_odom
-        self.get_logger().debug(f"target_position_in_odom: {target_position_in_odom}")
-
         self.target_pose_pub.publish(np2msg(dummy_pose, self.get_clock().now().to_msg(), "world", "camera"))
         self.tf_broadcaster.sendTransform(np2tf(T, self.get_clock().now().to_msg(), "world", "map"))
 


### PR DESCRIPTION
### Summary

Decouples global plan, target pose, and POI arrival from keyframe callback. Navigation now runs on a 2Hz timer using latest continuous odom instead of optimized keyframe pose.

### Changes

1. **Decouple global plan, target pose, and POI arrival from keyframe callback** — moved to a 2Hz `nav_target_timer_callback`
2. **Use latest odom instead of keyframe timestamp pose** — `pose_in_map` derived from `latest_odom_pose` for POI arrival check and target pose computation
3. **Target pose and POI arrival run at 2Hz** — no longer gated by keyframe frequency (~7-10Hz with jitter)
4. **Global plan replanning conditions** — replan only when: no cached path, POI index changed, or robot deviates from cached path by >0.5m; otherwise reuse cache

### Unchanged

- SDF search logic, map/planning resolution, lookahead constants

### Test plan

- `python3 -m py_compile tinynav/core/map_node.py`
- `git diff --check`