### PR TITLE
feat(unitree): support g1 humanoid alongside go2/b2

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -60,6 +60,12 @@ _PREVIEW_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_MAX_EDGE_PX', '320'))
 _PREVIEW_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_JPEG_QUALITY', '50'))
 _PREVIEW_HIGH_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_HIGH_MAX_EDGE_PX', '640'))
 _PREVIEW_HIGH_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_HIGH_JPEG_QUALITY', '80'))
+_SUPPORTED_ROBOT_MODELS = ('go2', 'b2', 'g1')
+_ROBOT_MODEL = os.environ.get('TINYNAV_ROBOT_MODEL', 'go2').strip().lower()
+if _ROBOT_MODEL not in _SUPPORTED_ROBOT_MODELS:
+    raise ValueError(
+        f"Invalid TINYNAV_ROBOT_MODEL={_ROBOT_MODEL!r}, expected one of {_SUPPORTED_ROBOT_MODELS}")
+_PLANNING_NODE_CMD = ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py', '--robot-model', _ROBOT_MODEL]
 _PREVIEW_PROFILES = {
     'default': (_PREVIEW_MAX_EDGE_PX, _PREVIEW_JPEG_QUALITY),
     'high': (_PREVIEW_HIGH_MAX_EDGE_PX, _PREVIEW_HIGH_JPEG_QUALITY),
@@ -624,10 +630,11 @@ class BackendNode(Ros2NodeManager):
         _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
         self._unitree_proc = self._launch_proc(
             'unitree',
-            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/unitree_control.py'],
+            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/unitree_control.py',
+             '--robot-model', _ROBOT_MODEL],
             env=_env,
         )
-        self.get_logger().info('unitree_control started')
+        self.get_logger().info(f'unitree_control started (robot_model={_ROBOT_MODEL})')
 
     def get_sensor_mode(self) -> str:
         return self._sensor_mode
@@ -748,7 +755,7 @@ class BackendNode(Ros2NodeManager):
             )
             self._planning_proc = self._launch_proc(
                 'planning',
-                ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py'],
+                _PLANNING_NODE_CMD,
                 env=env,
             )
         elif self._sensor_mode == 'realsense':
@@ -763,7 +770,7 @@ class BackendNode(Ros2NodeManager):
             )
             self._planning_proc = self._launch_proc(
                 'planning',
-                ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py'],
+                _PLANNING_NODE_CMD,
                 env=env,
             )
 
@@ -827,7 +834,7 @@ class BackendNode(Ros2NodeManager):
 
         self._planning_proc = self._launch_proc(
             'planning',
-            ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py'],
+            _PLANNING_NODE_CMD,
             env=_env,
         )
         self._map_node_proc = self._launch_proc(

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -1,3 +1,5 @@
+import argparse
+import sys
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import Image, CameraInfo, PointField
@@ -64,6 +66,20 @@ B2_CONFIG = RobotConfig(
     control_x=-0.5, control_y=0.0,
     safety_radius=0.1,
 )
+
+G1_CONFIG = RobotConfig(
+    name='g1', shape='square',
+    length=0.3, width=0.5,
+    camera_x=0.1, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.15,
+)
+
+ROBOT_CONFIGS = {
+    GO2_CONFIG.name: GO2_CONFIG,
+    B2_CONFIG.name: B2_CONFIG,
+    G1_CONFIG.name: G1_CONFIG,
+}
 
 # === Helper functions ===
 @njit(cache=True)
@@ -348,9 +364,11 @@ def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
 
 # === PlanningNode class ===
 class PlanningNode(Node):
-    def __init__(self):
+    def __init__(self, robot_model='go2'):
         super().__init__('planning_node')
-        self.robot = GO2_CONFIG
+        if robot_model not in ROBOT_CONFIGS:
+            raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {tuple(ROBOT_CONFIGS)}")
+        self.robot = ROBOT_CONFIGS[robot_model]
         self.get_logger().info(
             f"Robot: {self.robot.name} ({self.robot.shape} {self.robot.length}x{self.robot.width}m, "
             f"cam=({self.robot.camera_x},{self.robot.camera_y}), "
@@ -659,7 +677,11 @@ class PlanningNode(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    node = PlanningNode()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot-model", choices=tuple(ROBOT_CONFIGS), default='go2',
+                         help="Robot geometry to use for footprint/collision planning")
+    parsed_args, _ = parser.parse_known_args(sys.argv[1:])
+    node = PlanningNode(robot_model=parsed_args.robot_model)
 
     try:
         rclpy.spin(node)

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -1,17 +1,41 @@
+import argparse
 import rclpy
 from rclpy.node import Node
 from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
 from unitree_sdk2py.idl.geometry_msgs.msg.dds_ import Twist_
 from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
-from unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_
-from unitree_sdk2py.b2.sport.sport_client import SportClient as SportClientB2
 from std_msgs.msg import Float32, String
 from enum import Enum
-import logging
 import time
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+# go2/b2 are quadrupeds sharing the same SportClient gait API (Move/StandUp/
+# StandDown/BalanceStand/ClassicWalk). g1 is a humanoid controlled through the
+# FSM-based LocoClient instead, so it needs its own client, lowstate IDL, and
+# stand/sit mapping.
+_QUADRUPED_ROBOT_MODELS = ('go2', 'b2')
+_SUPPORTED_ROBOT_MODELS = _QUADRUPED_ROBOT_MODELS + ('g1',)
+_DEFAULT_ROBOT_MODEL = 'go2'
+
+
+def _build_sport_client(robot_model: str):
+    if robot_model == 'go2':
+        from unitree_sdk2py.go2.sport.sport_client import SportClient
+        return SportClient()
+    if robot_model == 'b2':
+        from unitree_sdk2py.b2.sport.sport_client import SportClient
+        return SportClient()
+    if robot_model == 'g1':
+        from unitree_sdk2py.g1.loco.g1_loco_client import LocoClient
+        return LocoClient()
+    raise ValueError(f"Unsupported robot model: {robot_model}")
+
+
+def _lowstate_type_and_topic(robot_model: str):
+    if robot_model in _QUADRUPED_ROBOT_MODELS:
+        from unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_
+        return LowState_, "rt/lowstate"
+    from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+    return LowState_, "rt/lowstate"
 
 
 class RobotStatus(Enum):
@@ -20,17 +44,23 @@ class RobotStatus(Enum):
 
 
 class Ros2UnitreeManagerNode(Node):
-    def __init__(self, networkInterface: str = "enP8p1s0"):
+    def __init__(self, networkInterface: str = "enP8p1s0", robot_model: str = _DEFAULT_ROBOT_MODEL):
         super().__init__('ros2_unitree_manager')
+        if robot_model not in _SUPPORTED_ROBOT_MODELS:
+            raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {_SUPPORTED_ROBOT_MODELS}")
+        self.robot_model = robot_model
+        self.is_quadruped = robot_model in _QUADRUPED_ROBOT_MODELS
+
         self.channel = ChannelFactoryInitialize(0, networkInterface)
-        self.sport_client = SportClientB2()
+        self.sport_client = _build_sport_client(robot_model)
         self.sport_client.SetTimeout(10.0)
         self.sport_client.Init()
-        self.sport_client.SwitchGait(1)
+        if self.is_quadruped:
+            self.sport_client.ClassicWalk(True)
         self._robot_status = RobotStatus.SITTING
         self.battery = 0.0
         self.last_twist_time = None
-        self.logger = logging.getLogger(__name__)
+        self.logger = self.get_logger()
 
         self.twist_subscriber = ChannelSubscriber("rt/cmd_vel", Twist_)
         self.twist_subscriber.Init(self.TwistMessageHandler, 10)
@@ -38,9 +68,10 @@ class Ros2UnitreeManagerNode(Node):
         self.action_subscriber = ChannelSubscriber("rt/service/command", String_)
         self.action_subscriber.Init(self.ActionMessageHandler, 10)
 
-        lowstate_subscriber = ChannelSubscriber("rt/lf/lowstate", LowState_)
+        lowstate_type, lowstate_topic = _lowstate_type_and_topic(robot_model)
+        lowstate_subscriber = ChannelSubscriber(lowstate_topic, lowstate_type)
         lowstate_subscriber.Init(self.LowStateMessageHandler, 10)
-        
+
         self.publisher_battery = self.create_publisher(Float32, '/battery', 10)
         self.publisher_robot_status = self.create_publisher(String, '/robot_status', 10)
 
@@ -53,7 +84,7 @@ class Ros2UnitreeManagerNode(Node):
             time_interval = current_time - self.last_twist_time
             self.logger.debug(f"cmd_vel callback time interval: {time_interval*1000:.2f} ms")
         self.last_twist_time = current_time
-        
+
         if  (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
             self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
             self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
@@ -62,24 +93,38 @@ class Ros2UnitreeManagerNode(Node):
         time.sleep(0.02)
 
     def ActionMessageHandler(self, msg: String_):
+        self.logger.info(f"ActionMessageHandler received: {msg.data!r}")
         if msg.data.split(" ")[0] == "play":
             action_key = msg.data.split(" ")[1]
             if action_key == "sit":
-                self.logger.info("Sitting")
-                self.sport_client.StandDown()
+                if self.is_quadruped:
+                    code = self.sport_client.StandDown()
+                    self.logger.info(f"Sitting: StandDown code={code}")
+                else:
+                    code = self.sport_client.StandUp2Squat()
+                    self.logger.info(f"Sitting: StandUp2Squat code={code}")
                 self._robot_status = RobotStatus.SITTING
             elif action_key == "stand":
-                self.logger.info("Standing")
-                self.sport_client.StandUp()
-                self.sport_client.BalanceStand()
+                if self.is_quadruped:
+                    code1 = self.sport_client.StandUp()
+                    code2 = self.sport_client.BalanceStand()
+                    self.logger.info(f"Standing: StandUp code={code1}, BalanceStand code={code2}")
+                else:
+                    code1 = self.sport_client.Damp()
+                    time.sleep(0.5)
+                    code2 = self.sport_client.Squat2StandUp()
+                    self.logger.info(f"Standing: Damp code={code1}, Squat2StandUp code={code2}")
                 self._robot_status = RobotStatus.STANDUP
-    
+
     def _publish_robot_status(self):
         msg = String()
         msg.data = self._robot_status.value
         self.publisher_robot_status.publish(msg)
 
-    def LowStateMessageHandler(self, msg: LowState_):
+    def LowStateMessageHandler(self, msg):
+        if not self.is_quadruped:
+            # g1's lowstate has no battery field; skip battery reporting.
+            return
         try:
             self.battery = float(msg.bms_state.soc)
             battery_msg = Float32()
@@ -92,8 +137,15 @@ class Ros2UnitreeManagerNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-    node = Ros2UnitreeManagerNode("enP8p1s0")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot-model", choices=_SUPPORTED_ROBOT_MODELS, default=_DEFAULT_ROBOT_MODEL,
+                         help="Unitree robot model to control")
+    parser.add_argument("--network-interface", default="enP8p1s0",
+                         help="Network interface connected to the robot")
+    parsed_args, ros_args = parser.parse_known_args(args=args)
+
+    rclpy.init(args=ros_args)
+    node = Ros2UnitreeManagerNode(parsed_args.network_interface, parsed_args.robot_model)
     rclpy.spin(node)
     node.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
g1 is controlled through the FSM-based LocoClient instead of the quadruped SportClient, so it needs its own client, lowstate IDL, and stand/sit mapping (Damp -> Squat2StandUp instead of StandUp -> BalanceStand). unitree_control.py's sport client used to be hardcoded to the b2 SportClient regardless of the actual robot connected.

Thread --robot-model through node_manager.py so planning_node.py's footprint/collision config and unitree_control.py's client selection both follow TINYNAV_ROBOT_MODEL (default unchanged: go2), instead of each defaulting independently.