### PR TITLE
fix(planning): prefer rotate-in-place for behind targets

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -418,8 +418,8 @@ class PlanningNode(Node):
             return
 
         abs_error = abs(heading_error)
-        enter_threshold = np.deg2rad(110.0)
-        exit_threshold = np.deg2rad(70.0)
+        enter_threshold = np.deg2rad(120.0)
+        exit_threshold = np.deg2rad(100.0)
 
         if self.behind_target_mode:
             if abs_error < exit_threshold:
@@ -427,7 +427,9 @@ class PlanningNode(Node):
                 self.behind_turn_sign = 0.0
         elif abs_error > enter_threshold:
             self.behind_target_mode = True
-            self.behind_turn_sign = 1.0 if heading_error >= 0.0 else -1.0
+            # Trajectory param[1] is camera-frame omega_y. After conversion to robot cmd_vel,
+            # its sign is opposite to robot yaw: positive omega_y turns the robot right.
+            self.behind_turn_sign = -1.0 if heading_error >= 0.0 else 1.0
 
     def info_callback(self, msg):
         if self.K is None:

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -381,6 +381,8 @@ class PlanningNode(Node):
         self.baseline = None
         self.last_T = None
         self.last_param = (0.0, 0.0) # acc and gyro
+        self.behind_target_mode = False
+        self.behind_turn_sign = 0.0
         self.obstacle_config = ObstacleConfig()
         self.stamp = None
         self.current_pose = None  # Store the latest pose from odometry
@@ -397,6 +399,35 @@ class PlanningNode(Node):
 
     def target_pose_callback(self, msg):
         self.target_pose = np.array([msg.pose.pose.position.x, msg.pose.pose.position.y, msg.pose.pose.position.z])
+
+    def _target_heading_error(self, T, target_pose):
+        if target_pose is None:
+            return None
+        center = self.camera_to_robot_center(T)
+        forward = T[:3, :3] @ np.array([0.0, 0.0, 1.0])
+        left = T[:3, :3] @ np.array([1.0, 0.0, 0.0])
+        to_target = target_pose - center
+        forward_dist = float(np.dot(to_target[:2], forward[:2]))
+        left_dist = float(np.dot(to_target[:2], left[:2]))
+        return float(np.arctan2(left_dist, forward_dist))
+
+    def _update_behind_target_mode(self, heading_error):
+        if heading_error is None:
+            self.behind_target_mode = False
+            self.behind_turn_sign = 0.0
+            return
+
+        abs_error = abs(heading_error)
+        enter_threshold = np.deg2rad(110.0)
+        exit_threshold = np.deg2rad(70.0)
+
+        if self.behind_target_mode:
+            if abs_error < exit_threshold:
+                self.behind_target_mode = False
+                self.behind_turn_sign = 0.0
+        elif abs_error > enter_threshold:
+            self.behind_target_mode = True
+            self.behind_turn_sign = 1.0 if heading_error >= 0.0 else -1.0
 
     def info_callback(self, msg):
         if self.K is None:
@@ -608,13 +639,18 @@ class PlanningNode(Node):
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
             enter_threshold = 0.30
+            target_heading_error = self._target_heading_error(T, self.target_pose)
+            self._update_behind_target_mode(target_heading_error)
+            behind_target_mode = self.behind_target_mode
+            behind_turn_sign = self.behind_turn_sign
 
             def cost_function(traj, param, score, target_pose):
                 # predefined backward trajectory penalty
                 is_backward_traj = param[0] < 0.0
+                is_rotate_in_place = abs(param[0]) < 1e-6 and abs(param[1]) > 1e-3
                 should_reverse = front_clearance <= enter_threshold
                 reverse_gate_penalty = 0.0
-                if should_reverse and not is_backward_traj:
+                if should_reverse and not is_backward_traj and not (behind_target_mode and is_rotate_in_place):
                         reverse_gate_penalty = 1e9
                 elif not should_reverse and is_backward_traj:
                         reverse_gate_penalty = 1e9
@@ -623,8 +659,20 @@ class PlanningNode(Node):
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
+                behind_target_penalty = 0.0
+                if behind_target_mode:
+                    correct_turn = is_rotate_in_place and np.sign(param[1]) == behind_turn_sign
+                    if not correct_turn:
+                        behind_target_penalty = 1e6
 
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
+                return (
+                    score * 100000
+                    + 100 * dist
+                    + 10 * abs(self.last_param[0] - param[0])
+                    + 10 * abs(self.last_param[1] - param[1])
+                    + reverse_gate_penalty
+                    + behind_target_penalty
+                )
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -419,7 +419,7 @@ class PlanningNode(Node):
 
         abs_error = abs(heading_error)
         enter_threshold = np.deg2rad(120.0)
-        exit_threshold = np.deg2rad(60.0)
+        exit_threshold = np.deg2rad(100.0)
 
         if self.behind_target_mode:
             if abs_error < exit_threshold:
@@ -676,16 +676,6 @@ class PlanningNode(Node):
 
                 return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
 
-            def select_reverse_trajectory():
-                reverse_costs = np.where(
-                    (params[:, 0] < 0.0) & np.isfinite(scores_array),
-                    scores_array,
-                    np.inf,
-                )
-                if not np.any(np.isfinite(reverse_costs)):
-                    return None
-                return np.array([int(np.argmin(reverse_costs))])
-
             if behind_target_mode and not should_reverse:
                 # In behind-target mode, do not let the normal cost planner compete.
                 # Publish a fixed safe in-place rotation trajectory until heading error exits the hysteresis band.
@@ -700,10 +690,9 @@ class PlanningNode(Node):
                 if np.any(np.isfinite(rotate_costs)):
                     top_indices = np.array([int(np.argmin(rotate_costs))])
                 else:
-                    top_indices = select_reverse_trajectory()
-                    if top_indices is None:
-                        self.get_logger().info('No safe behind-target rotate or reverse trajectory, stopping path.')
-                        return
+                    self.get_logger().debug('No safe behind-target rotate trajectory, falling back to cost planner.')
+                    top_k = 1
+                    top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores_array[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
             else:
                 top_k = 1
                 top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores_array[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -641,10 +641,12 @@ class PlanningNode(Node):
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
             enter_threshold = 0.30
+            should_reverse = front_clearance <= enter_threshold
             target_heading_error = self._target_heading_error(T, self.target_pose)
             self._update_behind_target_mode(target_heading_error)
             behind_target_mode = self.behind_target_mode
             behind_turn_sign = self.behind_turn_sign
+            scores_array = np.asarray(scores, dtype=np.float64)
 
             # path
             path = Path()
@@ -654,40 +656,46 @@ class PlanningNode(Node):
             if self.target_pose is None:
                 return
 
-            if all(s == float('inf') for s in scores):
+            if np.all(np.isinf(scores_array)):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 return
 
-            if behind_target_mode:
+            def cost_function(traj, param, score, target_pose):
+                # predefined backward trajectory penalty
+                is_backward_traj = param[0] < 0.0
+                reverse_gate_penalty = 0.0
+                if should_reverse and not is_backward_traj:
+                        reverse_gate_penalty = 1e9
+                elif not should_reverse and is_backward_traj:
+                        reverse_gate_penalty = 1e9
+
+                # regular trajectory penalty
+                traj_end = np.array(traj[-1,:3])
+                target_end = target_pose if target_pose is not None else traj_end
+                dist = np.linalg.norm(traj_end - target_end)
+
+                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
+
+            if behind_target_mode and not should_reverse:
                 # In behind-target mode, do not let the normal cost planner compete.
-                # Publish a fixed in-place rotation trajectory until heading error exits the hysteresis band.
+                # Publish a fixed safe in-place rotation trajectory until heading error exits the hysteresis band.
                 fixed_turn_speed = 1.0
                 rotate_costs = np.where(
-                    (np.abs(params[:, 0]) < 1e-6) & (np.sign(params[:, 1]) == behind_turn_sign),
+                    (np.abs(params[:, 0]) < 1e-6)
+                    & (np.sign(params[:, 1]) == behind_turn_sign)
+                    & np.isfinite(scores_array),
                     np.abs(np.abs(params[:, 1]) - fixed_turn_speed),
                     np.inf,
                 )
-                top_indices = np.array([int(np.argmin(rotate_costs))])
+                if np.any(np.isfinite(rotate_costs)):
+                    top_indices = np.array([int(np.argmin(rotate_costs))])
+                else:
+                    self.get_logger().debug('No safe behind-target rotate trajectory, falling back to cost planner.')
+                    top_k = 1
+                    top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores_array[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
             else:
-                def cost_function(traj, param, score, target_pose):
-                    # predefined backward trajectory penalty
-                    is_backward_traj = param[0] < 0.0
-                    should_reverse = front_clearance <= enter_threshold
-                    reverse_gate_penalty = 0.0
-                    if should_reverse and not is_backward_traj:
-                            reverse_gate_penalty = 1e9
-                    elif not should_reverse and is_backward_traj:
-                            reverse_gate_penalty = 1e9
-
-                    # regular trajectory penalty
-                    traj_end = np.array(traj[-1,:3])
-                    target_end = target_pose if target_pose is not None else traj_end
-                    dist = np.linalg.norm(traj_end - target_end)
-
-                    return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
-
                 top_k = 1
-                top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
+                top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores_array[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
 
             self.last_param = params[top_indices[0]]
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -646,40 +646,6 @@ class PlanningNode(Node):
             behind_target_mode = self.behind_target_mode
             behind_turn_sign = self.behind_turn_sign
 
-            def cost_function(traj, param, score, target_pose):
-                # predefined backward trajectory penalty
-                is_backward_traj = param[0] < 0.0
-                is_rotate_in_place = abs(param[0]) < 1e-6 and abs(param[1]) > 1e-3
-                should_reverse = front_clearance <= enter_threshold
-                reverse_gate_penalty = 0.0
-                if should_reverse and not is_backward_traj and not (behind_target_mode and is_rotate_in_place):
-                        reverse_gate_penalty = 1e9
-                elif not should_reverse and is_backward_traj:
-                        reverse_gate_penalty = 1e9
-
-                # regular trajectory penalty
-                traj_end = np.array(traj[-1,:3])
-                target_end = target_pose if target_pose is not None else traj_end
-                dist = np.linalg.norm(traj_end - target_end)
-                behind_target_penalty = 0.0
-                if behind_target_mode:
-                    correct_turn = is_rotate_in_place and np.sign(param[1]) == behind_turn_sign
-                    if not correct_turn:
-                        behind_target_penalty = 1e6
-
-                return (
-                    score * 100000
-                    + 100 * dist
-                    + 10 * abs(self.last_param[0] - param[0])
-                    + 10 * abs(self.last_param[1] - param[1])
-                    + reverse_gate_penalty
-                    + behind_target_penalty
-                )
-
-            top_k = 1
-            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
-            self.last_param = params[top_indices[0]]
-
             # path
             path = Path()
             path.header = depth_msg.header
@@ -691,6 +657,39 @@ class PlanningNode(Node):
             if all(s == float('inf') for s in scores):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 return
+
+            if behind_target_mode:
+                # In behind-target mode, do not let the normal cost planner compete.
+                # Publish a fixed in-place rotation trajectory until heading error exits the hysteresis band.
+                fixed_turn_speed = 0.6
+                rotate_costs = np.where(
+                    (np.abs(params[:, 0]) < 1e-6) & (np.sign(params[:, 1]) == behind_turn_sign),
+                    np.abs(np.abs(params[:, 1]) - fixed_turn_speed),
+                    np.inf,
+                )
+                top_indices = np.array([int(np.argmin(rotate_costs))])
+            else:
+                def cost_function(traj, param, score, target_pose):
+                    # predefined backward trajectory penalty
+                    is_backward_traj = param[0] < 0.0
+                    should_reverse = front_clearance <= enter_threshold
+                    reverse_gate_penalty = 0.0
+                    if should_reverse and not is_backward_traj:
+                            reverse_gate_penalty = 1e9
+                    elif not should_reverse and is_backward_traj:
+                            reverse_gate_penalty = 1e9
+
+                    # regular trajectory penalty
+                    traj_end = np.array(traj[-1,:3])
+                    target_end = target_pose if target_pose is not None else traj_end
+                    dist = np.linalg.norm(traj_end - target_end)
+
+                    return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
+
+                top_k = 1
+                top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
+
+            self.last_param = params[top_indices[0]]
 
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -419,7 +419,7 @@ class PlanningNode(Node):
 
         abs_error = abs(heading_error)
         enter_threshold = np.deg2rad(120.0)
-        exit_threshold = np.deg2rad(100.0)
+        exit_threshold = np.deg2rad(60.0)
 
         if self.behind_target_mode:
             if abs_error < exit_threshold:
@@ -676,6 +676,16 @@ class PlanningNode(Node):
 
                 return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
 
+            def select_reverse_trajectory():
+                reverse_costs = np.where(
+                    (params[:, 0] < 0.0) & np.isfinite(scores_array),
+                    scores_array,
+                    np.inf,
+                )
+                if not np.any(np.isfinite(reverse_costs)):
+                    return None
+                return np.array([int(np.argmin(reverse_costs))])
+
             if behind_target_mode and not should_reverse:
                 # In behind-target mode, do not let the normal cost planner compete.
                 # Publish a fixed safe in-place rotation trajectory until heading error exits the hysteresis band.
@@ -690,9 +700,10 @@ class PlanningNode(Node):
                 if np.any(np.isfinite(rotate_costs)):
                     top_indices = np.array([int(np.argmin(rotate_costs))])
                 else:
-                    self.get_logger().debug('No safe behind-target rotate trajectory, falling back to cost planner.')
-                    top_k = 1
-                    top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores_array[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
+                    top_indices = select_reverse_trajectory()
+                    if top_indices is None:
+                        self.get_logger().info('No safe behind-target rotate or reverse trajectory, stopping path.')
+                        return
             else:
                 top_k = 1
                 top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores_array[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -661,7 +661,7 @@ class PlanningNode(Node):
             if behind_target_mode:
                 # In behind-target mode, do not let the normal cost planner compete.
                 # Publish a fixed in-place rotation trajectory until heading error exits the hysteresis band.
-                fixed_turn_speed = 0.6
+                fixed_turn_speed = 1.0
                 rotate_costs = np.where(
                     (np.abs(params[:, 0]) < 1e-6) & (np.sign(params[:, 1]) == behind_turn_sign),
                     np.abs(np.abs(params[:, 1]) - fixed_turn_speed),


### PR DESCRIPTION
## Summary

Prefer rotate-in-place when the target is behind the robot, reducing turn cost by avoiding arc-based planning for rear targets.

## Changes

- `tinynav/core/planning_node.py`: Add behind-target rotate cost logic (+51 -3)

## Testing

TBD