### PR TITLE
tool: backfill the two capture-path priors, split out of tinynav-pilot

### DIFF
--- a/tool/backfill_path_priors.py
+++ b/tool/backfill_path_priors.py
@@ -1,0 +1,108 @@
+"""Backfill the two capture-path priors that older maps predate.
+
+`build_map_node` grew these after the first maps were captured:
+
+  - `path_climb.npy`  — stair hint (map_node -> /planning/on_stairs)
+  - `path_speed.npy`  — capture-speed prior (map_node -> /planning/speed_cap)
+
+Both are pure functions of `poses.npy`, so a map captured before they existed can
+be brought up to date without re-capturing.
+
+This lives in the fork because the priors do: `tinynav.core.path_speed` and
+`tinynav.core.stair_hint` compute them and only this branch's map_node reads them.
+Its companion — the DINOv2 patch VLAD relocalization index, which upstream
+map_node requires — is backfilled by `deploy/backfill_map_priors.py` in
+tinynav-pilot, which stays pin-agnostic by depending on nothing this branch adds.
+Run both when a pre-existing map needs to be navigable on this branch.
+
+No ROS, no GPU, no TensorRT: just numpy over the stored poses. Safe to run against
+a live stack, though `map_node` reads these at map load, so restart it afterwards
+to pick them up.
+
+    python3 tool/backfill_path_priors.py
+
+Idempotent: each artifact is skipped when already present (`--force` recomputes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+
+DEFAULT_MAPS_ROOT = "/tinynav/tinynav_db/maps"
+
+
+def _map_dirs(maps_root: str, names: list[str] | None) -> list[str]:
+    if names:
+        return [os.path.join(maps_root, n) for n in names]
+    out = []
+    for name in sorted(os.listdir(maps_root)):
+        path = os.path.join(maps_root, name)
+        # Skip the 'map'/'active' symlinks and any half-built capture.
+        if os.path.islink(path) or not os.path.isdir(path):
+            continue
+        if os.path.exists(os.path.join(path, "poses.npy")):
+            out.append(path)
+    return out
+
+
+def backfill_path_priors(map_path: str, poses: dict, force: bool, dry_run: bool) -> None:
+    from tinynav.core.path_speed import compute_path_speed
+    from tinynav.core.stair_hint import compute_path_climb
+
+    for filename, compute, describe in (
+        ("path_climb.npy", compute_path_climb,
+         lambda a: f"{int((a[:, 3] >= 0.5).sum())}/{len(a)} samples climbing"),
+        ("path_speed.npy", compute_path_speed,
+         lambda a: f"median capture speed {np.nanmedian(a[:, 3]):.2f} m/s"),
+    ):
+        out_path = os.path.join(map_path, filename)
+        if os.path.exists(out_path) and not force:
+            print(f"  {filename}: present, skipping")
+            continue
+        if dry_run:
+            print(f"  {filename}: WOULD compute")
+            continue
+        array = compute(poses)
+        np.save(out_path, array)
+        print(f"  {filename}: saved ({describe(array)})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--maps-root", default=DEFAULT_MAPS_ROOT)
+    parser.add_argument("--map", action="append", dest="maps",
+                        help="map directory name; repeatable. Default: every map under --maps-root")
+    parser.add_argument("--force", action="store_true",
+                        help="recompute artifacts that already exist")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="report what is missing without writing")
+    args = parser.parse_args()
+
+    map_paths = _map_dirs(args.maps_root, args.maps)
+    if not map_paths:
+        print(f"no maps found under {args.maps_root}", file=sys.stderr)
+        return 1
+
+    failed = []
+    for map_path in map_paths:
+        print(f"{map_path}")
+        try:
+            poses = np.load(f"{map_path}/poses.npy", allow_pickle=True).item()
+            backfill_path_priors(map_path, poses, args.force, args.dry_run)
+        except Exception as e:
+            print(f"  FAILED: {e}", file=sys.stderr)
+            failed.append(map_path)
+
+    if failed:
+        print(f"\n{len(failed)}/{len(map_paths)} maps failed: {failed}", file=sys.stderr)
+        return 1
+    print(f"\n{len(map_paths)} map(s) up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Splits the capture-path prior backfill out of tinynav-pilot and into this branch, where the code it depends on lives.

## Why it moved

`tinynav-pilot`'s `deploy/backfill_map_priors.py` backfilled two unrelated things: this branch's two capture-path priors, and the DINOv2 patch VLAD relocalization index that upstream `map_node` requires (#198). That was fine while pilot pinned tinynav to this fork. It broke the moment pilot's `main` pinned plain `UniflexAI/tinynav@main`:

```
FAILED: No module named 'tinynav.core.path_speed'
1/1 maps failed
```

The path-prior step ran first and unconditionally, so the ImportError killed the run before the VLAD backfill — the half that was actually needed, since `map_node` raises on a map with no `vlad_centres` and re-capturing was the only alternative.

Splitting on the dependency boundary fixes it properly: this script needs `tinynav.core.path_speed` / `tinynav.core.stair_hint` and only this branch's `map_node` reads its output, so it belongs here. Pilot keeps one script that depends on nothing the fork adds, identical on every pilot branch, and rebasing this fork never touches it.

## What it does

`path_climb.npy` (→ `/planning/on_stairs`) and `path_speed.npy` (→ `/planning/speed_cap`) are pure functions of `poses.npy`, so any map captured before they existed can be brought up to date in place.

No ROS, no GPU, no TensorRT — plain numpy over the stored poses, so unlike the VLAD backfill it needs none of the container plumbing:

```
python3 tool/backfill_path_priors.py
```

Idempotent; each artifact is skipped when present, `--force` recomputes. `map_node` reads these at map load, so restart it afterwards to pick them up.

## Verified

Against 200 synthetic poses — 150 flat, then 50 climbing at 6cm/sample, 0.1s spacing:

```
  path_climb.npy: saved (48/200 samples climbing)
  path_speed.npy: saved (median capture speed 1.00 m/s)
1 map(s) up to date
```

0.1m per 0.1s is exactly 1.00 m/s, and the climbing count matches the 50-sample ramp after windowing. Second run:

```
  path_climb.npy: present, skipping
  path_speed.npy: present, skipping
```

Not exercised against a real map yet — the device on hand pins upstream `main`, so these modules are not present there to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
