### PR TITLE
Enable GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- enable Pages site initialization in the workflow so the first deployment can create the site

## Why
- the previous deployment failed at actions/configure-pages with 'Get Pages site failed'
- that leaves https://uniflexai.github.io/tinynav/ unreachable until Pages is initialized on main

## Test
- workflow-only change; no local runtime change