### PR TITLE
feat(planning): score trajectory end heading toward the goal

### DIFF
--- a/tests/test_planning_node.py
+++ b/tests/test_planning_node.py
@@ -6,7 +6,8 @@ import os
 from numba import njit
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tinynav', 'core'))
-from planning_node import run_raycasting_loopy
+from planning_node import run_raycasting_loopy, generate_trajectory_library_3d, goal_heading_error
+from tinynav.core.math_utils import matrix_to_quat
 from tinynav.tinynav_cpp_bind import run_raycasting_cpp
 
 @njit
@@ -143,5 +144,73 @@ def test_run_raycasting_comparison():
             print_diffs(py_occupancy_grid, cpp_occupancy_grid, "Vectorized", "C++")
         assert False, "Implementations do not match."
 
+# Robot at the world origin, body +Z (forward) along world +X, body +Y (down) along
+# world -Z -- the camera convention /slam/odometry_visual publishes.
+_FACING_X = np.array([[0.0, 0.0, 1.0],
+                      [-1.0, 0.0, 0.0],
+                      [0.0, -1.0, 0.0]])
+
+def _pick(target, heading_weight):
+    """Lowest-cost (vx, omega) for a goal in open space.
+
+    Mirrors sync_callback's cost_function with an all-clear ESDF (score == 0) and
+    no reverse gating, so only the distance / heading / smoothness terms decide.
+    Keep the weights in sync with planning_node if they change there.
+    """
+    trajectories, params = generate_trajectory_library_3d(
+        init_p=np.zeros(3), init_q=matrix_to_quat(_FACING_X),
+    )
+    last_param = np.zeros(2)  # previous pick was a full stop
+    costs = [
+        100 * np.linalg.norm(trajectories[i][-1, :3] - target)
+        + heading_weight * goal_heading_error(trajectories[i][-1], target)
+        + 10 * abs(last_param[0] - params[i, 0])
+        + 10 * abs(last_param[1] - params[i, 1])
+        for i in range(len(trajectories))
+    ]
+    return params[np.argsort(costs, kind='stable')[0]]
+
+def test_goal_heading_error():
+    end = np.empty(7)
+    end[:3] = 0.0
+    end[3:] = matrix_to_quat(_FACING_X)
+    for target, expected in (
+        ([5.0, 0.0, 0.0], 0.0),          # dead ahead
+        ([-5.0, 0.0, 0.0], np.pi),       # dead behind
+        ([0.0, 5.0, 0.0], np.pi / 2),    # abeam
+        ([0.0, -5.0, 0.0], np.pi / 2),   # abeam, other side -- error is unsigned
+        ([0.0, 0.0, 5.0], 0.0),          # straight up: no XY bearing, no opinion
+    ):
+        got = goal_heading_error(end, np.array(target))
+        assert abs(got - expected) < 1e-6, f"target {target}: {got} != {expected}"
+    print("goal_heading_error: ok")
+
+def test_goal_behind_turns_in_place():
+    """The regression: forward-only samples all recede from a goal behind the robot,
+    so distance alone picks vx=0, and identical vx=0 endpoints leave smoothness to
+    pick omega=0 too. The robot must turn around instead of stalling."""
+    behind = np.array([-5.0, 0.0, 0.0])
+    vx_old, omega_old = _pick(behind, heading_weight=0.0)
+    assert (vx_old, omega_old) == (0.0, 0.0), f"expected the stall, got {vx_old}, {omega_old}"
+
+    vx, omega = _pick(behind, heading_weight=100.0)
+    assert abs(omega) > 1e-6, f"goal behind still yields omega={omega}"
+    print(f"goal behind: vx={vx:.3f} omega={omega:.3f} (was vx=0 omega=0)")
+
+def test_goal_ahead_still_drives_straight():
+    vx, omega = _pick(np.array([5.0, 0.0, 0.0]), heading_weight=100.0)
+    assert vx > 0.0 and abs(omega) < 1e-6, f"goal ahead yields vx={vx}, omega={omega}"
+    print(f"goal ahead: vx={vx:.3f} omega={omega:.3f}")
+
+def test_goal_abeam_turns_while_driving():
+    for side in (5.0, -5.0):
+        vx, omega = _pick(np.array([0.0, side, 0.0]), heading_weight=100.0)
+        assert vx > 0.0 and abs(omega) > 1e-6, f"goal abeam yields vx={vx}, omega={omega}"
+        print(f"goal abeam ({side:+.0f}): vx={vx:.3f} omega={omega:.3f}")
+
 if __name__ == "__main__":
+    test_goal_heading_error()
+    test_goal_behind_turns_in_place()
+    test_goal_ahead_still_drives_straight()
+    test_goal_abeam_turns_while_driving()
     test_run_raycasting_comparison()

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -323,6 +323,31 @@ def score_trajectories_by_ESDF(trajectories, ESDF_map, origin, resolution, safet
         occ_points.append(closest_step_for_traj)
     return scores, occ_points
 
+@njit(cache=True)
+def goal_heading_error(traj_end, target):
+    """Absolute yaw error at a trajectory's end: its heading vs the bearing from there to the goal.
+
+    The library is forward-only, so with the goal behind the robot every sample that
+    moves increases the endpoint distance and the distance term alone settles on
+    vx=0. All vx=0 samples then share one endpoint, leaving the smoothness term to
+    also pick omega=0: the robot stands still facing away instead of turning
+    around. Scoring the end heading breaks that tie toward the goal.
+    """
+    dx = target[0] - traj_end[0]
+    dy = target[1] - traj_end[1]
+    if dx * dx + dy * dy < 1e-6:
+        return 0.0
+
+    # world XY heading from the quaternion (body +Z forward), as in the footprint check
+    qx, qy, qz, qw = traj_end[3], traj_end[4], traj_end[5], traj_end[6]
+    fwd_x = 2.0 * (qx * qz + qw * qy)
+    fwd_y = 2.0 * (qy * qz - qw * qx)
+    if fwd_x * fwd_x + fwd_y * fwd_y < 1e-12:  # heading straight up/down: no XY bearing to compare
+        return 0.0
+
+    # atan2 of (cross, dot) is scale-free, so neither vector needs normalizing
+    return abs(np.arctan2(fwd_x * dy - fwd_y * dx, fwd_x * dx + fwd_y * dy))
+
 def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
     shift_m = new_origin - old_origin
     shift_voxels = np.round(shift_m / resolution).astype(int)
@@ -624,7 +649,13 @@ class PlanningNode(Node):
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
 
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
+                # 1 rad of end-heading error costs the same as 1 m of distance: it
+                # dominates while the goal is behind (up to pi, against the ~1.5 m a
+                # sample can cover) and yields to progress once roughly aligned, so
+                # the robot turns toward the goal instead of stalling at vx=w=0.
+                heading = goal_heading_error(traj[-1], target_pose) if target_pose is not None else 0.0
+
+                return score * 100000 + 100 * dist + 100 * heading + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]


### PR DESCRIPTION
## Problem

The trajectory library is forward-only, so with the goal behind the robot every sample that moves increases the endpoint distance. The distance term alone therefore settles on `vx=0`, and all `vx=0` samples share one endpoint (position never changes), leaving the smoothness term to pick `omega=0` as well. The result is a robot that stands still facing away from its goal.

## Change

`goal_heading_error()` — the unsigned yaw error between a trajectory's end heading and the bearing from that endpoint to the goal, using the same body-+Z-forward projection onto world XY as the ESDF footprint check. Weighted at 100 in `cost_function`, the same as one metre of distance, so it dominates while the goal is behind (up to pi rad, against the ~1.5 m a 3 s sample can cover) and yields to forward progress once roughly aligned.

Two files, +102/-2: `tinynav/core/planning_node.py` and `tests/test_planning_node.py`.

## Verification

Run in the `uniflexai/tinynav` image against this branch (i.e. rebased onto current `main`, `af5860f`), robot facing +X with an all-clear ESDF:

| goal | result |
| --- | --- |
| behind (-5, 0) | `vx=0.250 omega=-1.047` (was `vx=0 omega=0`) |
| ahead (5, 0) | `vx=0.500 omega=0.000` |
| abeam (0, +5) | `vx=0.500 omega=-0.598` |
| abeam (0, -5) | `vx=0.500 omega=+0.598` |

So the base now turns toward the goal, and arcs rather than spinning in place whenever forward progress is also available.

`pytest tests/test_planning_node.py`: the four new tests (`test_goal_heading_error`, `test_goal_behind_turns_in_place`, `test_goal_ahead_still_drives_straight`, `test_goal_abeam_turns_while_driving`) pass. `test_run_raycasting_comparison` fails, but it fails identically on unmodified `main` — pre-existing, not from this change. `ruff check ./tinynav` passes.

Test on the robot.
