### PR TITLE
feat(llm): add local llama runtime to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN echo "ARCH is $ARCH"
 # Configure image
 ARG PYTHON_VERSION=3.10
 ARG DEBIAN_FRONTEND=noninteractive
+ARG LLAMA_CPP_REF=4fc4ec5541b243957ae5099edb67372f8f3b550e
+ARG TINYNAV_LLM_MODEL_URL=https://huggingface.co/bartowski/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf
+ARG TINYNAV_LLM_MODEL_PATH=/tinynav/llm/models/qwen2.5-0.5b-instruct-q4_k_m.gguf
 
 # Install apt dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -166,6 +169,26 @@ RUN apt-get update && apt-get install -y \
     ros-humble-foxglove-msgs \
     ros-humble-foxglove-compressed-video-transport \
     && rm -rf /var/lib/apt/lists/*
+
+# llama.cpp runtime for local LLM command parsing
+RUN git clone https://github.com/ggml-org/llama.cpp.git /3rdparty/llama.cpp \
+    && cd /3rdparty/llama.cpp \
+    && git checkout "${LLAMA_CPP_REF}" \
+    && cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_CUDA=ON \
+    && cmake --build build --config Release -j"$(nproc)" --target llama-server llama-cli \
+    && mkdir -p /tinynav/llm/bin \
+    && cp -a build/bin/. /tinynav/llm/bin/ \
+    && ln -sf /tinynav/llm/bin/llama-server /usr/bin/llama-server \
+    && ln -sf /tinynav/llm/bin/llama-cli /usr/bin/llama-cli
+
+ENV LD_LIBRARY_PATH="/tinynav/llm/bin:${LD_LIBRARY_PATH}"
+ENV TINYNAV_LLM_MODEL_PATH="${TINYNAV_LLM_MODEL_PATH}"
+ENV TINYNAV_LLM_HOST=127.0.0.1
+ENV TINYNAV_LLM_PORT=8888
+
+RUN mkdir -p "$(dirname "${TINYNAV_LLM_MODEL_PATH}")" \
+    && curl -fL "${TINYNAV_LLM_MODEL_URL}" -o "${TINYNAV_LLM_MODEL_PATH}" \
+    && test -s "${TINYNAV_LLM_MODEL_PATH}"
 
 # Override apt-installed message_filters with UniflexAI/message_filters humble branch
 RUN mkdir -p /3rdparty/message_filters_ws/src \

--- a/scripts/start_app.sh
+++ b/scripts/start_app.sh
@@ -7,4 +7,6 @@ TINYNAV_DB_PATH="${TINYNAV_DB_PATH:-/tinynav/tinynav_db}"
 tmux new-session -s app \; \
   split-window -h \; \
   select-pane -t 0 \; send-keys "cd /tinynav && TINYNAV_DB_PATH=$TINYNAV_DB_PATH uvicorn app.backend.main:app --host 0.0.0.0 --port $BACKEND_PORT" C-m \; \
-  select-pane -t 1 \; send-keys "python -m http.server $FRONTEND_PORT --directory /tinynav/app/frontend/build/web" C-m
+  select-pane -t 1 \; send-keys "python -m http.server $FRONTEND_PORT --directory /tinynav/app/frontend/build/web" C-m \; \
+  split-window -v \; \
+  select-pane -t 2 \; send-keys "llama-server -m /tinynav/llm/models/qwen2.5-0.5b-instruct-q4_k_m.gguf -c 1024 -t 4 --host 0.0.0.0 --port 8888" C-m


### PR DESCRIPTION
## Summary

This PR adds a local llama.cpp runtime to the TinyNav Docker image and starts a default local LLM server with the app.

- Build pinned llama.cpp from source during image build.
- Install llama.cpp build outputs into `/tinynav/llm/bin`.
- Symlink `llama-server` and `llama-cli` into `/usr/bin`.
- Download the Qwen2.5 0.5B Instruct Q4_K_M GGUF model into `/tinynav/llm/models`.
- Start `llama-server` directly from `scripts/start_app.sh` on `0.0.0.0:8888`.

## Notes

- The llama.cpp revision is pinned to the commit currently validated on the office robot.

## Test plan

- `bash -n scripts/start_app.sh`
- `git diff --check`

Full Docker image build has not been run yet.
