### PR TITLE
fix(cmd_vel): add hysteresis to deadzone snap and trajectory gates

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -384,6 +384,7 @@ class PlanningNode(Node):
         self.obstacle_config = ObstacleConfig()
         self.stamp = None
         self.current_pose = None  # Store the latest pose from odometry
+        self._reverse_mode = False  # Hysteresis state for the forward/reverse gate
 
         self.smoothed_velocity = 0.0
 
@@ -607,12 +608,21 @@ class PlanningNode(Node):
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
+            # Hysteresis: enter reverse mode at enter_threshold, but require more
+            # clearance (exit_threshold) before returning to forward-only trajectories.
+            # A single threshold caused the gate to flip every cycle when front_clearance
+            # hovered right at the boundary.
             enter_threshold = 0.30
+            exit_threshold = 0.40
+            if front_clearance <= enter_threshold:
+                self._reverse_mode = True
+            elif front_clearance > exit_threshold:
+                self._reverse_mode = False
+            should_reverse = self._reverse_mode
 
             def cost_function(traj, param, score, target_pose):
                 # predefined backward trajectory penalty
                 is_backward_traj = param[0] < 0.0
-                should_reverse = front_clearance <= enter_threshold
                 reverse_gate_penalty = 0.0
                 if should_reverse and not is_backward_traj:
                         reverse_gate_penalty = 1e9

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -60,11 +60,18 @@ class CmdVelControlNode(Node):
         # Hack: if path first segment points far away from robot heading,
         # rotate in place instead of publishing near-zero cmd_vel.
         self.force_turn_heading_threshold = np.deg2rad(80.0)
+        # Minimal rotate-first gate, with hysteresis: engage at rotate_first_enter_threshold,
+        # stay engaged until heading_err drops below the smaller rotate_first_exit_threshold.
+        # A single threshold flip-flopped between "drive+turn" and "rotate only" when the
+        # planner's selected heading jittered near the boundary.
+        self.rotate_first_enter_threshold = 0.45  # rad, ~26 deg
+        self.rotate_first_exit_threshold = np.deg2rad(15.0)
 
         self.latest_cmd = Twist()
         self.prev_cmd = Twist()
         self._linear_engaged = False
         self._angular_engaged = False
+        self._rotate_first_engaged = False
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
         self._paused = False
@@ -81,6 +88,7 @@ class CmdVelControlNode(Node):
             self.prev_cmd = Twist()
             self._linear_engaged = False
             self._angular_engaged = False
+            self._rotate_first_engaged = False
 
     def _on_nav_active(self, msg: Bool):
         was_active = self._nav_active
@@ -90,6 +98,7 @@ class CmdVelControlNode(Node):
             self.prev_cmd = Twist()
             self._linear_engaged = False
             self._angular_engaged = False
+            self._rotate_first_engaged = False
             self.last_path_update_time = None
             # Send one stop when navigation is deactivated, then stay silent so
             # manual teleop can own /cmd_vel without being overwritten by zeros.
@@ -245,10 +254,16 @@ class CmdVelControlNode(Node):
         if (not is_backward_segment) and abs(heading_err) > self.force_turn_heading_threshold:
             vx = 0.0
             vyaw = float(np.clip(heading_err, -self.max_angular_speed, self.max_angular_speed))
-        # Minimal rotate-first gate: apply only for forward motion.
-        elif vx > 0.0 and abs(heading_err) > 0.45:
+            self._rotate_first_engaged = True
+        # Minimal rotate-first gate: apply only for forward motion. Hysteresis: engaging
+        # requires rotate_first_enter_threshold, but once engaged, stays engaged until
+        # heading_err drops below the smaller rotate_first_exit_threshold.
+        elif vx > 0.0 and abs(heading_err) > (self.rotate_first_exit_threshold if self._rotate_first_engaged else self.rotate_first_enter_threshold):
             vx = 0.0
             vyaw = float(np.clip(1.6 * heading_err, -0.6, 0.6))
+            self._rotate_first_engaged = True
+        else:
+            self._rotate_first_engaged = False
 
         vyaw = float(np.clip(vyaw, -self.max_angular_speed, self.max_angular_speed))
 

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -50,7 +50,12 @@ class CmdVelControlNode(Node):
         # Static-friction compensation: very small vx often cannot move the robot.
         self.min_effective_linear_speed = 0.1
         self.min_effective_angular_speed = 0.1
+        # Hysteresis: once moving, stay engaged until the target drops below this
+        # (lower) threshold, instead of re-testing against min_effective_* every
+        # cycle. Avoids bang-bang snapping between 0 and min when the planner's
+        # target hovers near min_effective_*.
         self.linear_engage_threshold = 0.04
+        self.angular_engage_threshold = 0.04
         self.fixed_reverse_speed = 0.2
         # Hack: if path first segment points far away from robot heading,
         # rotate in place instead of publishing near-zero cmd_vel.
@@ -58,6 +63,8 @@ class CmdVelControlNode(Node):
 
         self.latest_cmd = Twist()
         self.prev_cmd = Twist()
+        self._linear_engaged = False
+        self._angular_engaged = False
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
         self._paused = False
@@ -72,6 +79,8 @@ class CmdVelControlNode(Node):
         if not self._paused:
             # Reset prev_cmd so resume starts from zero cleanly
             self.prev_cmd = Twist()
+            self._linear_engaged = False
+            self._angular_engaged = False
 
     def _on_nav_active(self, msg: Bool):
         was_active = self._nav_active
@@ -79,6 +88,8 @@ class CmdVelControlNode(Node):
         if was_active and not self._nav_active:
             self.latest_cmd = Twist()
             self.prev_cmd = Twist()
+            self._linear_engaged = False
+            self._angular_engaged = False
             self.last_path_update_time = None
             # Send one stop when navigation is deactivated, then stay silent so
             # manual teleop can own /cmd_vel without being overwritten by zeros.
@@ -101,6 +112,8 @@ class CmdVelControlNode(Node):
         if self._paused:
             self.cmd_pub.publish(Twist())
             self.prev_cmd = Twist()
+            self._linear_engaged = False
+            self._angular_engaged = False
             return
 
         # Stale-path protection: slow down, then stop if planner has not refreshed.
@@ -125,6 +138,8 @@ class CmdVelControlNode(Node):
         if target_cmd.linear.x < 0.0:
             out.linear.x = target_cmd.linear.x
             out.angular.z = 0.0
+            self._linear_engaged = False
+            self._angular_engaged = False
             self.cmd_pub.publish(out)
             self.prev_cmd = out
             return
@@ -139,18 +154,36 @@ class CmdVelControlNode(Node):
         out.angular.z = float(np.clip(target_cmd.angular.z, -self.max_angular_speed, self.max_angular_speed))
 
         # Linear x: robot cannot execute tiny non-zero speeds reliably.
-        # When engaging forward motion, snap to +min; when stopping/decaying, snap to 0.
-        if 0.0 < out.linear.x < self.min_effective_linear_speed:
-            out.linear.x = self.min_effective_linear_speed if target_cmd.linear.x >= self.min_effective_linear_speed else 0.0
-        elif abs(out.linear.x) < self.min_effective_linear_speed:
-            out.linear.x = 0.0
+        # Hysteresis: reaching min_effective_linear_speed engages motion; once engaged,
+        # stay engaged (snap to min) until target truly drops below the lower
+        # linear_engage_threshold, instead of re-testing against min_effective_linear_speed
+        # every cycle. Avoids bang-bang snapping between 0 and min on noisy targets.
+        if out.linear.x >= self.min_effective_linear_speed:
+            self._linear_engaged = True
+        elif out.linear.x > 0.0:
+            required = self.linear_engage_threshold if self._linear_engaged else self.min_effective_linear_speed
+            if target_cmd.linear.x >= required:
+                out.linear.x = self.min_effective_linear_speed
+                self._linear_engaged = True
+            else:
+                out.linear.x = 0.0
+                self._linear_engaged = False
+        else:
+            self._linear_engaged = False
 
-        # Angular z: same idea; tiny requested turns snap to executable min, decays snap to 0.
-        if 0.0 < abs(out.angular.z) < self.min_effective_angular_speed:
-            if abs(target_cmd.angular.z) >= self.min_effective_angular_speed:
+        # Angular z: same hysteresis idea as linear x above.
+        if abs(out.angular.z) >= self.min_effective_angular_speed:
+            self._angular_engaged = True
+        elif abs(out.angular.z) > 0.0:
+            required = self.angular_engage_threshold if self._angular_engaged else self.min_effective_angular_speed
+            if abs(target_cmd.angular.z) >= required:
                 out.angular.z = float(np.sign(target_cmd.angular.z) * self.min_effective_angular_speed)
+                self._angular_engaged = True
             else:
                 out.angular.z = 0.0
+                self._angular_engaged = False
+        else:
+            self._angular_engaged = False
 
         self.cmd_pub.publish(out)
         self.prev_cmd = out


### PR DESCRIPTION
## Summary

Add hysteresis (dual enter/exit thresholds) to three bang-bang-prone gates in the velocity pipeline:

### 1. Linear/angular deadzone snap (`cmd_vel_control.py`)
- **Before:** Single `min_effective_*_speed` threshold — when planner target hovered near the boundary, cmd_vel snapped between 0 and min every cycle.
- **After:** Engage motion at `min_effective_*_speed`; once engaged, stay engaged until target drops below a lower `*_engage_threshold` (0.04). Eliminates bang-bang on noisy targets.

### 2. Forward/reverse trajectory gate (`planning_node.py`)
- **Before:** Single `enter_threshold = 0.30` — gate flipped every cycle when front clearance hovered at the boundary.
- **After:** Enter reverse mode at `0.30`, require `0.40` clearance to exit. Hysteresis state stored in `self._reverse_mode`.

### 3. Rotate-first heading gate (`cmd_vel_control.py`)
- **Before:** Single `0.45 rad` threshold — flip-flopped between drive+turn and rotate-only when heading jittered near boundary.
- **After:** Engage at `rotate_first_enter_threshold = 0.45 rad` (~26°), stay engaged until heading error drops below `rotate_first_exit_threshold = 15°`.

All hysteresis states are reset on pause, nav deactivation, and reverse command for clean transitions.

## Changed files
- `tinynav/core/planning_node.py` — +12 -1
- `tinynav/platforms/cmd_vel_control.py` — +57 -10

## Testing
- [ ] Test on hardware with obstacle-rich scenarios
- [ ] Verify no bang-bang at trajectory boundaries
- [ ] Confirm smooth pause/resume transitions