### PR TITLE
fix(unitree): retry DDS channel init until robot NIC is up

### DIFF
--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -8,10 +8,35 @@ from unitree_sdk2py.b2.sport.sport_client import SportClient as SportClientB2
 from std_msgs.msg import Float32, String
 from enum import Enum
 import logging
+import os
 import time
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+# ChannelFactoryInitialize raises "does not match an available interface" when
+# the robot NIC (enP8p1s0) isn't up yet at boot. Retry instead of crashing so
+# the node comes up as soon as the interface appears.
+_IFACE_ATTEMPTS = int(os.environ.get('UNITREE_IFACE_ATTEMPTS', '60'))
+_IFACE_RETRY_SEC = float(os.environ.get('UNITREE_IFACE_RETRY_SEC', '2.0'))
+
+
+def init_channel_with_retry(networkInterface: str):
+    """Initialize the Unitree DDS channel, retrying with a fixed delay until the
+    robot network interface is available. Raises once all attempts are used."""
+    last_err = None
+    for i in range(1, _IFACE_ATTEMPTS + 1):
+        try:
+            return ChannelFactoryInitialize(0, networkInterface)
+        except Exception as e:  # SDK raises bare Exception when iface not up yet
+            last_err = e
+            logger.warning(
+                "unitree channel init on %s failed (attempt %d/%d): %s; retry in %.0fs",
+                networkInterface, i, _IFACE_ATTEMPTS, e, _IFACE_RETRY_SEC)
+            time.sleep(_IFACE_RETRY_SEC)
+    raise RuntimeError(
+        f"unitree channel init on '{networkInterface}' failed after "
+        f"{_IFACE_ATTEMPTS} attempts") from last_err
 
 
 class RobotStatus(Enum):
@@ -22,7 +47,7 @@ class RobotStatus(Enum):
 class Ros2UnitreeManagerNode(Node):
     def __init__(self, networkInterface: str = "enP8p1s0"):
         super().__init__('ros2_unitree_manager')
-        self.channel = ChannelFactoryInitialize(0, networkInterface)
+        self.channel = init_channel_with_retry(networkInterface)
         self.sport_client = SportClientB2()
         self.sport_client.SetTimeout(10.0)
         self.sport_client.Init()


### PR DESCRIPTION
## Problem

`unitree_control` crashes on startup when launched before the robot NIC (`enP8p1s0`) is up. `ChannelFactoryInitialize(0, "enP8p1s0")` raises `Exception: channel factory init error.` with `enP8p1s0: does not match an available interface`, and since the launcher has no restart-on-crash, the node then stays dead until a manual restart. Observed intermittently at boot (whenever the interface isn't ready yet at the moment the node starts).

## Fix

Retry the channel init on failure with a fixed delay, so the node comes up as soon as the interface appears instead of crashing permanently. Tunable via env:

- `UNITREE_IFACE_ATTEMPTS` (default `60`)
- `UNITREE_IFACE_RETRY_SEC` (default `2.0`)

Retrying on the SDK exception is the authoritative signal (it tests the exact DDS bind that must succeed), so no platform-specific interface probing is needed.

## Testing

- Verified on-device: with a bogus interface it logs `attempt N/M` warnings then raises `RuntimeError` (no instant crash); with the real interface up it initializes first try and `/battery` flows through to `/device/status`.

## Follow-up (not in this PR)

The underlying gap is launcher-wide: every child node in `app/backend/node_manager.py` (`_launch_proc`) is crash-and-stay-dead on a boot-time dependency race (NIC, USB camera, DDS discovery). A generic restart-on-crash supervisor there would cover all of them and make per-node retries like this unnecessary. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)