### PR TITLE
feat(control): add per-robot velocity limits with go2/b2/g1/go2w/b2w support

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -60,6 +60,13 @@ _PREVIEW_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_MAX_EDGE_PX', '320'))
 _PREVIEW_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_JPEG_QUALITY', '50'))
 _PREVIEW_HIGH_MAX_EDGE_PX = int(os.environ.get('TINYNAV_PREVIEW_HIGH_MAX_EDGE_PX', '640'))
 _PREVIEW_HIGH_JPEG_QUALITY = int(os.environ.get('TINYNAV_PREVIEW_HIGH_JPEG_QUALITY', '80'))
+_SUPPORTED_ROBOT_MODELS = ('go2', 'go2w', 'b2', 'b2w', 'g1')
+_ROBOT_MODEL = os.environ.get('TINYNAV_ROBOT_MODEL', 'b2').strip().lower()
+if _ROBOT_MODEL not in _SUPPORTED_ROBOT_MODELS:
+    raise ValueError(
+        f"Invalid TINYNAV_ROBOT_MODEL={_ROBOT_MODEL!r}, expected one of {_SUPPORTED_ROBOT_MODELS}")
+_PLANNING_NODE_CMD = ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py', '--robot-model', _ROBOT_MODEL]
+_CMD_VEL_CONTROL_CMD = ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py', '--robot-model', _ROBOT_MODEL]
 _PREVIEW_PROFILES = {
     'default': (_PREVIEW_MAX_EDGE_PX, _PREVIEW_JPEG_QUALITY),
     'high': (_PREVIEW_HIGH_MAX_EDGE_PX, _PREVIEW_HIGH_JPEG_QUALITY),
@@ -624,10 +631,11 @@ class BackendNode(Ros2NodeManager):
         _env['PYTHONPATH'] = _VENV_SITE + ':' + _env.get('PYTHONPATH', '')
         self._unitree_proc = self._launch_proc(
             'unitree',
-            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/unitree_control.py'],
+            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/unitree_control.py',
+             '--robot-model', _ROBOT_MODEL],
             env=_env,
         )
-        self.get_logger().info('unitree_control started')
+        self.get_logger().info(f'unitree_control started (robot_model={_ROBOT_MODEL})')
 
     def get_sensor_mode(self) -> str:
         return self._sensor_mode
@@ -748,7 +756,7 @@ class BackendNode(Ros2NodeManager):
             )
             self._planning_proc = self._launch_proc(
                 'planning',
-                ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py'],
+                _PLANNING_NODE_CMD,
                 env=env,
             )
         elif self._sensor_mode == 'realsense':
@@ -763,7 +771,7 @@ class BackendNode(Ros2NodeManager):
             )
             self._planning_proc = self._launch_proc(
                 'planning',
-                ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py'],
+                _PLANNING_NODE_CMD,
                 env=env,
             )
 
@@ -791,7 +799,7 @@ class BackendNode(Ros2NodeManager):
         )
         self._cmd_vel_proc = self._launch_proc(
             'cmd_vel_control',
-            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py'],
+            _CMD_VEL_CONTROL_CMD,
             env=_env,
         )
         with self._lock:
@@ -827,7 +835,7 @@ class BackendNode(Ros2NodeManager):
 
         self._planning_proc = self._launch_proc(
             'planning',
-            ['uv', 'run', 'python', '/tinynav/tinynav/core/planning_node.py'],
+            _PLANNING_NODE_CMD,
             env=_env,
         )
         self._map_node_proc = self._launch_proc(
@@ -838,7 +846,7 @@ class BackendNode(Ros2NodeManager):
         )
         self._cmd_vel_proc = self._launch_proc(
             'cmd_vel_control',
-            ['uv', 'run', 'python', '/tinynav/tinynav/platforms/cmd_vel_control.py'],
+            _CMD_VEL_CONTROL_CMD,
             env=_env,
         )
         with self._lock:

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -1,3 +1,5 @@
+import argparse
+import sys
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import Image, CameraInfo, PointField
@@ -16,54 +18,7 @@ from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
-
-
-@dataclass
-class RobotConfig:
-    """Robot geometry. Body frame: +x forward, +y left."""
-    name: str = 'go2'
-    shape: str = 'square'
-    length: float = 0.7
-    width: float = 0.3
-    radius: float = 0.3
-    camera_x: float = 0.35
-    camera_y: float = 0.0
-    control_x: float = 0.0
-    control_y: float = 0.0
-    safety_radius: float = 0.1
-
-    @property
-    def cam_offset_3d(self):
-        """Offset [left, up, forward] from control center to camera in body frame."""
-        return np.array([self.camera_y - self.control_y, 0.0, self.camera_x - self.control_x], dtype=np.float32)
-
-    @property
-    def half_size(self):
-        if self.shape == 'circle':
-            return (self.radius, self.radius)
-        return (self.length / 2.0, self.width / 2.0)
-
-    def footprint_from_control(self):
-        """Returns (front_len, rear_len, half_w) relative to control center."""
-        hl, hw = self.half_size
-        return float(hl - self.control_x), float(hl + self.control_x), float(hw)
-
-
-GO2_CONFIG = RobotConfig(
-    name='go2', shape='square',
-    length=0.4, width=0.3,
-    camera_x=0.2, camera_y=0.0,
-    control_x=0.0, control_y=0.0,
-    safety_radius=0.2,
-)
-
-B2_CONFIG = RobotConfig(
-    name='b2', shape='square',
-    length=1.0, width=0.5,
-    camera_x=0.5, camera_y=0.0,
-    control_x=-0.5, control_y=0.0,
-    safety_radius=0.1,
-)
+from tinynav.core.robot_specs import ROBOT_CONFIGS
 
 # === Helper functions ===
 @njit(cache=True)
@@ -185,15 +140,16 @@ def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None)
 @njit(cache=True)
 def generate_trajectory_library_3d(
     num_samples=15, duration=3.0, dt=0.1,
-    init_p=np.zeros(3), init_q=np.array([0, 0, 0, 1])
+    init_p=np.zeros(3), init_q=np.array([0, 0, 0, 1]),
+    max_linear_vel=0.5, max_angular_vel=np.pi / 3,
 ):
     """Regular sampled lattice (forward-only)."""
     num_steps = int(duration / dt) + 1
 
-    vx_max = 0.5
+    vx_max = max_linear_vel
     n_vx = max(3, int(num_samples / 2))
     vx_samples = np.linspace(0.0, vx_max, n_vx)
-    omega_y_samples = np.linspace(-np.pi / 3, np.pi / 3, num_samples)
+    omega_y_samples = np.linspace(-max_angular_vel, max_angular_vel, num_samples)
 
     num_samples = len(vx_samples) * len(omega_y_samples)
 
@@ -348,9 +304,11 @@ def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
 
 # === PlanningNode class ===
 class PlanningNode(Node):
-    def __init__(self):
+    def __init__(self, robot_model='go2'):
         super().__init__('planning_node')
-        self.robot = GO2_CONFIG
+        if robot_model not in ROBOT_CONFIGS:
+            raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {tuple(ROBOT_CONFIGS)}")
+        self.robot = ROBOT_CONFIGS[robot_model]
         self.get_logger().info(
             f"Robot: {self.robot.name} ({self.robot.shape} {self.robot.length}x{self.robot.width}m, "
             f"cam=({self.robot.camera_x},{self.robot.camera_y}), "
@@ -592,7 +550,11 @@ class PlanningNode(Node):
         with Timer(name='traj gen', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             init_p = self.camera_to_robot_center(T)
             init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
-            trajectories, params = generate_trajectory_library_3d(init_p=init_p, init_q=init_q)
+            trajectories, params = generate_trajectory_library_3d(
+                init_p=init_p, init_q=init_q,
+                max_linear_vel=self.robot.max_linear_vel,
+                max_angular_vel=self.robot.max_angular_vel,
+            )
             vocab_trajs, vocab_params = generate_predefined_trajectory_vocabularies(init_p=init_p, init_q=init_q)
             trajectories = np.concatenate([trajectories, vocab_trajs], axis=0)
             params = np.concatenate([params, vocab_params], axis=0)
@@ -659,7 +621,11 @@ class PlanningNode(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    node = PlanningNode()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot-model", choices=tuple(ROBOT_CONFIGS), default='go2',
+                         help="Robot geometry to use for footprint/collision planning")
+    parsed_args, _ = parser.parse_known_args(sys.argv[1:])
+    node = PlanningNode(robot_model=parsed_args.robot_model)
 
     try:
         rclpy.spin(node)

--- a/tinynav/core/robot_specs.py
+++ b/tinynav/core/robot_specs.py
@@ -1,0 +1,95 @@
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class RobotConfig:
+    """Robot geometry + velocity limits. Body frame: +x forward, +y left.
+
+    Shared between planning_node (trajectory sampling/collision footprint) and
+    cmd_vel_control (final cmd_vel clamping) so both nodes read the same numbers
+    for a given --robot-model instead of keeping separate copies.
+    """
+    name: str = 'go2'
+    shape: str = 'square'
+    length: float = 0.7
+    width: float = 0.3
+    radius: float = 0.3
+    camera_x: float = 0.35
+    camera_y: float = 0.0
+    control_x: float = 0.0
+    control_y: float = 0.0
+    safety_radius: float = 0.1
+    # Bounds used to constrain trajectory-library velocity sampling and to clamp
+    # the final published cmd_vel. Placeholder values, same for every robot until
+    # real per-platform min/max linear & angular speeds are measured.
+    min_linear_vel: float = 0.1
+    max_linear_vel: float = 1.0
+    min_angular_vel: float = 0.1
+    max_angular_vel: float = 0.75
+
+    @property
+    def cam_offset_3d(self):
+        """Offset [left, up, forward] from control center to camera in body frame."""
+        return np.array([self.camera_y - self.control_y, 0.0, self.camera_x - self.control_x], dtype=np.float32)
+
+    @property
+    def half_size(self):
+        if self.shape == 'circle':
+            return (self.radius, self.radius)
+        return (self.length / 2.0, self.width / 2.0)
+
+    def footprint_from_control(self):
+        """Returns (front_len, rear_len, half_w) relative to control center."""
+        hl, hw = self.half_size
+        return float(hl - self.control_x), float(hl + self.control_x), float(hw)
+
+
+GO2_CONFIG = RobotConfig(
+    name='go2', shape='square',
+    length=0.4, width=0.3,
+    camera_x=0.2, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.2,
+)
+
+GO2W_CONFIG = RobotConfig(
+    name='go2w', shape='square',
+    length=0.4, width=0.3,
+    camera_x=0.2, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.2,
+)
+
+B2_CONFIG = RobotConfig(
+    name='b2', shape='square',
+    length=1.1, width=0.5,
+    camera_x=0.3, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.1,
+)
+
+B2W_CONFIG = RobotConfig(
+    name='b2w', shape='square',
+    length=1.1, width=0.5,
+    camera_x=0.3, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.1,
+)
+
+G1_CONFIG = RobotConfig(
+    name='g1', shape='square',
+    length=0.3, width=0.5,
+    camera_x=0.1, camera_y=0.0,
+    control_x=0.0, control_y=0.0,
+    safety_radius=0.15,
+    min_linear_vel=0.2,min_angular_vel=0.3
+)
+
+ROBOT_CONFIGS = {
+    GO2_CONFIG.name: GO2_CONFIG,
+    GO2W_CONFIG.name: GO2W_CONFIG,
+    B2_CONFIG.name: B2_CONFIG,
+    B2W_CONFIG.name: B2W_CONFIG,
+    G1_CONFIG.name: G1_CONFIG,
+}

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -1,3 +1,5 @@
+import argparse
+import sys
 import rclpy
 from rclpy.node import Node
 from geometry_msgs.msg import Twist
@@ -9,13 +11,17 @@ from scipy.spatial.transform import Rotation as R
 import numpy as np
 import logging
 import time
+from tinynav.core.robot_specs import ROBOT_CONFIGS
 
 # Module-level logger for cases where self.get_logger() is not available
 logger = logging.getLogger(__name__)
 
 class CmdVelControlNode(Node):
-    def __init__(self):
+    def __init__(self, robot_model='go2'):
         super().__init__('cmd_vel_control_node')
+        if robot_model not in ROBOT_CONFIGS:
+            raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {tuple(ROBOT_CONFIGS)}")
+        self.robot = ROBOT_CONFIGS[robot_model]
         self.logger = self.get_logger()  # Use ROS2 logger
         self.cmd_pub = self.create_publisher(Twist, '/cmd_vel', 10)
         self.pose_sub = self.create_subscription(Odometry, '/slam/odometry', self.pose_callback, 10)
@@ -40,7 +46,8 @@ class CmdVelControlNode(Node):
         self.path_stale_stop_factor = 5.0
         self.max_linear_acc = 0.6   # m/s^2
         self.max_angular_acc = 0.8  # rad/s^2
-        self.max_angular_speed = 0.8  # rad/s
+        self.max_angular_speed = self.robot.max_angular_vel  # rad/s
+        self.max_forward_speed = self.robot.max_linear_vel  # m/s
         self.planner_dt = 0.1       # trajectory dt in planning_node
         # planning_node publishes path with for j in range(..., step=10), so points are ~1.0 s apart.
         self.path_pose_stride = 10
@@ -48,8 +55,8 @@ class CmdVelControlNode(Node):
         self.path_filter_tau = 0.30
         self.lookahead_steps = 1
         # Static-friction compensation: very small vx often cannot move the robot.
-        self.min_effective_linear_speed = 0.1
-        self.min_effective_angular_speed = 0.1
+        self.min_effective_linear_speed = self.robot.min_linear_vel
+        self.min_effective_angular_speed = self.robot.min_angular_vel
         self.linear_engage_threshold = 0.04
         self.fixed_reverse_speed = 0.2
         # Hack: if path first segment points far away from robot heading,
@@ -199,7 +206,7 @@ class CmdVelControlNode(Node):
         if raw_vx < 0.0:
             vx = -self.fixed_reverse_speed
         else:
-            vx = float(np.clip(raw_vx, 0.0, 0.5))
+            vx = float(np.clip(raw_vx, 0.0, self.max_forward_speed))
         vy = 0.0
         vyaw = np.clip(angular_velocity_vec[2], -self.max_angular_speed, self.max_angular_speed)
         is_backward_segment = raw_vx < 0.0
@@ -244,7 +251,12 @@ def main(args=None):
         datefmt="%Y-%m-%d %H:%M:%S"
     )
     
-    node = CmdVelControlNode()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot-model", choices=tuple(ROBOT_CONFIGS), default='go2',
+                         help="Robot to use for min/max linear & angular speed limits")
+    parsed_args, _ = parser.parse_known_args(sys.argv[1:])
+
+    node = CmdVelControlNode(robot_model=parsed_args.robot_model)
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -1,17 +1,43 @@
+import argparse
 import rclpy
 from rclpy.node import Node
 from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
 from unitree_sdk2py.idl.geometry_msgs.msg.dds_ import Twist_
 from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
-from unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_
-from unitree_sdk2py.b2.sport.sport_client import SportClient as SportClientB2
 from std_msgs.msg import Float32, String
 from enum import Enum
-import logging
 import time
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+# go2/b2 are quadrupeds sharing the same SportClient gait API (Move/StandUp/
+# StandDown/BalanceStand/ClassicWalk). go2w/b2w are the wheeled variants of the
+# same chassis — the vendored SDK has no separate go2w/b2w package, so they reuse
+# the go2/b2 SportClient (same gait/lowstate API) as-is. g1 is a humanoid
+# controlled through the FSM-based LocoClient instead, so it needs its own
+# client, lowstate IDL, and stand/sit mapping.
+_QUADRUPED_ROBOT_MODELS = ('go2', 'go2w', 'b2', 'b2w')
+_SUPPORTED_ROBOT_MODELS = _QUADRUPED_ROBOT_MODELS + ('g1',)
+_DEFAULT_ROBOT_MODEL = 'go2'
+
+
+def _build_sport_client(robot_model: str):
+    if robot_model in ('go2', 'go2w'):
+        from unitree_sdk2py.go2.sport.sport_client import SportClient
+        return SportClient()
+    if robot_model in ('b2', 'b2w'):
+        from unitree_sdk2py.b2.sport.sport_client import SportClient
+        return SportClient()
+    if robot_model == 'g1':
+        from unitree_sdk2py.g1.loco.g1_loco_client import LocoClient
+        return LocoClient()
+    raise ValueError(f"Unsupported robot model: {robot_model}")
+
+
+def _lowstate_type_and_topic(robot_model: str):
+    if robot_model in _QUADRUPED_ROBOT_MODELS:
+        from unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_
+        return LowState_, "rt/lowstate"
+    from unitree_sdk2py.idl.unitree_hg.msg.dds_ import LowState_
+    return LowState_, "rt/lowstate"
 
 
 class RobotStatus(Enum):
@@ -20,17 +46,23 @@ class RobotStatus(Enum):
 
 
 class Ros2UnitreeManagerNode(Node):
-    def __init__(self, networkInterface: str = "enP8p1s0"):
+    def __init__(self, networkInterface: str = "enP8p1s0", robot_model: str = _DEFAULT_ROBOT_MODEL):
         super().__init__('ros2_unitree_manager')
+        if robot_model not in _SUPPORTED_ROBOT_MODELS:
+            raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {_SUPPORTED_ROBOT_MODELS}")
+        self.robot_model = robot_model
+        self.is_quadruped = robot_model in _QUADRUPED_ROBOT_MODELS
+
         self.channel = ChannelFactoryInitialize(0, networkInterface)
-        self.sport_client = SportClientB2()
+        self.sport_client = _build_sport_client(robot_model)
         self.sport_client.SetTimeout(10.0)
         self.sport_client.Init()
-        self.sport_client.SwitchGait(1)
+        if self.is_quadruped:
+            self.sport_client.ClassicWalk(True)
         self._robot_status = RobotStatus.SITTING
         self.battery = 0.0
         self.last_twist_time = None
-        self.logger = logging.getLogger(__name__)
+        self.logger = self.get_logger()
 
         self.twist_subscriber = ChannelSubscriber("rt/cmd_vel", Twist_)
         self.twist_subscriber.Init(self.TwistMessageHandler, 10)
@@ -38,9 +70,10 @@ class Ros2UnitreeManagerNode(Node):
         self.action_subscriber = ChannelSubscriber("rt/service/command", String_)
         self.action_subscriber.Init(self.ActionMessageHandler, 10)
 
-        lowstate_subscriber = ChannelSubscriber("rt/lf/lowstate", LowState_)
+        lowstate_type, lowstate_topic = _lowstate_type_and_topic(robot_model)
+        lowstate_subscriber = ChannelSubscriber(lowstate_topic, lowstate_type)
         lowstate_subscriber.Init(self.LowStateMessageHandler, 10)
-        
+
         self.publisher_battery = self.create_publisher(Float32, '/battery', 10)
         self.publisher_robot_status = self.create_publisher(String, '/robot_status', 10)
 
@@ -53,7 +86,7 @@ class Ros2UnitreeManagerNode(Node):
             time_interval = current_time - self.last_twist_time
             self.logger.debug(f"cmd_vel callback time interval: {time_interval*1000:.2f} ms")
         self.last_twist_time = current_time
-        
+
         if  (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
             self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
             self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
@@ -62,24 +95,38 @@ class Ros2UnitreeManagerNode(Node):
         time.sleep(0.02)
 
     def ActionMessageHandler(self, msg: String_):
+        self.logger.info(f"ActionMessageHandler received: {msg.data!r}")
         if msg.data.split(" ")[0] == "play":
             action_key = msg.data.split(" ")[1]
             if action_key == "sit":
-                self.logger.info("Sitting")
-                self.sport_client.StandDown()
+                if self.is_quadruped:
+                    code = self.sport_client.StandDown()
+                    self.logger.info(f"Sitting: StandDown code={code}")
+                else:
+                    code = self.sport_client.StandUp2Squat()
+                    self.logger.info(f"Sitting: StandUp2Squat code={code}")
                 self._robot_status = RobotStatus.SITTING
             elif action_key == "stand":
-                self.logger.info("Standing")
-                self.sport_client.StandUp()
-                self.sport_client.BalanceStand()
+                if self.is_quadruped:
+                    code1 = self.sport_client.StandUp()
+                    code2 = self.sport_client.BalanceStand()
+                    self.logger.info(f"Standing: StandUp code={code1}, BalanceStand code={code2}")
+                else:
+                    code1 = self.sport_client.Damp()
+                    time.sleep(0.5)
+                    code2 = self.sport_client.Squat2StandUp()
+                    self.logger.info(f"Standing: Damp code={code1}, Squat2StandUp code={code2}")
                 self._robot_status = RobotStatus.STANDUP
-    
+
     def _publish_robot_status(self):
         msg = String()
         msg.data = self._robot_status.value
         self.publisher_robot_status.publish(msg)
 
-    def LowStateMessageHandler(self, msg: LowState_):
+    def LowStateMessageHandler(self, msg):
+        if not self.is_quadruped:
+            # g1's lowstate has no battery field; skip battery reporting.
+            return
         try:
             self.battery = float(msg.bms_state.soc)
             battery_msg = Float32()
@@ -92,8 +139,15 @@ class Ros2UnitreeManagerNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-    node = Ros2UnitreeManagerNode("enP8p1s0")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot-model", choices=_SUPPORTED_ROBOT_MODELS, default=_DEFAULT_ROBOT_MODEL,
+                         help="Unitree robot model to control")
+    parser.add_argument("--network-interface", default="enP8p1s0",
+                         help="Network interface connected to the robot")
+    parsed_args, ros_args = parser.parse_known_args(args=args)
+
+    rclpy.init(args=ros_args)
+    node = Ros2UnitreeManagerNode(parsed_args.network_interface, parsed_args.robot_model)
     rclpy.spin(node)
     node.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
Extract RobotConfig (geometry + min/max linear/angular velocity) into a shared tinynav/core/robot_specs.py, imported by planning_node, cmd_vel_control, and unitree_control instead of duplicating robot specs.

- planning_node: --robot-model selects RobotConfig; wires max_linear_vel/max_angular_vel into the trajectory-library sampling (generate_trajectory_library_3d) and keeps the existing footprint/ collision use of self.robot.
- cmd_vel_control: --robot-model selects RobotConfig; max_forward_speed/ max_angular_speed/min_effective_linear_speed/min_effective_angular_speed now come from the robot config instead of hardcoded constants.
- unitree_control: --robot-model dispatches to the right unitree_sdk2py client (go2/b2 SportClient, g1 LocoClient) and lowstate IDL/topic. go2w/b2w reuse the go2/b2 SportClient as-is (same gait API) since the vendored SDK has no separate wheeled package.
- node_manager: TINYNAV_ROBOT_MODEL env var threads --robot-model through to planning_node, cmd_vel_control, and unitree_control launches.

This is scoped to only the robot-model adaptation, layered directly on top of origin/main — no unrelated behavior changes.