### PR TITLE
feat(map): confirm initial relocalization before activating

### DIFF
--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -248,6 +248,10 @@ class MapNode(Node):
         self.failed_relocalizations = []
 
         self.T_from_map_to_odom = None
+        self.initial_relocalization_observations = []
+        self.initial_relocalization_confirm_required = 3
+        self.initial_relocalization_translation_tolerance = 0.5
+        self.initial_relocalization_yaw_tolerance = np.deg2rad(10.0)
 
         self.pois = {}
         self.poi_index = -1
@@ -341,9 +345,10 @@ class MapNode(Node):
         self.keyframe_mapping(keyframe_image_msg, keyframe_odom_msg, depth_msg)
         image = self.bridge.imgmsg_to_cv2(keyframe_image_msg, desired_encoding="mono8")
 
-        success, pose_in_world = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
+        success, pose_in_world, pose_cov_weight = self.keyframe_relocalization(keyframe_image_msg.header.stamp, image)
         if success:
-            self.compute_transform_from_map_to_odom()
+            timestamp_ns = int(keyframe_image_msg.header.stamp.sec * 1e9) + int(keyframe_image_msg.header.stamp.nanosec)
+            self.handle_relocalization_observation(timestamp_ns, pose_in_world, pose_cov_weight)
 
 
     def keyframe_mapping_with_timer(self, keyframe_image_msg:Image, keyframe_odom_msg:Odometry, depth_msg:Image):
@@ -510,20 +515,84 @@ class MapNode(Node):
         return point_in_world, inliers
 
     @Timer(name="Relocalization loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms")
-    def keyframe_relocalization(self, timestamp, image:np.ndarray) -> tuple[bool, np.ndarray]:
+    def keyframe_relocalization(self, timestamp, image:np.ndarray) -> tuple[bool, np.ndarray, float]:
         features = asyncio.run(self.super_point_extractor.infer(image))
         res, pose_in_camera, pose_cov_weight = self.relocalize_with_depth(image, features, self.K)
         if res:
             # publish the relocalization pose for debug
             pose_in_world = np.linalg.inv(pose_in_camera)
-            timestamp_ns = int(timestamp.sec * 1e9) + int(timestamp.nanosec)
             self.relocation_pub.publish(np2msg(pose_in_world, timestamp, "world", "camera"))
-            self.relocalization_poses[timestamp_ns] = pose_in_world
-            self.relocalization_pose_weights[timestamp_ns] = pose_cov_weight
-            return True, pose_in_world
+            return True, pose_in_world, pose_cov_weight
         else:
             self.failed_relocalizations.append(timestamp)
-            return False, np.eye(4)
+            return False, np.eye(4), -np.inf
+
+    def handle_relocalization_observation(self, timestamp_ns: int, pose_in_world: np.ndarray, pose_cov_weight: float):
+        if timestamp_ns not in self.pose_graph_used_pose:
+            self.get_logger().warning(
+                f"Relocalization timestamp {timestamp_ns} not found in odom pose graph; skipping observation"
+            )
+            return
+
+        if self.T_from_map_to_odom is None:
+            self.try_confirm_initial_relocalization(timestamp_ns, pose_in_world, pose_cov_weight)
+            return
+
+        self.relocalization_poses[timestamp_ns] = pose_in_world
+        self.relocalization_pose_weights[timestamp_ns] = pose_cov_weight
+        self.compute_transform_from_map_to_odom()
+
+    def try_confirm_initial_relocalization(self, timestamp_ns: int, pose_in_world: np.ndarray, pose_cov_weight: float):
+        camera_in_map_world = pose_in_world
+        camera_in_odom_world = self.pose_graph_used_pose[timestamp_ns]
+        observation_T_from_map_to_odom = camera_in_odom_world @ np.linalg.inv(camera_in_map_world)
+
+        if len(self.initial_relocalization_observations) > 0:
+            reference_T = self.initial_relocalization_observations[0][3]
+            translation_error, yaw_error = self.transform_xy_yaw_error(
+                observation_T_from_map_to_odom,
+                reference_T,
+            )
+            if (
+                translation_error > self.initial_relocalization_translation_tolerance
+                or yaw_error > self.initial_relocalization_yaw_tolerance
+            ):
+                self.get_logger().info(
+                    "Initial relocalization candidate changed; reset confirmation "
+                    f"(translation_error={translation_error:.3f}m, "
+                    f"yaw_error={np.rad2deg(yaw_error):.1f}deg)"
+                )
+                self.initial_relocalization_observations = []
+
+        self.initial_relocalization_observations.append(
+            (timestamp_ns, pose_in_world, pose_cov_weight, observation_T_from_map_to_odom)
+        )
+        self.get_logger().info(
+            "Initial relocalization confirmation "
+            f"{len(self.initial_relocalization_observations)}/"
+            f"{self.initial_relocalization_confirm_required}"
+        )
+
+        if len(self.initial_relocalization_observations) < self.initial_relocalization_confirm_required:
+            return
+
+        for observation_timestamp, observation_pose, observation_weight, _ in self.initial_relocalization_observations:
+            self.relocalization_poses[observation_timestamp] = observation_pose
+            self.relocalization_pose_weights[observation_timestamp] = observation_weight
+
+        self.compute_transform_from_map_to_odom()
+        self.get_logger().info(
+            "Initial relocalization confirmed; map->odom transform is now active"
+        )
+        self.initial_relocalization_observations = []
+
+    @staticmethod
+    def transform_xy_yaw_error(T_a: np.ndarray, T_b: np.ndarray) -> tuple[float, float]:
+        translation_error = float(np.linalg.norm(T_a[:2, 3] - T_b[:2, 3]))
+        yaw_a = np.arctan2(T_a[1, 0], T_a[0, 0])
+        yaw_b = np.arctan2(T_b[1, 0], T_b[0, 0])
+        yaw_error = float(np.abs(np.arctan2(np.sin(yaw_a - yaw_b), np.cos(yaw_a - yaw_b))))
+        return translation_error, yaw_error
 
     def save_relocalization_poses(self):
         if self._save_completed:


### PR DESCRIPTION
## Summary

- add an initial relocalization confirmation stage before activating `map -> odom`
- require 3 consistent relocalization observations within 0.5m / 10deg before committing the initial transform
- keep the existing post-localization behavior unchanged: subsequent observations still update `map -> odom` through the existing recent-observation optimization

## Motivation

A single false-positive initial relocalization can immediately set an incorrect `map -> odom` transform. Once that transform is active, the rest of the localization/navigation stack may be biased by the wrong initial state, making it hard to recover.

This change avoids the `first success wins` behavior during startup. The first successful relocalization now becomes a candidate, and the transform is activated only after multiple observations agree with it.

## Testing

- `python3 -m py_compile tinynav/core/map_node.py`
