### PR TITLE
feat(operate): recolour ESDF heatmap via fragment shader

### DIFF
--- a/app/frontend/lib/pages/esdf_colormap_layer.dart
+++ b/app/frontend/lib/pages/esdf_colormap_layer.dart
@@ -1,0 +1,186 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// Single source of truth for the ESDF heatmap palette.
+///
+/// Ordered danger→safe (t=0 → t=1): dark red core → coral → amber → olive →
+/// teal → deep cyan → navy far-field. Rasterized into a 256×1 LUT texture and
+/// fed to the `esdf_colormap` fragment shader. Tweak colours here only — the
+/// shader samples this gradient, it does not hardcode it.
+const LinearGradient _kEsdfHeatmap = LinearGradient(
+  colors: [
+    Color(0xFF7A1E18), // 0.00 danger core
+    Color(0xFFB43A24), // 0.15 danger edge
+    Color(0xFFD8903D), // 0.30 warning amber
+    Color(0xFF8FA66A), // 0.45 transition olive
+    Color(0xFF238B8F), // 0.60 safe teal
+    Color(0xFF0B5D7C), // 0.78 far-field cyan
+    Color(0xFF06111D), // 1.00 background navy
+  ],
+  stops: [0.0, 0.15, 0.30, 0.45, 0.60, 0.78, 1.0],
+);
+
+/// Renders the ESDF heatmap bytes recoloured through the `esdf_colormap`
+/// fragment shader, replacing the baked-in JET palette with [_kEsdfHeatmap].
+///
+/// The source bytes arrive already colourised (JET, baked upstream). The shader
+/// recovers a scalar per pixel and looks up a new colour from a palette LUT.
+/// If the shader or image is not ready yet (or the shader asset fails to load),
+/// it falls back to the original [Image.memory] bitmap so behaviour never
+/// degrades below the previous implementation.
+class EsdfColormapLayer extends StatefulWidget {
+  final Uint8List bytes;
+  final double opacity;
+
+  const EsdfColormapLayer({
+    super.key,
+    required this.bytes,
+    this.opacity = 0.85,
+  });
+
+  @override
+  State<EsdfColormapLayer> createState() => _EsdfColormapLayerState();
+}
+
+class _EsdfColormapLayerState extends State<EsdfColormapLayer> {
+  // Shared across all instances — the program and palette LUT are built once.
+  static ui.FragmentProgram? _program;
+  static ui.Image? _lut;
+  static Future<void>? _assetsFuture;
+
+  ui.FragmentShader? _shader;
+  ui.Image? _srcImage;
+  bool _ready = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAssets();
+    _decode(widget.bytes);
+  }
+
+  @override
+  void didUpdateWidget(EsdfColormapLayer old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.bytes, widget.bytes)) {
+      _decode(widget.bytes);
+    }
+  }
+
+  Future<void> _loadAssets() async {
+    try {
+      _assetsFuture ??= _buildSharedAssets();
+      await _assetsFuture;
+    } catch (_) {
+      // Leave _ready false → graceful fallback to Image.memory.
+      return;
+    }
+    if (!mounted) return;
+    final program = _program;
+    if (program == null || _lut == null) return;
+    setState(() {
+      _shader ??= program.fragmentShader();
+      _ready = true;
+    });
+  }
+
+  static Future<void> _buildSharedAssets() async {
+    _program =
+        await ui.FragmentProgram.fromAsset('shaders/esdf_colormap.frag');
+    _lut = await _buildLut();
+  }
+
+  static Future<ui.Image> _buildLut() {
+    const int width = 256;
+    const int height = 1;
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    final rect = Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble());
+    canvas.drawRect(
+      rect,
+      Paint()..shader = _kEsdfHeatmap.createShader(rect),
+    );
+    return recorder.endRecording().toImage(width, height);
+  }
+
+  void _decode(Uint8List bytes) {
+    ui.decodeImageFromList(bytes, (img) {
+      if (!mounted) {
+        img.dispose();
+        return;
+      }
+      final old = _srcImage;
+      setState(() => _srcImage = img);
+      old?.dispose();
+    });
+  }
+
+  @override
+  void dispose() {
+    _srcImage?.dispose();
+    _shader?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final shader = _shader;
+    final lut = _lut;
+    final src = _srcImage;
+
+    if (!_ready || shader == null || lut == null || src == null) {
+      return Opacity(
+        opacity: widget.opacity,
+        child: Image.memory(
+          widget.bytes,
+          fit: BoxFit.fill,
+          gaplessPlayback: true,
+        ),
+      );
+    }
+
+    return CustomPaint(
+      size: Size.infinite,
+      painter: _EsdfShaderPainter(
+        shader: shader,
+        src: src,
+        lut: lut,
+        opacity: widget.opacity,
+      ),
+    );
+  }
+}
+
+class _EsdfShaderPainter extends CustomPainter {
+  final ui.FragmentShader shader;
+  final ui.Image src;
+  final ui.Image lut;
+  final double opacity;
+
+  const _EsdfShaderPainter({
+    required this.shader,
+    required this.src,
+    required this.lut,
+    required this.opacity,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    shader
+      ..setFloat(0, size.width)
+      ..setFloat(1, size.height)
+      ..setFloat(2, opacity)
+      ..setImageSampler(0, src)
+      ..setImageSampler(1, lut);
+    canvas.drawRect(Offset.zero & size, Paint()..shader = shader);
+  }
+
+  @override
+  bool shouldRepaint(_EsdfShaderPainter old) =>
+      !identical(old.src, src) ||
+      !identical(old.lut, lut) ||
+      !identical(old.shader, shader) ||
+      old.opacity != opacity;
+}

--- a/app/frontend/lib/pages/operate_tab.dart
+++ b/app/frontend/lib/pages/operate_tab.dart
@@ -12,6 +12,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../core/models.dart';
 import '../core/providers.dart';
+import 'esdf_colormap_layer.dart';
 import 'local_voxel_painter.dart';
 import 'map_painter.dart';
 import 'planning_painter.dart';
@@ -538,12 +539,10 @@ class _LocalPlanningViewState extends ConsumerState<_LocalPlanningView> {
                           children: [
                             const ColoredBox(color: Color(0xFF0F1621)),
                             if (widget.showEsdf && p?.esdfImage != null)
-                              Opacity(
-                                opacity: 0.85,
-                                child: Image.memory(
-                                  p!.esdfImage!,
-                                  fit: BoxFit.fill,
-                                  gaplessPlayback: true,
+                              Positioned.fill(
+                                child: EsdfColormapLayer(
+                                  bytes: p!.esdfImage!,
+                                  opacity: 0.85,
                                 ),
                               ),
                             if (widget.showObstacle && p?.obstacleImage != null)

--- a/app/frontend/pubspec.yaml
+++ b/app/frontend/pubspec.yaml
@@ -26,6 +26,9 @@ flutter:
   assets:
     - assets/images/
 
+  shaders:
+    - shaders/esdf_colormap.frag
+
   fonts:
     - family: RobotoLocal
       fonts:

--- a/app/frontend/shaders/esdf_colormap.frag
+++ b/app/frontend/shaders/esdf_colormap.frag
@@ -1,0 +1,72 @@
+#version 460 core
+#include <flutter/runtime_effect.glsl>
+
+// Recolours the ESDF heatmap layer.
+//
+// The source image (uSrc) arrives already colourised with a JET-ish colormap
+// baked in upstream (robot planning node → backend). This shader recovers a
+// scalar t in [0,1] from each pixel, then looks up a new colour from a 256x1
+// palette LUT (uLut) built from the _kEsdfHeatmap gradient in
+// esdf_colormap_layer.dart. This keeps the palette a single source of truth in
+// Dart; the shader stays generic.
+//
+// Uniform layout (must match _EsdfShaderPainter in esdf_colormap_layer.dart):
+//   setFloat(0,1) -> uSize
+//   setFloat(2)   -> uOpacity
+//   setImageSampler(0) -> uSrc
+//   setImageSampler(1) -> uLut
+
+uniform vec2 uSize;      // draw area in pixels
+uniform float uOpacity;  // layer opacity [0,1]
+uniform sampler2D uSrc;  // JET-colourised ESDF source
+uniform sampler2D uLut;  // 256x1 palette, x=0 danger .. x=1 far-field
+
+out vec4 fragColor;
+
+// Saturation below this = treat as background / no-data.
+const float kMinSaturation = 0.06;
+
+// ── JET → scalar recovery ──────────────────────────────────────────────────
+// Uses hue angle rather than an RGB-curve match: hue is far more robust to
+// JPEG compression noise and brightness variation than per-channel matching.
+// JET sweeps hue red(danger) → yellow → green → cyan → blue(safe), so hue maps
+// (approximately) monotonically to the scalar. Orientation: red=danger→t=0,
+// blue=safe→t=1.
+//
+// NOTE: this is the calibration-sensitive block. If danger/safe come out
+// reversed or the no-data cutoff is wrong on real frames, adjust HERE only.
+float jetToT(vec3 c) {
+  float mx = max(c.r, max(c.g, c.b));
+  float mn = min(c.r, min(c.g, c.b));
+  float chroma = mx - mn;
+
+  // Near-gray / background pixels carry no field value → push to far-field.
+  if (chroma < kMinSaturation) {
+    return 1.0;
+  }
+
+  float hue;
+  if (mx == c.r) {
+    hue = mod((c.g - c.b) / chroma, 6.0);
+  } else if (mx == c.g) {
+    hue = (c.b - c.r) / chroma + 2.0;
+  } else {
+    hue = (c.r - c.g) / chroma + 4.0;
+  }
+  hue /= 6.0; // [0,1): red=0, green=1/3, blue=2/3
+
+  // Map red(0)→t=0 (danger) .. blue(2/3)→t=1 (safe). Hues beyond blue
+  // (magenta) are clamped to the far-field end.
+  return clamp(hue / (2.0 / 3.0), 0.0, 1.0);
+}
+
+void main() {
+  vec2 uv = FlutterFragCoord().xy / uSize;
+  vec4 src = texture(uSrc, uv);
+
+  float t = jetToT(src.rgb);
+  vec3 col = texture(uLut, vec2(t, 0.5)).rgb;
+
+  // Premultiplied alpha (Flutter fragment shader convention).
+  fragColor = vec4(col * uOpacity, uOpacity);
+}


### PR DESCRIPTION
## What

Replace the baked-in JET (rainbow) palette of the ESDF heatmap layer in the Operate tab with a 7-stop **"deep-navy → coral-red" tech palette**, remapped on the GPU via a Flutter fragment shader.

The source ESDF bytes arrive already colourised (JET, baked upstream in the planning node → backend). Rather than change the data contract, the shader recovers a scalar `t ∈ [0,1]` per pixel from the source hue, then looks up a new colour from a 256×1 palette LUT. Orientation: **red = danger (near obstacle), navy = safe (far field).**

Frontend-only — backend, the WebSocket data contract, and interaction logic are untouched.

## How

- **`shaders/esdf_colormap.frag`** — recovers a scalar from the JET-ish source pixel via HSV hue (robust to JPEG noise), then samples the new colour from the LUT. Near-gray / no-data pixels are pushed to the far-field end.
- **`EsdfColormapLayer`** — decodes the bytes to a `ui.Image`, rasterises the palette gradient into a 256×1 LUT texture once (shared across instances), and paints via `CustomPaint` + shader. Falls back to `Image.memory` when the shader/image isn't ready or the asset fails to load, so behaviour never degrades below the previous implementation.
- The palette lives in one place (`_kEsdfHeatmap` gradient) as the single source of truth — tweak colours there; the shader stays generic.
- Registered the shader in `pubspec.yaml` and swapped the ESDF `Image.memory` block in `operate_tab.dart` for `EsdfColormapLayer`.

## Screenshot

New palette in the Operate tab — a dark-red danger core hugs the obstacle footprint, fading through coral/amber into the teal → navy safe field:

<img width="1792" height="704" alt="20260710-105036" src="https://github.com/user-attachments/assets/3cb33f89-2df9-4d36-978b-a3f4bf9317e1" />
<img width="1720" height="686" alt="image" src="https://github.com/user-attachments/assets/0542c482-f58e-499f-81b7-f5943c1d49e7" />

## Test plan

- [x] `flutter build web --release --no-web-resources-cdn` — builds clean (Flutter 3.41.9).
- [x] Verified on-device: heatmap renders with the new palette (no JET green/yellow bands; maroon → amber → teal → navy present).
- [x] Fallback path preserved (`Image.memory`) when the shader asset is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
