### PR TITLE
feat(planning): score trajectory end heading toward the goal

### DIFF
--- a/tests/test_planning_node.py
+++ b/tests/test_planning_node.py
@@ -10,9 +10,6 @@ from planning_node import (
     run_raycasting_loopy,
     generate_trajectory_library_3d,
     goal_heading_error,
-    trajectory_cost,
-    HEADING_WEIGHT,
-    HEADING_FADE_DIST,
 )
 from tinynav.core.math_utils import matrix_to_quat
 from tinynav.tinynav_cpp_bind import run_raycasting_cpp
@@ -156,13 +153,29 @@ _FACING_X = np.array([[0.0, 0.0, 1.0],
                       [-1.0, 0.0, 0.0],
                       [0.0, -1.0, 0.0]])
 
-def _pick(target, heading_weight=HEADING_WEIGHT):
-    """Lowest-cost (vx, omega) from the planner's own trajectory_cost, with a clear ESDF
+# mirrors the regular-trajectory term of PlanningNode.cost_function (planning_node.py); keep
+# the weights (100000/100/100/10/10) and heading fade distance (2.0) in sync by hand
+_HEADING_WEIGHT = 100.0
+_HEADING_FADE_DIST = 2.0
+
+def _trajectory_cost(traj, param, score, target_end, last_param, heading_weight=_HEADING_WEIGHT):
+    dist = np.linalg.norm(np.asarray(traj[-1, :3]) - target_end)
+    heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / _HEADING_FADE_DIST)
+    return (
+        score * 100000
+        + 100 * dist
+        + heading_weight * heading
+        + 10 * abs(last_param[0] - param[0])
+        + 10 * abs(last_param[1] - param[1])
+    )
+
+def _pick(target, heading_weight=_HEADING_WEIGHT):
+    """Lowest-cost (vx, omega) from the planner's own cost terms, with a clear ESDF
     (score=0), no reverse gating and a standing start."""
     trajectories, params = generate_trajectory_library_3d(init_p=np.zeros(3), init_q=matrix_to_quat(_FACING_X))
     last_param = np.zeros(2)
     costs = [
-        trajectory_cost(trajectories[i], params[i], 0.0, target, last_param, heading_weight=heading_weight)
+        _trajectory_cost(trajectories[i], params[i], 0.0, target, last_param, heading_weight=heading_weight)
         for i in range(len(trajectories))
     ]
     return params[np.argsort(costs, kind='stable')[0]]
@@ -203,7 +216,7 @@ def test_heading_fades_within_arrival_radius():
     # the pick must still be the trajectory that lands closest to the goal
     trajectories, params = generate_trajectory_library_3d(init_p=np.zeros(3), init_q=matrix_to_quat(_FACING_X))
     close = np.array([0.4, 0.3, 0.0])
-    assert np.linalg.norm(close) < HEADING_FADE_DIST
+    assert np.linalg.norm(close) < _HEADING_FADE_DIST
 
     dists = [np.linalg.norm(trajectories[i][-1, :3] - close) for i in range(len(trajectories))]
     nearest = int(np.argmin(dists))
@@ -220,12 +233,12 @@ def test_heading_fade_is_monotonic_in_distance():
 
     def heading_term(range_m):
         target = np.array([0.0, range_m, 0.0])  # 90 deg off the nose at every range
-        return trajectory_cost(traj, param, 0.0, target, last_param) - 100 * range_m
+        return _trajectory_cost(traj, param, 0.0, target, last_param) - 100 * range_m
 
     terms = [heading_term(r) for r in (0.5, 1.0, 2.0, 4.0)]
     assert terms[0] < terms[1] < terms[2], f"heading penalty not growing with range: {terms}"
     assert abs(terms[2] - terms[3]) < 1e-9, f"heading penalty not saturated past the fade distance: {terms}"
-    assert abs(terms[2] - HEADING_WEIGHT * np.pi / 2) < 1e-9, f"saturated penalty {terms[2]} != full weight"
+    assert abs(terms[2] - _HEADING_WEIGHT * np.pi / 2) < 1e-9, f"saturated penalty {terms[2]} != full weight"
 
 if __name__ == "__main__":
     test_goal_heading_error()

--- a/tests/test_planning_node.py
+++ b/tests/test_planning_node.py
@@ -6,7 +6,8 @@ import os
 from numba import njit
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tinynav', 'core'))
-from planning_node import run_raycasting_loopy
+from planning_node import run_raycasting_loopy, generate_trajectory_library_3d, goal_heading_error
+from tinynav.core.math_utils import matrix_to_quat
 from tinynav.tinynav_cpp_bind import run_raycasting_cpp
 
 @njit
@@ -143,5 +144,58 @@ def test_run_raycasting_comparison():
             print_diffs(py_occupancy_grid, cpp_occupancy_grid, "Vectorized", "C++")
         assert False, "Implementations do not match."
 
+# body +Z (forward) along world +X, body +Y (down) along world -Z: the camera convention
+_FACING_X = np.array([[0.0, 0.0, 1.0],
+                      [-1.0, 0.0, 0.0],
+                      [0.0, -1.0, 0.0]])
+
+def _pick(target, heading_weight):
+    """Lowest-cost (vx, omega) from cost_function with a clear ESDF and no reverse gating."""
+    trajectories, params = generate_trajectory_library_3d(init_p=np.zeros(3), init_q=matrix_to_quat(_FACING_X))
+    last_param = np.zeros(2)
+    costs = [
+        100 * np.linalg.norm(trajectories[i][-1, :3] - target)
+        + heading_weight * goal_heading_error(trajectories[i][-1], target)
+        + 10 * abs(last_param[0] - params[i, 0])
+        + 10 * abs(last_param[1] - params[i, 1])
+        for i in range(len(trajectories))
+    ]
+    return params[np.argsort(costs, kind='stable')[0]]
+
+def test_goal_heading_error():
+    end = np.zeros(7)
+    end[3:] = matrix_to_quat(_FACING_X)
+    for target, expected in (
+        ([5.0, 0.0, 0.0], 0.0),
+        ([-5.0, 0.0, 0.0], np.pi),
+        ([0.0, 5.0, 0.0], np.pi / 2),
+        ([0.0, -5.0, 0.0], np.pi / 2),  # unsigned, so both sides score the same
+        ([0.0, 0.0, 5.0], 0.0),         # no XY bearing
+    ):
+        got = goal_heading_error(end, np.array(target))
+        assert abs(got - expected) < 1e-6, f"target {target}: {got} != {expected}"
+
+def test_goal_behind_turns_in_place():
+    # forward-only samples all recede from a target behind, so distance alone picks vx=0,
+    # and the shared vx=0 endpoint leaves smoothness to pick omega=0 too
+    behind = np.array([-5.0, 0.0, 0.0])
+    assert tuple(_pick(behind, heading_weight=0.0)) == (0.0, 0.0)
+
+    vx, omega = _pick(behind, heading_weight=100.0)
+    assert abs(omega) > 1e-6, f"target behind still yields omega={omega}"
+
+def test_goal_ahead_still_drives_straight():
+    vx, omega = _pick(np.array([5.0, 0.0, 0.0]), heading_weight=100.0)
+    assert vx > 0.0 and abs(omega) < 1e-6, f"target ahead yields vx={vx}, omega={omega}"
+
+def test_goal_abeam_turns_while_driving():
+    for side in (5.0, -5.0):
+        vx, omega = _pick(np.array([0.0, side, 0.0]), heading_weight=100.0)
+        assert vx > 0.0 and abs(omega) > 1e-6, f"target abeam yields vx={vx}, omega={omega}"
+
 if __name__ == "__main__":
+    test_goal_heading_error()
+    test_goal_behind_turns_in_place()
+    test_goal_ahead_still_drives_straight()
+    test_goal_abeam_turns_while_driving()
     test_run_raycasting_comparison()

--- a/tests/test_planning_node.py
+++ b/tests/test_planning_node.py
@@ -6,7 +6,14 @@ import os
 from numba import njit
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tinynav', 'core'))
-from planning_node import run_raycasting_loopy, generate_trajectory_library_3d, goal_heading_error
+from planning_node import (
+    run_raycasting_loopy,
+    generate_trajectory_library_3d,
+    goal_heading_error,
+    trajectory_cost,
+    HEADING_WEIGHT,
+    HEADING_FADE_DIST,
+)
 from tinynav.core.math_utils import matrix_to_quat
 from tinynav.tinynav_cpp_bind import run_raycasting_cpp
 
@@ -149,15 +156,13 @@ _FACING_X = np.array([[0.0, 0.0, 1.0],
                       [-1.0, 0.0, 0.0],
                       [0.0, -1.0, 0.0]])
 
-def _pick(target, heading_weight):
-    """Lowest-cost (vx, omega) from cost_function with a clear ESDF and no reverse gating."""
+def _pick(target, heading_weight=HEADING_WEIGHT):
+    """Lowest-cost (vx, omega) from the planner's own trajectory_cost, with a clear ESDF
+    (score=0), no reverse gating and a standing start."""
     trajectories, params = generate_trajectory_library_3d(init_p=np.zeros(3), init_q=matrix_to_quat(_FACING_X))
     last_param = np.zeros(2)
     costs = [
-        100 * np.linalg.norm(trajectories[i][-1, :3] - target)
-        + heading_weight * goal_heading_error(trajectories[i][-1], target)
-        + 10 * abs(last_param[0] - params[i, 0])
-        + 10 * abs(last_param[1] - params[i, 1])
+        trajectory_cost(trajectories[i], params[i], 0.0, target, last_param, heading_weight=heading_weight)
         for i in range(len(trajectories))
     ]
     return params[np.argsort(costs, kind='stable')[0]]
@@ -181,21 +186,52 @@ def test_goal_behind_turns_in_place():
     behind = np.array([-5.0, 0.0, 0.0])
     assert tuple(_pick(behind, heading_weight=0.0)) == (0.0, 0.0)
 
-    vx, omega = _pick(behind, heading_weight=100.0)
+    vx, omega = _pick(behind)
     assert abs(omega) > 1e-6, f"target behind still yields omega={omega}"
 
 def test_goal_ahead_still_drives_straight():
-    vx, omega = _pick(np.array([5.0, 0.0, 0.0]), heading_weight=100.0)
+    vx, omega = _pick(np.array([5.0, 0.0, 0.0]))
     assert vx > 0.0 and abs(omega) < 1e-6, f"target ahead yields vx={vx}, omega={omega}"
 
 def test_goal_abeam_turns_while_driving():
     for side in (5.0, -5.0):
-        vx, omega = _pick(np.array([0.0, side, 0.0]), heading_weight=100.0)
+        vx, omega = _pick(np.array([0.0, side, 0.0]))
         assert vx > 0.0 and abs(omega) > 1e-6, f"target abeam yields vx={vx}, omega={omega}"
+
+def test_heading_fades_within_arrival_radius():
+    # inside HEADING_FADE_DIST the heading term is scaled down, so it cannot outbid distance:
+    # the pick must still be the trajectory that lands closest to the goal
+    trajectories, params = generate_trajectory_library_3d(init_p=np.zeros(3), init_q=matrix_to_quat(_FACING_X))
+    close = np.array([0.4, 0.3, 0.0])
+    assert np.linalg.norm(close) < HEADING_FADE_DIST
+
+    dists = [np.linalg.norm(trajectories[i][-1, :3] - close) for i in range(len(trajectories))]
+    nearest = int(np.argmin(dists))
+    picked = _pick(close)
+    assert tuple(picked) == tuple(params[nearest]), f"close goal picked {picked}, not nearest {params[nearest]}"
+
+def test_heading_fade_is_monotonic_in_distance():
+    # same bearing error, different range: the heading penalty grows with distance and saturates
+    end = np.zeros(7)
+    end[3:] = matrix_to_quat(_FACING_X)
+    traj = end[None, :]
+    last_param = np.zeros(2)
+    param = np.zeros(2)
+
+    def heading_term(range_m):
+        target = np.array([0.0, range_m, 0.0])  # 90 deg off the nose at every range
+        return trajectory_cost(traj, param, 0.0, target, last_param) - 100 * range_m
+
+    terms = [heading_term(r) for r in (0.5, 1.0, 2.0, 4.0)]
+    assert terms[0] < terms[1] < terms[2], f"heading penalty not growing with range: {terms}"
+    assert abs(terms[2] - terms[3]) < 1e-9, f"heading penalty not saturated past the fade distance: {terms}"
+    assert abs(terms[2] - HEADING_WEIGHT * np.pi / 2) < 1e-9, f"saturated penalty {terms[2]} != full weight"
 
 if __name__ == "__main__":
     test_goal_heading_error()
     test_goal_behind_turns_in_place()
     test_goal_ahead_still_drives_straight()
     test_goal_abeam_turns_while_driving()
+    test_heading_fades_within_arrival_radius()
+    test_heading_fade_is_monotonic_in_distance()
     test_run_raycasting_comparison()

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -280,6 +280,24 @@ def goal_heading_error(traj_end, target):
     fwd_y = 2.0 * (qy * qz - qw * qx)
     return abs(np.arctan2(fwd_x * dy - fwd_y * dx, fwd_x * dx + fwd_y * dy))
 
+# heading error is weighted like distance (1 rad ~ 1 m) far from the goal, then faded out
+# linearly inside HEADING_FADE_DIST so bearing noise cannot dominate the distance term on arrival
+HEADING_WEIGHT = 100.0
+HEADING_FADE_DIST = 2.0
+
+def trajectory_cost(traj, param, score, target_end, last_param, reverse_gate_penalty=0.0, heading_weight=HEADING_WEIGHT):
+    """Cost of one candidate trajectory: collision, goal distance, end heading, control smoothness."""
+    dist = np.linalg.norm(np.asarray(traj[-1, :3]) - target_end)
+    heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / HEADING_FADE_DIST)
+    return (
+        score * 100000
+        + 100 * dist
+        + heading_weight * heading
+        + 10 * abs(last_param[0] - param[0])
+        + 10 * abs(last_param[1] - param[1])
+        + reverse_gate_penalty
+    )
+
 def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
     shift_m = new_origin - old_origin
     shift_voxels = np.round(shift_m / resolution).astype(int)
@@ -583,12 +601,8 @@ class PlanningNode(Node):
                 # regular trajectory penalty
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
-                dist = np.linalg.norm(traj_end - target_end)
 
-                # 1 rad of end-heading error costs like 1 m, so a target behind turns the robot instead of stalling at vx=omega=0
-                heading = goal_heading_error(traj[-1], target_end)
-
-                return score * 100000 + 100 * dist + 100 * heading + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
+                return trajectory_cost(traj, param, score, target_end, self.last_param, reverse_gate_penalty)
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -280,24 +280,6 @@ def goal_heading_error(traj_end, target):
     fwd_y = 2.0 * (qy * qz - qw * qx)
     return abs(np.arctan2(fwd_x * dy - fwd_y * dx, fwd_x * dx + fwd_y * dy))
 
-# heading error is weighted like distance (1 rad ~ 1 m) far from the goal, then faded out
-# linearly inside HEADING_FADE_DIST so bearing noise cannot dominate the distance term on arrival
-HEADING_WEIGHT = 100.0
-HEADING_FADE_DIST = 2.0
-
-def trajectory_cost(traj, param, score, target_end, last_param, reverse_gate_penalty=0.0, heading_weight=HEADING_WEIGHT):
-    """Cost of one candidate trajectory: collision, goal distance, end heading, control smoothness."""
-    dist = np.linalg.norm(np.asarray(traj[-1, :3]) - target_end)
-    heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / HEADING_FADE_DIST)
-    return (
-        score * 100000
-        + 100 * dist
-        + heading_weight * heading
-        + 10 * abs(last_param[0] - param[0])
-        + 10 * abs(last_param[1] - param[1])
-        + reverse_gate_penalty
-    )
-
 def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
     shift_m = new_origin - old_origin
     shift_voxels = np.round(shift_m / resolution).astype(int)
@@ -601,8 +583,19 @@ class PlanningNode(Node):
                 # regular trajectory penalty
                 traj_end = np.array(traj[-1,:3])
                 target_end = target_pose if target_pose is not None else traj_end
+                dist = np.linalg.norm(traj_end - target_end)
+                # heading error weighted like distance (1 rad ~ 1 m) far from the goal, faded out
+                # linearly inside 2 m so bearing noise cannot dominate the distance term on arrival
+                heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / 2.0)
 
-                return trajectory_cost(traj, param, score, target_end, self.last_param, reverse_gate_penalty)
+                return (
+                    score * 100000
+                    + 100 * dist
+                    + 100 * heading
+                    + 10 * abs(self.last_param[0] - param[0])
+                    + 10 * abs(self.last_param[1] - param[1])
+                    + reverse_gate_penalty
+                )
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -5,6 +5,7 @@ from nav_msgs.msg import Path, Odometry, OccupancyGrid
 from cv_bridge import CvBridge
 import numpy as np
 from scipy.ndimage import distance_transform_edt, binary_dilation
+from scipy.spatial.transform import Rotation as R
 from numba import njit
 import message_filters
 from rclpy.time import Time
@@ -267,18 +268,13 @@ def score_trajectories_by_ESDF(trajectories, ESDF_map, origin, resolution, safet
         occ_points.append(closest_step_for_traj)
     return scores, occ_points
 
-@njit(cache=True)
 def goal_heading_error(traj_end, target):
-    """Absolute yaw error between a trajectory's end heading and the bearing to the target.
-    Degenerate input (target at the end point, heading straight up) scores 0."""
+    """Absolute yaw error between a trajectory's end heading and the bearing to the target."""
     dx = target[0] - traj_end[0]
     dy = target[1] - traj_end[1]
-    qx, qy, qz, qw = traj_end[3], traj_end[4], traj_end[5], traj_end[6]
-
-    # world XY forward from quaternion (body +Z forward)
-    fwd_x = 2.0 * (qx * qz + qw * qy)
-    fwd_y = 2.0 * (qy * qz - qw * qx)
-    return abs(np.arctan2(fwd_x * dy - fwd_y * dx, fwd_x * dx + fwd_y * dy))
+    yaw1 = R.from_quat(traj_end[3:7]).as_euler("xyz")[2] + np.pi / 2
+    yaw2 = np.arctan2(dy, dx)
+    return abs(np.arctan2(np.sin(yaw2 - yaw1), np.cos(yaw2 - yaw1)))
 
 def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
     shift_m = new_origin - old_origin

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -267,6 +267,19 @@ def score_trajectories_by_ESDF(trajectories, ESDF_map, origin, resolution, safet
         occ_points.append(closest_step_for_traj)
     return scores, occ_points
 
+@njit(cache=True)
+def goal_heading_error(traj_end, target):
+    """Absolute yaw error between a trajectory's end heading and the bearing to the target.
+    Degenerate input (target at the end point, heading straight up) scores 0."""
+    dx = target[0] - traj_end[0]
+    dy = target[1] - traj_end[1]
+    qx, qy, qz, qw = traj_end[3], traj_end[4], traj_end[5], traj_end[6]
+
+    # world XY forward from quaternion (body +Z forward)
+    fwd_x = 2.0 * (qx * qz + qw * qy)
+    fwd_y = 2.0 * (qy * qz - qw * qx)
+    return abs(np.arctan2(fwd_x * dy - fwd_y * dx, fwd_x * dx + fwd_y * dy))
+
 def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
     shift_m = new_origin - old_origin
     shift_voxels = np.round(shift_m / resolution).astype(int)
@@ -572,7 +585,10 @@ class PlanningNode(Node):
                 target_end = target_pose if target_pose is not None else traj_end
                 dist = np.linalg.norm(traj_end - target_end)
 
-                return score * 100000 + 100 * dist + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
+                # 1 rad of end-heading error costs like 1 m, so a target behind turns the robot instead of stalling at vx=omega=0
+                heading = goal_heading_error(traj[-1], target_end)
+
+                return score * 100000 + 100 * dist + 100 * heading + 10 * abs(self.last_param[0] - param[0]) + 10 * abs(self.last_param[1] - param[1]) + reverse_gate_penalty
 
             top_k = 1
             top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]


### PR DESCRIPTION
## Summary
- Adds `goal_heading_error()` to `planning_node.py`: the absolute yaw error between a
  trajectory's end heading and the bearing from there to the target, taken in world XY.
- Weights it into the DWA `cost_function` at `100 * heading`, the same weight as `100 * dist`,
  so 1 rad of end-heading error costs about as much as 1 m of distance.
- Fixes a stall when the target is behind the robot: the trajectory library is forward-only, so
  every moving sample increases the endpoint distance and the distance term alone settles on
  vx=0. All vx=0 samples then share one endpoint, leaving the smoothness term to pick omega=0
  too, and the robot stands still facing away instead of turning around. Scoring the end heading
  breaks that tie toward the target.

## Test plan
- [x] `python tests/test_planning_node.py`: `goal_heading_error` matches ahead / behind / abeam
      by hand, and library picks stay correct - target behind now yields omega != 0 (was vx=omega=0),
      target ahead still drives straight, target abeam turns while driving
- [x] On-robot check that the turn-around is smooth and does not oscillate near the target

## Videos
### With Heading Cost
[with_heading_real.webm](https://github.com/user-attachments/assets/deb051e9-152a-4612-affb-b3b03b0594eb)
### No Heading Cost
[no_heading_real.webm](https://github.com/user-attachments/assets/90eb5b67-8030-484a-9c83-3ff0b7568dc2)
