### PR TITLE
fix(backend): allow forcing sensor mode via TINYNAV_SENSOR_MODE

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -421,16 +421,31 @@ class BackendNode(Ros2NodeManager):
     def _detect_and_init_sensor(self):
         domain = os.environ.get('ROS_DOMAIN_ID', '0')
         self.get_logger().info(f'BackendNode ROS_DOMAIN_ID={domain}')
-        try:
-            result = subprocess.run(
-                ['ros2', 'node', 'list'], capture_output=True, text=True, timeout=3
+
+        # Explicit override: when TINYNAV_SENSOR_MODE is set, honor it verbatim and
+        # skip node-based detection. Avoids misdetecting a looper rig as realsense when
+        # /insight_full is slow to come up (the looper bridge just subscribes and waits).
+        forced = os.environ.get('TINYNAV_SENSOR_MODE', '').strip().lower()
+        if forced and forced not in ('looper', 'realsense'):
+            self.get_logger().warn(
+                f'Ignoring invalid TINYNAV_SENSOR_MODE={forced!r}; falling back to detection'
             )
-            if '/insight_full' in result.stdout.splitlines():
-                self._sensor_mode = 'looper'
-                self.get_logger().info('Sensor mode: looper — launching looper bridge + planning')
+            forced = ''
+
+        try:
+            if forced:
+                self._sensor_mode = forced
+                self.get_logger().info(f'Sensor mode: {forced} (forced via TINYNAV_SENSOR_MODE)')
             else:
-                self._sensor_mode = 'realsense'
-                self.get_logger().info('Sensor mode: realsense — launching driver + perception + planning')
+                result = subprocess.run(
+                    ['ros2', 'node', 'list'], capture_output=True, text=True, timeout=3
+                )
+                if '/insight_full' in result.stdout.splitlines():
+                    self._sensor_mode = 'looper'
+                    self.get_logger().info('Sensor mode: looper — launching looper bridge + planning')
+                else:
+                    self._sensor_mode = 'realsense'
+                    self.get_logger().info('Sensor mode: realsense — launching driver + perception + planning')
 
             if self._sensor_mode in ('looper', 'realsense'):
                 _env = os.environ.copy()


### PR DESCRIPTION
## Problem

Sensor mode is detected once at backend startup via a single `ros2 node list` probe in `_detect_and_init_sensor`: if `/insight_full` is present → `looper`, otherwise → `realsense`.

Because `/insight_full` (the looper SDK node) is often slow to come up, this one-shot probe frequently runs before the node exists, so a looper rig gets **misdetected as realsense** and the wrong sensor procs are launched.

## Change

Add an explicit override:

- When `TINYNAV_SENSOR_MODE` is set to `looper` or `realsense`, honor it verbatim and skip node-based detection.
- When **unset**, the original detection logic is **unchanged** — existing deployments are unaffected.
- An invalid value logs a warning and falls back to detection.

Only `_detect_and_init_sensor` is touched; `_sensor_mode` semantics and all downstream branches / the `/sensor/mode` API are untouched.

## Why defaulting a looper rig to looper is safe

Even if `/insight_full` isn't up yet, looper mode only launches `looper_bridge_node` + `planning_node` (no sensor driver). The bridge just subscribes to the sensor topics and idles (`Waiting for Looper bridge inputs`) until the SDK node starts publishing, then bridges automatically — no restart needed.

## Deployment

Looper rigs add one line to their compose `environment:`:

```yaml
      TINYNAV_SENSOR_MODE: looper
```

RealSense rigs need no change (default detection path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)