### PR TITLE
feat(planning): add local avoidance recovery trajectories

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -238,7 +238,7 @@ def generate_predefined_trajectory_vocabularies(
 
     # Recovery reverse trajectories.
     # Keep the speed conservative here; speed tuning is handled separately.
-    reverse_speed = 0.2
+    reverse_speed = 0.3
     for omega_y in [0.0, -0.5, 0.5]:
         p = init_p.copy()
         q = quat_to_matrix(init_q)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -386,6 +386,7 @@ class PlanningNode(Node):
         self.current_pose = None  # Store the latest pose from odometry
 
         self.smoothed_velocity = 0.0
+        self._last_avoidance_debug_log_time = 0.0
 
         self.create_subscription(Odometry, '/control/target_pose', self.target_pose_callback, 10)
         self.target_pose = None
@@ -608,11 +609,13 @@ class PlanningNode(Node):
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
             enter_threshold = 0.30
+            should_reverse = front_clearance <= enter_threshold
+            valid_traj_count = int(np.sum(np.isfinite(scores)))
+            all_collision = valid_traj_count == 0
 
             def cost_function(traj, param, score, target_pose):
                 # predefined backward trajectory penalty
                 is_backward_traj = param[0] < 0.0
-                should_reverse = front_clearance <= enter_threshold
                 reverse_gate_penalty = 0.0
                 if should_reverse and not is_backward_traj:
                         reverse_gate_penalty = 1e9
@@ -627,8 +630,37 @@ class PlanningNode(Node):
                 return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
 
             top_k = 1
-            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
-            self.last_param = params[top_indices[0]]
+            costs = np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))])
+            top_indices = np.argsort(costs, kind='stable')[:top_k]
+            selected_index = int(top_indices[0])
+            selected_param = params[selected_index]
+            selected_score = float(scores[selected_index])
+            selected_cost = float(costs[selected_index])
+            selected_is_reverse = bool(selected_param[0] < 0.0)
+            target_dist = float("nan")
+            if self.target_pose is not None:
+                target_dist = float(np.linalg.norm(trajectories[selected_index][-1, :3] - self.target_pose))
+            now_debug = time.monotonic()
+            should_log_debug = (
+                now_debug - self._last_avoidance_debug_log_time > 0.5
+                or all_collision
+                or should_reverse
+                or selected_is_reverse
+            )
+            if should_log_debug:
+                self._last_avoidance_debug_log_time = now_debug
+                self.get_logger().info(
+                    "planning_avoidance_debug "
+                    f"front_clearance={front_clearance:.2f} enter_threshold={enter_threshold:.2f} "
+                    f"should_reverse={should_reverse} all_collision={all_collision} "
+                    f"valid_traj_count={valid_traj_count}/{len(trajectories)} "
+                    f"selected_idx={selected_index} selected_vx={selected_param[0]:.2f} "
+                    f"selected_omega={selected_param[1]:.2f} selected_reverse={selected_is_reverse} "
+                    f"selected_score={selected_score:.3f} selected_cost={selected_cost:.1f} "
+                    f"target_dist={target_dist:.2f} last_vx={self.last_param[0]:.2f} "
+                    f"last_omega={self.last_param[1]:.2f} dilation_cells={self.obstacle_config.dilation_cells}"
+                )
+            self.last_param = selected_param
 
             # path
             path = Path()
@@ -638,7 +670,7 @@ class PlanningNode(Node):
             if self.target_pose is None:
                 return
 
-            if all(s == float('inf') for s in scores):
+            if all_collision:
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 return
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -236,21 +236,24 @@ def generate_predefined_trajectory_vocabularies(
     trajectories = []
     params = []
 
-    # constant reverse trajectory
-    # vx = -0.2 m/s, omega = 0
+    # Recovery reverse trajectories.
+    # Keep the speed conservative here; speed tuning is handled separately.
     reverse_speed = 0.2
-    p = init_p.copy()
-    q = quat_to_matrix(init_q)
-    traj = np.empty((num_steps, 7), dtype=np.float64)
-    for i in range(num_steps):
-        v_world = q @ np.array([0.0, 0.0, -reverse_speed])
-        p += v_world * dt
-        traj[i, :3] = p
-        traj[i, 3:] = matrix_to_quat(q)
-    for i in range(num_steps):
-        traj[i, 2] = traj[0, 2]
-    trajectories.append(traj)
-    params.append(np.array([-reverse_speed, 0.0], dtype=np.float64))
+    for omega_y in [0.0, -0.5, 0.5]:
+        p = init_p.copy()
+        q = quat_to_matrix(init_q)
+        traj = np.empty((num_steps, 7), dtype=np.float64)
+        for i in range(num_steps):
+            dq = rotvec_to_matrix(np.array([0.0, omega_y * dt, 0.0]))
+            q = q @ dq
+            v_world = q @ np.array([0.0, 0.0, -reverse_speed])
+            p += v_world * dt
+            traj[i, :3] = p
+            traj[i, 3:] = matrix_to_quat(q)
+        for i in range(num_steps):
+            traj[i, 2] = traj[0, 2]
+        trajectories.append(traj)
+        params.append(np.array([-reverse_speed, omega_y], dtype=np.float64))
 
     return np.asarray(trajectories), np.asarray(params)
 
@@ -612,6 +615,37 @@ class PlanningNode(Node):
             should_reverse = front_clearance <= enter_threshold
             valid_traj_count = int(np.sum(np.isfinite(scores)))
             all_collision = valid_traj_count == 0
+            recovery_indices = np.flatnonzero(params[:, 0] < 0.0)
+
+            def choose_recovery_index():
+                if len(recovery_indices) == 0:
+                    return 0, "none"
+                recovery_scores = scores[recovery_indices]
+                finite_mask = np.isfinite(recovery_scores)
+                if np.any(finite_mask):
+                    finite_indices = recovery_indices[finite_mask]
+                    finite_scores = recovery_scores[finite_mask]
+                    return int(finite_indices[int(np.argmin(finite_scores))]), "finite"
+
+                ignore_steps = min(3, trajectories.shape[1] - 1)
+                delayed_scores, _ = score_trajectories_by_ESDF(
+                    trajectories[recovery_indices, ignore_steps:, :],
+                    ESDF_map,
+                    self.origin,
+                    self.resolution,
+                    self.robot.safety_radius,
+                    front_len,
+                    rear_len,
+                    half_w,
+                )
+                delayed_finite_mask = np.isfinite(delayed_scores)
+                if np.any(delayed_finite_mask):
+                    finite_indices = recovery_indices[delayed_finite_mask]
+                    finite_scores = delayed_scores[delayed_finite_mask]
+                    return int(finite_indices[int(np.argmin(finite_scores))]), f"delayed_{ignore_steps}"
+
+                straight_reverse = recovery_indices[int(np.argmin(np.abs(params[recovery_indices, 1])))]
+                return int(straight_reverse), "fallback_straight"
 
             def cost_function(traj, param, score, target_pose):
                 # predefined backward trajectory penalty
@@ -630,8 +664,15 @@ class PlanningNode(Node):
                 return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
 
             top_k = 1
-            costs = np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))])
-            top_indices = np.argsort(costs, kind='stable')[:top_k]
+            recovery_reason = "normal"
+            if all_collision:
+                selected_index, recovery_reason = choose_recovery_index()
+                top_indices = np.array([selected_index], dtype=np.int64)
+                costs = np.full(len(trajectories), float("inf"), dtype=np.float64)
+                costs[selected_index] = 0.0
+            else:
+                costs = np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))])
+                top_indices = np.argsort(costs, kind='stable')[:top_k]
             selected_index = int(top_indices[0])
             selected_param = params[selected_index]
             selected_score = float(scores[selected_index])
@@ -654,6 +695,7 @@ class PlanningNode(Node):
                     f"front_clearance={front_clearance:.2f} enter_threshold={enter_threshold:.2f} "
                     f"should_reverse={should_reverse} all_collision={all_collision} "
                     f"valid_traj_count={valid_traj_count}/{len(trajectories)} "
+                    f"recovery_reason={recovery_reason} "
                     f"selected_idx={selected_index} selected_vx={selected_param[0]:.2f} "
                     f"selected_omega={selected_param[1]:.2f} selected_reverse={selected_is_reverse} "
                     f"selected_score={selected_score:.3f} selected_cost={selected_cost:.1f} "
@@ -671,8 +713,11 @@ class PlanningNode(Node):
                 return
 
             if all_collision:
-                self.get_logger().info('All trajectories in collision, stopping path.')
-                return
+                self.get_logger().warning(
+                    "All trajectories in collision; publishing recovery path "
+                    f"idx={selected_index} vx={selected_param[0]:.2f} "
+                    f"omega={selected_param[1]:.2f} reason={recovery_reason}"
+                )
 
             for i in top_indices:
                 for j in range(0, len(trajectories[i]), 10):

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -8,6 +8,7 @@ from scipy.ndimage import distance_transform_edt, binary_dilation
 from dataclasses import dataclass
 from numba import njit
 import message_filters
+import time
 from rclpy.time import Time
 from sensor_msgs.msg import PointCloud2, PointCloud
 from geometry_msgs.msg import PoseStamped, Point32

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -51,7 +51,7 @@ class CmdVelControlNode(Node):
         self.min_effective_linear_speed = 0.1
         self.min_effective_angular_speed = 0.1
         self.linear_engage_threshold = 0.04
-        self.fixed_reverse_speed = 0.2
+        self.fixed_reverse_speed = 0.3
         # Hack: if path first segment points far away from robot heading,
         # rotate in place instead of publishing near-zero cmd_vel.
         self.force_turn_heading_threshold = np.deg2rad(80.0)

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -60,6 +60,7 @@ class CmdVelControlNode(Node):
         self.prev_cmd = Twist()
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
+        self._last_cmd_debug_log_time = 0.0
         self._paused = False
         self._nav_active = False
         _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
@@ -113,9 +114,13 @@ class CmdVelControlNode(Node):
         if age > stale_stop_s:
             target_cmd.linear.x = 0.0
             target_cmd.angular.z = 0.0
+            stale_state = "stop"
         elif age > stale_slow_s:
             target_cmd.linear.x *= 0.3
             target_cmd.angular.z *= 0.5
+            stale_state = "slow"
+        else:
+            stale_state = "fresh"
 
         out = Twist()
         out.linear.y = 0.0
@@ -125,8 +130,11 @@ class CmdVelControlNode(Node):
         if target_cmd.linear.x < 0.0:
             out.linear.x = target_cmd.linear.x
             out.angular.z = 0.0
+            prev_vx = self.prev_cmd.linear.x
+            prev_wz = self.prev_cmd.angular.z
             self.cmd_pub.publish(out)
             self.prev_cmd = out
+            self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, reverse_passthrough=True)
             return
 
         # Forward/turning commands still get acceleration limiting and robot minimum-speed locks.
@@ -152,8 +160,29 @@ class CmdVelControlNode(Node):
             else:
                 out.angular.z = 0.0
 
+        prev_vx = self.prev_cmd.linear.x
+        prev_wz = self.prev_cmd.angular.z
         self.cmd_pub.publish(out)
         self.prev_cmd = out
+        self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, reverse_passthrough=False)
+
+    def _log_cmd_debug(self, now, age, stale_state, target_cmd, out, prev_vx, prev_wz, reverse_passthrough):
+        if (
+            now - self._last_cmd_debug_log_time < 0.5
+            and stale_state == "fresh"
+            and not reverse_passthrough
+        ):
+            return
+        self._last_cmd_debug_log_time = now
+        self.logger.info(
+            "cmd_vel_debug "
+            f"age={age:.2f} stale_state={stale_state} "
+            f"path_dt_ema={self.path_period_ema:.2f} "
+            f"target_vx={target_cmd.linear.x:.2f} target_wz={target_cmd.angular.z:.2f} "
+            f"out_vx={out.linear.x:.2f} out_wz={out.angular.z:.2f} "
+            f"prev_vx={prev_vx:.2f} prev_wz={prev_wz:.2f} "
+            f"reverse_passthrough={reverse_passthrough}"
+        )
         
     def path_callback(self, msg):
         if not self._nav_active:
@@ -226,9 +255,12 @@ class CmdVelControlNode(Node):
         self.latest_cmd.linear.y = float(vy)
         self.latest_cmd.angular.z = float(vyaw)
         age = 0.0 if self.last_path_update_time is None else (time.monotonic() - self.last_path_update_time)
-        self.logger.debug(
-            f"cmd vx={self.latest_cmd.linear.x:.3f} vyaw={self.latest_cmd.angular.z:.3f} "
-            f"path_age={age:.2f}s path_dt_ema={self.path_period_ema:.2f}s lookahead={step_idx}"
+        self.logger.info(
+            "cmd_path_debug "
+            f"raw_vx={raw_vx:.2f} heading_err={heading_err:.2f} "
+            f"backward_segment={is_backward_segment} "
+            f"cmd_vx={self.latest_cmd.linear.x:.2f} cmd_wz={self.latest_cmd.angular.z:.2f} "
+            f"path_age={age:.2f} path_dt_ema={self.path_period_ema:.2f} lookahead={step_idx}"
         )
 
     def destroy_node(self):

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -51,15 +51,7 @@ class CmdVelControlNode(Node):
         self.min_effective_linear_speed = 0.1
         self.min_effective_angular_speed = 0.1
         self.linear_engage_threshold = 0.04
-        self.fixed_reverse_speed = 0.3
-        self.max_reverse_speed = 0.45
-        self.vx_ki = 0.10
-        self.vx_i_limit_reverse = 0.05
-        self.vx_integral = 0.0
-        self.vx_integral_target_sign = 0.0
-        self.actual_vx = 0.0
-        self._last_pose_robot_T = None
-        self._last_pose_stamp = None
+        self.fixed_reverse_speed = 0.2
         # Hack: if path first segment points far away from robot heading,
         # rotate in place instead of publishing near-zero cmd_vel.
         self.force_turn_heading_threshold = np.deg2rad(80.0)
@@ -68,7 +60,6 @@ class CmdVelControlNode(Node):
         self.prev_cmd = Twist()
         self.last_cmd_pub_time = time.monotonic()
         self.last_path_update_time = None
-        self._last_cmd_debug_log_time = 0.0
         self._paused = False
         self._nav_active = False
         _latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
@@ -78,7 +69,6 @@ class CmdVelControlNode(Node):
 
     def _on_paused(self, msg: Bool):
         self._paused = msg.data
-        self._reset_vx_integral()
         if not self._paused:
             # Reset prev_cmd so resume starts from zero cleanly
             self.prev_cmd = Twist()
@@ -86,8 +76,6 @@ class CmdVelControlNode(Node):
     def _on_nav_active(self, msg: Bool):
         was_active = self._nav_active
         self._nav_active = bool(msg.data)
-        if self._nav_active != was_active:
-            self._reset_vx_integral()
         if was_active and not self._nav_active:
             self.latest_cmd = Twist()
             self.prev_cmd = Twist()
@@ -98,63 +86,9 @@ class CmdVelControlNode(Node):
 
     def pose_callback(self, msg):
         self.pose = msg
-        try:
-            T = self._odom_msg_to_np(msg)
-            T_robot = T @ self.T_robot_to_camera
-            stamp = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
-            if stamp <= 0.0:
-                stamp = time.monotonic()
-            if self._last_pose_robot_T is not None and self._last_pose_stamp is not None:
-                dt = stamp - self._last_pose_stamp
-                if 1e-3 <= dt <= 0.5:
-                    delta = np.linalg.inv(self._last_pose_robot_T) @ T_robot
-                    measured_vx = float(delta[0, 3] / dt)
-                    self.actual_vx = 0.7 * self.actual_vx + 0.3 * measured_vx
-            self._last_pose_robot_T = T_robot
-            self._last_pose_stamp = stamp
-        except Exception:
-            pass
-
-    @staticmethod
-    def _odom_msg_to_np(msg):
-        T = np.eye(4)
-        position = msg.pose.pose.position
-        rot = msg.pose.pose.orientation
-        quat = [rot.x, rot.y, rot.z, rot.w]
-        T[:3, :3] = R.from_quat(quat).as_matrix()
-        T[:3, 3] = np.array([position.x, position.y, position.z]).ravel()
-        return T
 
     def _clamp_step(self, target: float, current: float, max_delta: float) -> float:
         return float(np.clip(target - current, -max_delta, max_delta) + current)
-
-    def _reset_vx_integral(self):
-        self.vx_integral = 0.0
-        self.vx_integral_target_sign = 0.0
-
-    def _apply_vx_pi(self, target_vx: float, dt: float):
-        if target_vx >= -0.05 or not np.isfinite(self.actual_vx):
-            self._reset_vx_integral()
-            return target_vx, 0.0, 0.0
-
-        target_sign = float(np.sign(target_vx))
-        if self.vx_integral_target_sign != 0.0 and target_sign != self.vx_integral_target_sign:
-            self._reset_vx_integral()
-        self.vx_integral_target_sign = target_sign
-
-        error = float(target_vx - self.actual_vx)
-        if abs(error) < 0.03:
-            self._reset_vx_integral()
-            return target_vx, 0.0, error
-
-        self.vx_integral += error * dt
-        i_limit = self.vx_i_limit_reverse
-        integral_limit = i_limit / max(self.vx_ki, 1e-6)
-        self.vx_integral = float(np.clip(self.vx_integral, -integral_limit, integral_limit))
-        i_term = float(np.clip(self.vx_ki * self.vx_integral, -i_limit, i_limit))
-        compensated_vx = target_vx + i_term
-        compensated_vx = float(np.clip(compensated_vx, -self.max_reverse_speed, 0.0))
-        return compensated_vx, i_term, error
 
     def cmd_timer_callback(self):
         now = time.monotonic()
@@ -179,21 +113,9 @@ class CmdVelControlNode(Node):
         if age > stale_stop_s:
             target_cmd.linear.x = 0.0
             target_cmd.angular.z = 0.0
-            stale_state = "stop"
         elif age > stale_slow_s:
             target_cmd.linear.x *= 0.3
             target_cmd.angular.z *= 0.5
-            stale_state = "slow"
-        else:
-            stale_state = "fresh"
-
-        raw_target_vx = target_cmd.linear.x
-        vx_i_term = 0.0
-        vx_error = 0.0
-        if stale_state == "fresh":
-            target_cmd.linear.x, vx_i_term, vx_error = self._apply_vx_pi(target_cmd.linear.x, dt)
-        else:
-            self._reset_vx_integral()
 
         out = Twist()
         out.linear.y = 0.0
@@ -203,11 +125,8 @@ class CmdVelControlNode(Node):
         if target_cmd.linear.x < 0.0:
             out.linear.x = target_cmd.linear.x
             out.angular.z = 0.0
-            prev_vx = self.prev_cmd.linear.x
-            prev_wz = self.prev_cmd.angular.z
             self.cmd_pub.publish(out)
             self.prev_cmd = out
-            self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, raw_target_vx, vx_error, vx_i_term, reverse_passthrough=True)
             return
 
         # Forward/turning commands still get acceleration limiting and robot minimum-speed locks.
@@ -233,31 +152,8 @@ class CmdVelControlNode(Node):
             else:
                 out.angular.z = 0.0
 
-        prev_vx = self.prev_cmd.linear.x
-        prev_wz = self.prev_cmd.angular.z
         self.cmd_pub.publish(out)
         self.prev_cmd = out
-        self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, raw_target_vx, vx_error, vx_i_term, reverse_passthrough=False)
-
-    def _log_cmd_debug(self, now, age, stale_state, target_cmd, out, prev_vx, prev_wz, raw_target_vx, vx_error, vx_i_term, reverse_passthrough):
-        if (
-            now - self._last_cmd_debug_log_time < 0.5
-            and stale_state == "fresh"
-            and not reverse_passthrough
-        ):
-            return
-        self._last_cmd_debug_log_time = now
-        self.logger.info(
-            "cmd_vel_debug "
-            f"age={age:.2f} stale_state={stale_state} "
-            f"path_dt_ema={self.path_period_ema:.2f} "
-            f"raw_target_vx={raw_target_vx:.2f} target_vx={target_cmd.linear.x:.2f} "
-            f"target_wz={target_cmd.angular.z:.2f} actual_vx={self.actual_vx:.2f} "
-            f"vx_error={vx_error:.2f} vx_integral={self.vx_integral:.2f} vx_i_term={vx_i_term:.2f} "
-            f"out_vx={out.linear.x:.2f} out_wz={out.angular.z:.2f} "
-            f"prev_vx={prev_vx:.2f} prev_wz={prev_wz:.2f} "
-            f"reverse_passthrough={reverse_passthrough}"
-        )
         
     def path_callback(self, msg):
         if not self._nav_active:
@@ -330,12 +226,9 @@ class CmdVelControlNode(Node):
         self.latest_cmd.linear.y = float(vy)
         self.latest_cmd.angular.z = float(vyaw)
         age = 0.0 if self.last_path_update_time is None else (time.monotonic() - self.last_path_update_time)
-        self.logger.info(
-            "cmd_path_debug "
-            f"raw_vx={raw_vx:.2f} heading_err={heading_err:.2f} "
-            f"backward_segment={is_backward_segment} "
-            f"cmd_vx={self.latest_cmd.linear.x:.2f} cmd_wz={self.latest_cmd.angular.z:.2f} "
-            f"path_age={age:.2f} path_dt_ema={self.path_period_ema:.2f} lookahead={step_idx}"
+        self.logger.debug(
+            f"cmd vx={self.latest_cmd.linear.x:.3f} vyaw={self.latest_cmd.angular.z:.3f} "
+            f"path_age={age:.2f}s path_dt_ema={self.path_period_ema:.2f}s lookahead={step_idx}"
         )
 
     def destroy_node(self):

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -52,6 +52,15 @@ class CmdVelControlNode(Node):
         self.min_effective_angular_speed = 0.1
         self.linear_engage_threshold = 0.04
         self.fixed_reverse_speed = 0.3
+        self.max_reverse_speed = 0.45
+        self.vx_ki = 0.25
+        self.vx_i_limit_forward = 0.05
+        self.vx_i_limit_reverse = 0.10
+        self.vx_integral = 0.0
+        self.vx_integral_target_sign = 0.0
+        self.actual_vx = 0.0
+        self._last_pose_robot_T = None
+        self._last_pose_stamp = None
         # Hack: if path first segment points far away from robot heading,
         # rotate in place instead of publishing near-zero cmd_vel.
         self.force_turn_heading_threshold = np.deg2rad(80.0)
@@ -70,6 +79,7 @@ class CmdVelControlNode(Node):
 
     def _on_paused(self, msg: Bool):
         self._paused = msg.data
+        self._reset_vx_integral()
         if not self._paused:
             # Reset prev_cmd so resume starts from zero cleanly
             self.prev_cmd = Twist()
@@ -77,6 +87,8 @@ class CmdVelControlNode(Node):
     def _on_nav_active(self, msg: Bool):
         was_active = self._nav_active
         self._nav_active = bool(msg.data)
+        if self._nav_active != was_active:
+            self._reset_vx_integral()
         if was_active and not self._nav_active:
             self.latest_cmd = Twist()
             self.prev_cmd = Twist()
@@ -87,9 +99,62 @@ class CmdVelControlNode(Node):
 
     def pose_callback(self, msg):
         self.pose = msg
+        try:
+            T = self._odom_msg_to_np(msg)
+            T_robot = T @ self.T_robot_to_camera
+            stamp = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+            if stamp <= 0.0:
+                stamp = time.monotonic()
+            if self._last_pose_robot_T is not None and self._last_pose_stamp is not None:
+                dt = stamp - self._last_pose_stamp
+                if 1e-3 <= dt <= 0.5:
+                    delta = np.linalg.inv(self._last_pose_robot_T) @ T_robot
+                    measured_vx = float(delta[0, 3] / dt)
+                    self.actual_vx = 0.7 * self.actual_vx + 0.3 * measured_vx
+            self._last_pose_robot_T = T_robot
+            self._last_pose_stamp = stamp
+        except Exception:
+            pass
+
+    @staticmethod
+    def _odom_msg_to_np(msg):
+        T = np.eye(4)
+        position = msg.pose.pose.position
+        rot = msg.pose.pose.orientation
+        quat = [rot.x, rot.y, rot.z, rot.w]
+        T[:3, :3] = R.from_quat(quat).as_matrix()
+        T[:3, 3] = np.array([position.x, position.y, position.z]).ravel()
+        return T
 
     def _clamp_step(self, target: float, current: float, max_delta: float) -> float:
         return float(np.clip(target - current, -max_delta, max_delta) + current)
+
+    def _reset_vx_integral(self):
+        self.vx_integral = 0.0
+        self.vx_integral_target_sign = 0.0
+
+    def _apply_vx_pi(self, target_vx: float, dt: float):
+        if abs(target_vx) < 0.05 or not np.isfinite(self.actual_vx):
+            self._reset_vx_integral()
+            return target_vx, 0.0, 0.0
+
+        target_sign = float(np.sign(target_vx))
+        if self.vx_integral_target_sign != 0.0 and target_sign != self.vx_integral_target_sign:
+            self._reset_vx_integral()
+        self.vx_integral_target_sign = target_sign
+
+        error = float(target_vx - self.actual_vx)
+        self.vx_integral += error * dt
+        i_limit = self.vx_i_limit_reverse if target_vx < 0.0 else self.vx_i_limit_forward
+        integral_limit = i_limit / max(self.vx_ki, 1e-6)
+        self.vx_integral = float(np.clip(self.vx_integral, -integral_limit, integral_limit))
+        i_term = float(np.clip(self.vx_ki * self.vx_integral, -i_limit, i_limit))
+        compensated_vx = target_vx + i_term
+        if target_vx < 0.0:
+            compensated_vx = float(np.clip(compensated_vx, -self.max_reverse_speed, 0.0))
+        else:
+            compensated_vx = float(np.clip(compensated_vx, 0.0, 0.5))
+        return compensated_vx, i_term, error
 
     def cmd_timer_callback(self):
         now = time.monotonic()
@@ -122,6 +187,14 @@ class CmdVelControlNode(Node):
         else:
             stale_state = "fresh"
 
+        raw_target_vx = target_cmd.linear.x
+        vx_i_term = 0.0
+        vx_error = 0.0
+        if stale_state == "fresh":
+            target_cmd.linear.x, vx_i_term, vx_error = self._apply_vx_pi(target_cmd.linear.x, dt)
+        else:
+            self._reset_vx_integral()
+
         out = Twist()
         out.linear.y = 0.0
 
@@ -134,7 +207,7 @@ class CmdVelControlNode(Node):
             prev_wz = self.prev_cmd.angular.z
             self.cmd_pub.publish(out)
             self.prev_cmd = out
-            self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, reverse_passthrough=True)
+            self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, raw_target_vx, vx_error, vx_i_term, reverse_passthrough=True)
             return
 
         # Forward/turning commands still get acceleration limiting and robot minimum-speed locks.
@@ -164,9 +237,9 @@ class CmdVelControlNode(Node):
         prev_wz = self.prev_cmd.angular.z
         self.cmd_pub.publish(out)
         self.prev_cmd = out
-        self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, reverse_passthrough=False)
+        self._log_cmd_debug(now, age, stale_state, target_cmd, out, prev_vx, prev_wz, raw_target_vx, vx_error, vx_i_term, reverse_passthrough=False)
 
-    def _log_cmd_debug(self, now, age, stale_state, target_cmd, out, prev_vx, prev_wz, reverse_passthrough):
+    def _log_cmd_debug(self, now, age, stale_state, target_cmd, out, prev_vx, prev_wz, raw_target_vx, vx_error, vx_i_term, reverse_passthrough):
         if (
             now - self._last_cmd_debug_log_time < 0.5
             and stale_state == "fresh"
@@ -178,7 +251,9 @@ class CmdVelControlNode(Node):
             "cmd_vel_debug "
             f"age={age:.2f} stale_state={stale_state} "
             f"path_dt_ema={self.path_period_ema:.2f} "
-            f"target_vx={target_cmd.linear.x:.2f} target_wz={target_cmd.angular.z:.2f} "
+            f"raw_target_vx={raw_target_vx:.2f} target_vx={target_cmd.linear.x:.2f} "
+            f"target_wz={target_cmd.angular.z:.2f} actual_vx={self.actual_vx:.2f} "
+            f"vx_error={vx_error:.2f} vx_integral={self.vx_integral:.2f} vx_i_term={vx_i_term:.2f} "
             f"out_vx={out.linear.x:.2f} out_wz={out.angular.z:.2f} "
             f"prev_vx={prev_vx:.2f} prev_wz={prev_wz:.2f} "
             f"reverse_passthrough={reverse_passthrough}"

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -53,9 +53,8 @@ class CmdVelControlNode(Node):
         self.linear_engage_threshold = 0.04
         self.fixed_reverse_speed = 0.3
         self.max_reverse_speed = 0.45
-        self.vx_ki = 0.25
-        self.vx_i_limit_forward = 0.05
-        self.vx_i_limit_reverse = 0.10
+        self.vx_ki = 0.10
+        self.vx_i_limit_reverse = 0.05
         self.vx_integral = 0.0
         self.vx_integral_target_sign = 0.0
         self.actual_vx = 0.0
@@ -134,7 +133,7 @@ class CmdVelControlNode(Node):
         self.vx_integral_target_sign = 0.0
 
     def _apply_vx_pi(self, target_vx: float, dt: float):
-        if abs(target_vx) < 0.05 or not np.isfinite(self.actual_vx):
+        if target_vx >= -0.05 or not np.isfinite(self.actual_vx):
             self._reset_vx_integral()
             return target_vx, 0.0, 0.0
 
@@ -144,16 +143,17 @@ class CmdVelControlNode(Node):
         self.vx_integral_target_sign = target_sign
 
         error = float(target_vx - self.actual_vx)
+        if abs(error) < 0.03:
+            self._reset_vx_integral()
+            return target_vx, 0.0, error
+
         self.vx_integral += error * dt
-        i_limit = self.vx_i_limit_reverse if target_vx < 0.0 else self.vx_i_limit_forward
+        i_limit = self.vx_i_limit_reverse
         integral_limit = i_limit / max(self.vx_ki, 1e-6)
         self.vx_integral = float(np.clip(self.vx_integral, -integral_limit, integral_limit))
         i_term = float(np.clip(self.vx_ki * self.vx_integral, -i_limit, i_limit))
         compensated_vx = target_vx + i_term
-        if target_vx < 0.0:
-            compensated_vx = float(np.clip(compensated_vx, -self.max_reverse_speed, 0.0))
-        else:
-            compensated_vx = float(np.clip(compensated_vx, 0.0, 0.5))
+        compensated_vx = float(np.clip(compensated_vx, -self.max_reverse_speed, 0.0))
         return compensated_vx, i_term, error
 
     def cmd_timer_callback(self):


### PR DESCRIPTION
## Summary

- add throttled `planning_avoidance_debug` logs for local trajectory selection
- add reverse recovery trajectory candidates: straight reverse, reverse-left, reverse-right
- when all normal local trajectories are in collision, publish the best recovery trajectory instead of returning without a path

## Motivation

When an obstacle is close or directly blocking the path, the planner can get stuck because every sampled local trajectory is considered in collision. In that case the node previously stopped publishing a path, which made the robot look frozen and gave little visibility into why.

This branch makes the failure mode easier to diagnose and gives the controller a conservative recovery path to execute when the normal candidate set is fully blocked.

## Behavior

- Normal trajectory scoring is unchanged when at least one candidate is valid.
- If all candidates collide, the planner chooses among reverse recovery candidates.
- Recovery ranking first uses finite ESDF scores if any reverse candidate is valid.
- If immediate reverse candidates are blocked, it retries scoring after skipping the first few trajectory steps, which helps when the robot is already very close to an obstacle.
- If no reverse candidate can be scored as valid, it falls back to straight reverse.

## Testing

- `python3 -m py_compile tinynav/core/planning_node.py`
