### PR TITLE
feat(map): snap POI position to nearest SDF prior path

### DIFF
--- a/app/backend/routers/map.py
+++ b/app/backend/routers/map.py
@@ -4,6 +4,7 @@ import os
 import re
 from typing import Optional
 
+import numpy as np
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 from PIL import Image
@@ -140,9 +141,59 @@ def map_preview_image(map_name: str):
     return Response(content=png_bytes, media_type='image/png')
 
 
+def _snap_to_sdf(map_path: str, x: float, y: float, search_radius: int = 8, sdf_threshold: float = 0.5) -> tuple[float, float, float]:
+    """Snap a (x, y) world position to the nearest point on the prior path (SDF).
+
+    Searches a cylindrical neighbourhood around (x, y) across all z-slices
+    for the cell with the minimum SDF value.  If that minimum is below
+    *sdf_threshold* the snapped world coordinates are returned; otherwise
+    the original (x, y, 0) is returned unchanged.
+    """
+    sdf_path = os.path.join(map_path, 'sdf_map.npy')
+    meta_path = os.path.join(map_path, 'occupancy_meta.npy')
+    if not (os.path.exists(sdf_path) and os.path.exists(meta_path)):
+        return x, y, 0.0
+
+    sdf_map = np.load(sdf_path)          # (Nx, Ny, Nz) float32
+    meta = np.load(meta_path)            # [origin_x, origin_y, origin_z, resolution]
+    origin = meta[:3]
+    resolution = float(meta[3])
+
+    ix = int(round((x - origin[0]) / resolution))
+    iy = int(round((y - origin[1]) / resolution))
+
+    Nx, Ny, Nz = sdf_map.shape
+    x0 = max(0, ix - search_radius)
+    x1 = min(Nx, ix + search_radius + 1)
+    y0 = max(0, iy - search_radius)
+    y1 = min(Ny, iy + search_radius + 1)
+
+    if x0 >= x1 or y0 >= y1:
+        return x, y, 0.0
+
+    # Sub-volume: (x_range, y_range, all z)  → find global min SDF cell
+    sub = sdf_map[x0:x1, y0:y1, :]
+    flat_idx = int(np.argmin(sub))
+    bx, by, bz = np.unravel_index(flat_idx, sub.shape)
+    min_sdf = float(sub[bx, by, bz])
+
+    if min_sdf > sdf_threshold:
+        # Too far from any prior path — keep original position
+        return x, y, 0.0
+
+    gx = x0 + bx
+    gy = y0 + by
+    gz = bz
+
+    wx = gx * resolution + origin[0]
+    wy = gy * resolution + origin[1]
+    wz = gz * resolution + origin[2]
+    return wx, wy, wz
+
+
 class MapPoiCreateRequest(BaseModel):
     name: str
-    position: list[float]  # [x, y, z]
+    position: list[float]  # [x, y, z]  — z will be snapped from SDF
 
 
 @router.post('/preview/{map_name}/pois')
@@ -150,6 +201,12 @@ def map_preview_create_poi(map_name: str, req: MapPoiCreateRequest):
     path = _resolve_map_path(map_name)
     if len(req.position) != 3:
         raise HTTPException(400, 'position must be [x, y, z]')
+
+    # Snap (x, y) to the nearest prior-path point using the SDF map.
+    # The incoming z is ignored — the snapped z comes from the SDF volume.
+    sx, sy, sz = _snap_to_sdf(path, req.position[0], req.position[1])
+    snapped_position = [sx, sy, sz]
+
     pois_file = os.path.join(path, 'pois.json')
     pois: dict = {}
     if os.path.exists(pois_file):
@@ -157,7 +214,7 @@ def map_preview_create_poi(map_name: str, req: MapPoiCreateRequest):
             pois = json.load(f)
     existing_ids = [int(k) for k in pois.keys()] if pois else []
     new_id = max(existing_ids) + 1 if existing_ids else 0
-    pois[str(new_id)] = {'id': new_id, 'name': req.name, 'position': req.position}
+    pois[str(new_id)] = {'id': new_id, 'name': req.name, 'position': snapped_position}
     with open(pois_file, 'w') as f:
         json.dump(pois, f, indent=2)
     return pois[str(new_id)]


### PR DESCRIPTION
## Summary

When adding a POI via long-press on the map preview, the (x, y) position is now snapped to the nearest point on the prior path using the SDF (signed distance field) volume stored in the map directory.

## Changes

- **Add  helper** in :
  - Loads  and  from the map directory
  - Converts the input (x, y) world coordinate to voxel indices
  - Searches a cylindrical neighbourhood (±8 cells) across all z-slices for the cell with the minimum SDF value
  - If the minimum SDF ≤ 0.5, returns the snapped world coordinates (x, y, z)
  - Falls back to the original (x, y, 0.0) if no SDF map exists or the nearest path is too far

- **Update ** to call  before saving the POI to 

## Notes

- Frontend requires no changes — the incoming z is ignored and replaced by the snapped z from the SDF volume
- The SDF threshold (0.5) is consistent with the  used in  in 
- If the map directory has no , the endpoint behaves as before (no snapping)

## Test plan

- [ ] Build a map with SDF, long-press to add a POI near a prior path, verify the saved position is on the path
- [ ] Long-press far from any path, verify fallback to original (x, y, 0.0)
- [ ] Test with a map that has no SDF files, verify no crash and fallback behavior