### PR TITLE
Add GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,400 @@
+:root {
+  color-scheme: light;
+  --ink: #17201c;
+  --muted: #5d6962;
+  --line: #d7ddd8;
+  --panel: #f7f8f5;
+  --paper: #ffffff;
+  --green: #0c7a57;
+  --green-dark: #07533c;
+  --blue: #245b7c;
+  --gold: #d39b21;
+  --shadow: 0 18px 60px rgba(23, 32, 28, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background: var(--paper);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 68px;
+  padding: 14px clamp(20px, 4vw, 56px);
+  border-bottom: 1px solid rgba(215, 221, 216, 0.78);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 18px;
+  font-weight: 760;
+}
+
+.brand img {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 2vw, 26px);
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.nav-links a:hover {
+  color: var(--green-dark);
+}
+
+.hero {
+  min-height: calc(100vh - 68px);
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
+  align-items: center;
+  gap: clamp(28px, 5vw, 72px);
+  padding: clamp(38px, 7vw, 88px) clamp(20px, 4vw, 56px) clamp(34px, 5vw, 64px);
+  background:
+    linear-gradient(90deg, rgba(247, 248, 245, 0.94), rgba(255, 255, 255, 0.78)),
+    var(--paper);
+}
+
+.hero-copy {
+  max-width: 620px;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: var(--green);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  overflow-wrap: anywhere;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(56px, 9vw, 132px);
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin: 0;
+  max-width: 820px;
+  font-size: clamp(30px, 4.8vw, 58px);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin: 0 0 12px;
+  font-size: 22px;
+  line-height: 1.16;
+}
+
+.lede {
+  margin: 26px 0 0;
+  max-width: 590px;
+  color: var(--muted);
+  font-size: clamp(19px, 2.2vw, 25px);
+  line-height: 1.42;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 34px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.button.primary {
+  color: #ffffff;
+  border-color: var(--green-dark);
+  background: var(--green-dark);
+}
+
+.button.secondary {
+  color: var(--green-dark);
+  background: #ffffff;
+}
+
+.hero-media {
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  background: #0f1412;
+}
+
+.hero-media img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
+.section {
+  padding: clamp(70px, 10vw, 128px) clamp(20px, 4vw, 56px);
+}
+
+.section-heading {
+  max-width: 920px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 42px;
+}
+
+.feature-card {
+  min-height: 220px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--paper);
+}
+
+.feature-card:nth-child(2) {
+  border-top-color: var(--blue);
+}
+
+.feature-card:nth-child(3) {
+  border-top-color: var(--gold);
+}
+
+.feature-card p,
+.split-section p,
+.media-band p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.62;
+}
+
+.split-section {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  gap: clamp(30px, 5vw, 72px);
+  align-items: center;
+  padding: clamp(70px, 10vw, 128px) clamp(20px, 4vw, 56px);
+  background: var(--panel);
+}
+
+.split-section p {
+  max-width: 620px;
+  margin-top: 22px;
+}
+
+.check-list {
+  display: grid;
+  gap: 12px;
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+  color: var(--ink);
+  font-weight: 650;
+}
+
+.check-list li {
+  padding-left: 22px;
+  position: relative;
+}
+
+.check-list li::before {
+  position: absolute;
+  left: 0;
+  color: var(--gold);
+  content: "•";
+}
+
+.image-panel {
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  background: #ffffff;
+}
+
+.image-panel img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.media-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.74fr);
+  gap: clamp(30px, 5vw, 72px);
+  align-items: center;
+  padding: clamp(70px, 10vw, 128px) clamp(20px, 4vw, 56px);
+}
+
+.media-band figure {
+  margin: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.media-band img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
+.quickstart {
+  background: #14201b;
+  color: #ffffff;
+}
+
+.quickstart .eyebrow {
+  color: #8edabf;
+}
+
+.quickstart h2 {
+  color: #ffffff;
+}
+
+.command-block {
+  display: grid;
+  gap: 1px;
+  max-width: 860px;
+  margin-top: 38px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.command-block code {
+  display: block;
+  padding: 16px 18px;
+  overflow-x: auto;
+  color: #e9fff6;
+  background: rgba(0, 0, 0, 0.22);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.site-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 18px;
+  padding: 28px clamp(20px, 4vw, 56px);
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.site-footer span {
+  margin-right: auto;
+  color: var(--ink);
+  font-weight: 720;
+}
+
+.site-footer a:hover {
+  color: var(--green-dark);
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .split-section,
+  .media-band {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .site-header {
+    position: static;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .nav-links {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card {
+    min-height: auto;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>TinyNav</title>
+    <meta name="description" content="TinyNav is a lightweight, hackable robot navigation stack for stereo SLAM, mapping, planning, and control.">
+    <link rel="stylesheet" href="assets/site.css">
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="./" aria-label="TinyNav home">
+        <img src="tinynav.png" alt="" width="40" height="40">
+        <span>TinyNav</span>
+      </a>
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="#stack">Stack</a>
+        <a href="#maps">Maps</a>
+        <a href="#quickstart">Quickstart</a>
+        <a href="https://github.com/UniflexAI/tinynav">GitHub</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-copy">
+          <p class="eyebrow">Stereo SLAM · Mapping · Planning · Control</p>
+          <h1>TinyNav</h1>
+          <p class="lede">A lightweight, hackable system to guide robots through real spaces with GPU-accelerated perception and map-based navigation.</p>
+          <div class="actions">
+            <a class="button primary" href="https://github.com/UniflexAI/tinynav">View Repository</a>
+            <a class="button secondary" href="#quickstart">Run the Demo</a>
+          </div>
+        </div>
+        <figure class="hero-media">
+          <img src="docker_run_rviz.png" alt="TinyNav running in RViz with trajectory planning and map visualization">
+        </figure>
+      </section>
+
+      <section id="stack" class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Runtime Stack</p>
+          <h2>ROS 2 nodes built for real-time robot navigation</h2>
+        </div>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Perception</h3>
+            <p>Stereo odometry, depth, IMU fusion, TensorRT feature matching, and dense local geometry for closed-loop control.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Mapping</h3>
+            <p>Keyframe maps, loop closure, pose graph optimization, DINO scene retrieval, and persistent map storage.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Planning</h3>
+            <p>Occupancy grids, ESDF maps, trajectory library scoring, and practical command generation for mobile robots.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Platforms</h3>
+            <p>Runs on desktop GPUs and Jetson-class devices, with examples for Unitree GO2, LeKiwi, RealSense, and Looper.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="maps" class="split-section">
+        <div>
+          <p class="eyebrow">Map Workflow</p>
+          <h2>Build, inspect, and reuse maps</h2>
+          <p>TinyNav records keyframes, descriptors, poses, occupancy, and depth products into a reusable map database. The same map can support localization, planning, visualization, and retrieval workflows.</p>
+          <ul class="check-list">
+            <li>Pose graph refinement for long-running maps</li>
+            <li>Global image descriptors for loop and place recognition</li>
+            <li>Map artifacts stored in simple local files</li>
+          </ul>
+        </div>
+        <figure class="image-panel">
+          <img src="map.png" alt="TinyNav generated map visualization">
+        </figure>
+      </section>
+
+      <section class="media-band">
+        <figure>
+          <img src="looper.jpg" alt="Looper stereo camera supported by TinyNav">
+        </figure>
+        <div>
+          <p class="eyebrow">Sensors</p>
+          <h2>Designed around stereo cameras and GPU inference</h2>
+          <p>Looper and RealSense workflows are first-class paths in the repository, with scripts for live sensors, rosbag replay, mapping, and navigation.</p>
+        </div>
+      </section>
+
+      <section id="quickstart" class="section quickstart">
+        <div class="section-heading">
+          <p class="eyebrow">Quickstart</p>
+          <h2>Run the sample rosbag demo</h2>
+        </div>
+        <div class="command-block">
+          <code>git clone https://github.com/UniflexAI/tinynav.git</code>
+          <code>cd tinynav</code>
+          <code>bash scripts/check_env.sh</code>
+          <code>bash scripts/run_rosbag_examples.sh</code>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <span>Maintained by Uniflex AI</span>
+      <a href="https://discord.gg/gnZKFJ8W9Q">Discord</a>
+      <a href="https://x.com/UniflexAI">X</a>
+      <a href="https://github.com/UniflexAI/tinynav/blob/main/LICENSE">License</a>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static TinyNav homepage under docs/index.html
- add responsive styling under docs/assets/site.css using existing docs images
- add a GitHub Pages workflow that publishes the docs directory

## Test
- python3 -m http.server --directory docs smoke test
- verified /, /assets/site.css, and /docker_run_rviz.png return HTTP 200 locally