### PR TITLE
feat(sim): add ROS web lab for planning and cmd_vel debugging

### DIFF
--- a/scripts/run_offline_planning_web.sh
+++ b/scripts/run_offline_planning_web.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+cd /tinynav
+source /opt/ros/humble/setup.bash
+uv run python tool/simulator/ros_planning_web.py

--- a/scripts/run_offline_planning_web.sh
+++ b/scripts/run_offline_planning_web.sh
@@ -2,5 +2,7 @@
 set -euo pipefail
 
 cd /tinynav
+set +u
 source /opt/ros/humble/setup.bash
+set -u
 uv run python tool/simulator/ros_planning_web.py

--- a/tool/simulator/offline_planning_mvp.py
+++ b/tool/simulator/offline_planning_mvp.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+"""Offline perception-to-planning MVP for tinynav.
+
+This intentionally stays small and inspectable:
+  scene objects -> synthetic depth -> tinynav raycasting -> obstacle/ESDF -> trajectory scoring
+
+Example:
+  uv run python tool/simulator/offline_planning_mvp.py
+  uv run python tool/simulator/offline_planning_mvp.py --write-example /tmp/scene.json
+  uv run python tool/simulator/offline_planning_mvp.py --config /tmp/scene.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from numba import njit
+from scipy.ndimage import distance_transform_edt
+from scipy.spatial.transform import Rotation as R
+
+from tinynav.core.planning_node import (
+    B2_CONFIG,
+    GO2_CONFIG,
+    ObstacleConfig,
+    build_obstacle_map,
+    generate_predefined_trajectory_vocabularies,
+    generate_trajectory_library_3d,
+    score_trajectories_by_ESDF,
+    select_trajectory_with_recovery,
+)
+
+
+@dataclass
+class SimObject:
+    name: str
+    kind: str
+    center: tuple[float, float, float]
+    size: tuple[float, float, float]
+
+    @property
+    def bounds(self) -> tuple[np.ndarray, np.ndarray]:
+        center = np.asarray(self.center, dtype=np.float64)
+        half = np.asarray(self.size, dtype=np.float64) / 2.0
+        return center - half, center + half
+
+
+def default_config() -> dict:
+    return {
+        "name": "narrow_passage",
+        "output_dir": "outputs/offline_planning_mvp",
+        "robot": {
+            "preset": "b2",
+            "length": 1.0,
+            "width": 0.5,
+            "camera_x": 0.5,
+            "control_x": 0.5,
+            "safety_radius": 0.1,
+            "comfort_radius": 0.1,
+        },
+        "grid": {
+            "shape": [120, 100, 40],
+            "resolution": 0.1,
+            "origin": [-2.0, -5.0, -1.0],
+        },
+        "camera": {
+            "width": 160,
+            "image_height": 100,
+            "fx": 120.0,
+            "fy": 120.0,
+            "max_range": 6.0,
+            "ray_step": 3,
+            "mount_height": 0.45,
+        },
+        "start": {"xy": [0.0, 0.0], "yaw_deg": 0.0},
+        "target": [4.0, 0.0, 0.0],
+        "planner": {
+            "num_samples": 21,
+            "duration": 3.0,
+            "dt": 0.1,
+            "vx_max": 0.5,
+            "reverse_speed": 0.3,
+            "reverse_omegas": [0.0, -0.5, 0.5],
+            "front_reverse_threshold": 0.3,
+            "trajectory_smooth_weight": 10.0,
+            "last_param": [0.0, 0.0],
+        },
+        "obstacle": {
+            "robot_z_bottom": -0.5,
+            "robot_z_top": 0.4,
+            "occ_threshold": 0.09,
+            "min_wall_span_m": 0.35,
+            "dilation_cells": 1,
+        },
+        "objects": [
+            {"name": "left_wall", "kind": "box", "center": [2.0, 1.0, 0.35], "size": [3.2, 0.25, 1.3]},
+            {"name": "right_wall", "kind": "box", "center": [2.0, -1.0, 0.35], "size": [3.2, 0.25, 1.3]},
+            {"name": "center_box", "kind": "box", "center": [1.65, 0.0, 0.25], "size": [0.45, 0.55, 0.5]},
+        ],
+    }
+
+
+def deep_update(base: dict, patch: dict) -> dict:
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def load_config(path: str | None) -> dict:
+    config = default_config()
+    if path:
+        with open(path, "r", encoding="utf-8") as f:
+            deep_update(config, json.load(f))
+    return config
+
+
+def robot_from_config(config: dict):
+    preset = config["robot"].get("preset", "b2").lower()
+    robot = B2_CONFIG if preset == "b2" else GO2_CONFIG
+    robot = type(robot)(**asdict(robot))
+    for key, value in config["robot"].items():
+        if key != "preset" and hasattr(robot, key):
+            setattr(robot, key, value)
+    if not hasattr(robot, "comfort_radius"):
+        robot.comfort_radius = config["robot"].get("comfort_radius", 0.8)
+    return robot
+
+
+def make_camera_pose(start_xy: list[float], yaw_deg: float, camera_height: float,
+                     forward_offset: float = 0.0, left_offset: float = 0.0) -> tuple[np.ndarray, np.ndarray]:
+    yaw = np.deg2rad(yaw_deg)
+    forward = np.array([np.cos(yaw), np.sin(yaw), 0.0], dtype=np.float64)
+    left = np.array([-np.sin(yaw), np.cos(yaw), 0.0], dtype=np.float64)
+    right = np.array([np.sin(yaw), -np.cos(yaw), 0.0], dtype=np.float64)
+    down = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    rot = np.column_stack([right, down, forward])
+    T = np.eye(4, dtype=np.float64)
+    T[:3, :3] = rot
+    camera_xy = np.asarray([start_xy[0], start_xy[1], 0.0], dtype=np.float64)
+    camera_xy = camera_xy + forward * float(forward_offset) + left * float(left_offset)
+    T[:3, 3] = [camera_xy[0], camera_xy[1], camera_height]
+    return T, R.from_matrix(rot).as_quat()
+
+
+def intersect_box(origin: np.ndarray, direction: np.ndarray, obj: SimObject, max_range: float) -> float:
+    box_min, box_max = obj.bounds
+    inv_d = np.divide(1.0, direction, out=np.full(3, np.inf), where=np.abs(direction) > 1e-9)
+    t0 = (box_min - origin) * inv_d
+    t1 = (box_max - origin) * inv_d
+    t_near = np.maximum.reduce(np.minimum(t0, t1))
+    t_far = np.minimum.reduce(np.maximum(t0, t1))
+    if t_far < 0.0 or t_near > t_far:
+        return np.inf
+    hit = t_near if t_near > 0.0 else t_far
+    return hit if 0.0 < hit <= max_range else np.inf
+
+
+@njit(cache=True)
+def render_depth_boxes(bounds_min: np.ndarray, bounds_max: np.ndarray, T_cam_to_world: np.ndarray,
+                       width: int, height: int, fx: float, fy: float, cx: float, cy: float,
+                       max_range: float) -> tuple[np.ndarray, np.ndarray]:
+    depth = np.zeros((height, width), dtype=np.float32)
+    hit_mask = np.zeros((height, width), dtype=np.bool_)
+    cam_origin = T_cam_to_world[:3, 3]
+    rot = T_cam_to_world[:3, :3]
+
+    for v in range(height):
+        for u in range(width):
+            ray_cam_x = (u - cx) / fx
+            ray_cam_y = (v - cy) / fy
+            ray_cam_z = 1.0
+            norm = np.sqrt(ray_cam_x * ray_cam_x + ray_cam_y * ray_cam_y + ray_cam_z * ray_cam_z)
+            ray_cam_x /= norm
+            ray_cam_y /= norm
+            ray_cam_z /= norm
+
+            ray_world_x = rot[0, 0] * ray_cam_x + rot[0, 1] * ray_cam_y + rot[0, 2] * ray_cam_z
+            ray_world_y = rot[1, 0] * ray_cam_x + rot[1, 1] * ray_cam_y + rot[1, 2] * ray_cam_z
+            ray_world_z = rot[2, 0] * ray_cam_x + rot[2, 1] * ray_cam_y + rot[2, 2] * ray_cam_z
+
+            best = np.inf
+            for obj_idx in range(bounds_min.shape[0]):
+                t_near = -np.inf
+                t_far = np.inf
+                valid = True
+                for axis in range(3):
+                    if axis == 0:
+                        ray = ray_world_x
+                        origin = cam_origin[0]
+                    elif axis == 1:
+                        ray = ray_world_y
+                        origin = cam_origin[1]
+                    else:
+                        ray = ray_world_z
+                        origin = cam_origin[2]
+
+                    if abs(ray) <= 1e-9:
+                        if origin < bounds_min[obj_idx, axis] or origin > bounds_max[obj_idx, axis]:
+                            valid = False
+                            break
+                        continue
+
+                    inv_ray = 1.0 / ray
+                    t0 = (bounds_min[obj_idx, axis] - origin) * inv_ray
+                    t1 = (bounds_max[obj_idx, axis] - origin) * inv_ray
+                    if t0 > t1:
+                        tmp = t0
+                        t0 = t1
+                        t1 = tmp
+                    if t0 > t_near:
+                        t_near = t0
+                    if t1 < t_far:
+                        t_far = t1
+
+                if not valid or t_far < 0.0 or t_near > t_far:
+                    continue
+                hit = t_near if t_near > 0.0 else t_far
+                if 0.0 < hit <= max_range and hit < best:
+                    best = hit
+
+            if np.isfinite(best):
+                depth[v, u] = best * ray_cam_z
+                hit_mask[v, u] = True
+    return depth, hit_mask
+
+
+def render_depth(objects: list[SimObject], T_cam_to_world: np.ndarray, cam: dict) -> tuple[np.ndarray, np.ndarray]:
+    width = int(cam["width"])
+    height = int(cam.get("image_height", cam.get("height", 100)))
+    fx = float(cam["fx"])
+    fy = float(cam["fy"])
+    cx = (width - 1) / 2.0
+    cy = (height - 1) / 2.0
+    max_range = float(cam["max_range"])
+    bounds_min = np.zeros((len(objects), 3), dtype=np.float64)
+    bounds_max = np.zeros((len(objects), 3), dtype=np.float64)
+    for idx, obj in enumerate(objects):
+        bounds_min[idx], bounds_max[idx] = obj.bounds
+    return render_depth_boxes(bounds_min, bounds_max, T_cam_to_world, width, height, fx, fy, cx, cy, max_range)
+
+
+@njit(cache=True)
+def run_synthetic_raycasting(depth_image, hit_mask, T_cam_to_world, grid_shape, fx, fy, cx, cy,
+                             origin, step, resolution, max_range):
+    """Raycast synthetic depth.
+
+    All rays carve free space. Only rays that hit an object add occupied evidence
+    at the endpoint. This matches real planning behavior better than skipping
+    no-hit pixels, because moved-away objects become observed free space.
+    """
+    occupancy_grid = np.zeros(grid_shape, dtype=np.float64)
+    depth_height, depth_width = depth_image.shape
+    grid_shape_x, grid_shape_y, grid_shape_z = grid_shape
+    origin_x, origin_y, origin_z = origin
+
+    cam_orig_x = T_cam_to_world[0, 3]
+    cam_orig_y = T_cam_to_world[1, 3]
+    cam_orig_z = T_cam_to_world[2, 3]
+
+    start_voxel_x = int(np.floor((cam_orig_x - origin_x) / resolution))
+    start_voxel_y = int(np.floor((cam_orig_y - origin_y) / resolution))
+    start_voxel_z = int(np.floor((cam_orig_z - origin_z) / resolution))
+
+    for v in range(0, depth_height, step):
+        for u in range(0, depth_width, step):
+            hit = bool(hit_mask[v, u])
+            d = float(depth_image[v, u]) if hit else float(max_range)
+            if (not np.isfinite(d)) or d <= 0:
+                continue
+
+            px = (u - cx) * d / fx
+            py = (v - cy) * d / fy
+            pz = d
+
+            pw_x = T_cam_to_world[0, 0] * px + T_cam_to_world[0, 1] * py + T_cam_to_world[0, 2] * pz + T_cam_to_world[0, 3]
+            pw_y = T_cam_to_world[1, 0] * px + T_cam_to_world[1, 1] * py + T_cam_to_world[1, 2] * pz + T_cam_to_world[1, 3]
+            pw_z = T_cam_to_world[2, 0] * px + T_cam_to_world[2, 1] * py + T_cam_to_world[2, 2] * pz + T_cam_to_world[2, 3]
+
+            end_voxel_x = int(np.floor((pw_x - origin_x) / resolution))
+            end_voxel_y = int(np.floor((pw_y - origin_y) / resolution))
+            end_voxel_z = int(np.floor((pw_z - origin_z) / resolution))
+
+            diff_x = end_voxel_x - start_voxel_x
+            diff_y = end_voxel_y - start_voxel_y
+            diff_z = end_voxel_z - start_voxel_z
+            steps = max(abs(diff_x), abs(diff_y), abs(diff_z))
+            if steps == 0:
+                continue
+
+            for i in range(steps + 1):
+                t = i / steps
+                interp_x = int(round(start_voxel_x + t * diff_x))
+                interp_y = int(round(start_voxel_y + t * diff_y))
+                interp_z = int(round(start_voxel_z + t * diff_z))
+                if (0 <= interp_x < grid_shape_x and
+                    0 <= interp_y < grid_shape_y and
+                    0 <= interp_z < grid_shape_z):
+                    occupancy_grid[interp_x, interp_y, interp_z] -= 0.05
+
+            if hit and (0 <= end_voxel_x < grid_shape_x and
+                        0 <= end_voxel_y < grid_shape_y and
+                        0 <= end_voxel_z < grid_shape_z):
+                occupancy_grid[end_voxel_x, end_voxel_y, end_voxel_z] += 0.2
+
+    return np.clip(occupancy_grid, -0.1, 0.1)
+
+
+def front_obstacle_dist(center: np.ndarray, yaw_deg: float, obstacle_mask: np.ndarray, origin: np.ndarray,
+                        resolution: float, front_len: float, half_w: float, max_dist: float = 2.0) -> float:
+    yaw = np.deg2rad(yaw_deg)
+    fwd = np.array([np.cos(yaw), np.sin(yaw)], dtype=np.float64)
+    left = np.array([-fwd[1], fwd[0]], dtype=np.float64)
+    steps = int(max_dist / resolution) + 1
+    rows, cols = obstacle_mask.shape
+    for step in range(steps):
+        d_from_face = step * resolution
+        d_from_center = front_len + d_from_face
+        for w in (-half_w, 0.0, half_w):
+            p = center[:2] + fwd * d_from_center + left * w
+            ix = int((p[0] - origin[0]) / resolution)
+            iy = int((p[1] - origin[1]) / resolution)
+            if 0 <= ix < rows and 0 <= iy < cols and obstacle_mask[ix, iy]:
+                return d_from_face
+    return max_dist + resolution
+
+
+def generate_forward_trajectories(planner: dict, init_p: np.ndarray, init_q: np.ndarray):
+    kwargs = {
+        "num_samples": int(planner["num_samples"]),
+        "duration": float(planner["duration"]),
+        "dt": float(planner["dt"]),
+        "init_p": init_p,
+        "init_q": init_q,
+    }
+    try:
+        return generate_trajectory_library_3d(**kwargs, vx_max=float(planner["vx_max"]))
+    except TypeError as exc:
+        if "vx_max" not in str(exc) and "too many arguments" not in str(exc):
+            raise
+        return generate_trajectory_library_3d(**kwargs)
+
+
+def generate_reverse_trajectories(planner: dict, init_p: np.ndarray, init_q: np.ndarray):
+    kwargs = {
+        "duration": float(planner["duration"]),
+        "dt": float(planner["dt"]),
+        "init_p": init_p,
+        "init_q": init_q,
+    }
+    try:
+        return generate_predefined_trajectory_vocabularies(
+            **kwargs,
+            reverse_speed=float(planner["reverse_speed"]),
+            reverse_omegas=tuple(float(v) for v in planner["reverse_omegas"]),
+        )
+    except TypeError as exc:
+        if "reverse_speed" not in str(exc) and "reverse_omegas" not in str(exc):
+            raise
+        return generate_predefined_trajectory_vocabularies(**kwargs)
+
+
+def score_trajectories_compat(trajectories: np.ndarray, esdf: np.ndarray, origin: np.ndarray, resolution: float,
+                              robot, front_len: float, rear_len: float, half_w: float):
+    try:
+        return score_trajectories_by_ESDF(
+            trajectories,
+            esdf,
+            origin,
+            resolution,
+            float(robot.safety_radius),
+            float(robot.comfort_radius),
+            front_len,
+            rear_len,
+            half_w,
+        )
+    except TypeError as exc:
+        if "too many arguments" not in str(exc):
+            raise
+        return score_trajectories_by_ESDF(
+            trajectories,
+            esdf,
+            origin,
+            resolution,
+            float(robot.safety_radius),
+            front_len,
+            rear_len,
+            half_w,
+        )
+
+
+def footprint_polygon(pose: np.ndarray, front_len: float, rear_len: float, half_w: float) -> np.ndarray:
+    x, y, _, qx, qy, qz, qw = pose
+    fwd = np.array([2.0 * (qx * qz + qw * qy), 2.0 * (qy * qz - qw * qx)])
+    n = np.linalg.norm(fwd)
+    fwd = fwd / n if n > 1e-6 else np.array([1.0, 0.0])
+    left = np.array([-fwd[1], fwd[0]])
+    center = np.array([x, y])
+    return np.array([
+        center + fwd * front_len + left * half_w,
+        center + fwd * front_len - left * half_w,
+        center - fwd * rear_len - left * half_w,
+        center - fwd * rear_len + left * half_w,
+        center + fwd * front_len + left * half_w,
+    ])
+
+
+def trajectory_xy(traj: np.ndarray) -> list[list[float]]:
+    return [[float(p[0]), float(p[1])] for p in traj]
+
+
+def trajectory_yaw_deg(traj: np.ndarray) -> list[float]:
+    return [yaw_from_pose(p) for p in traj]
+
+
+def footprint_xy_series(traj: np.ndarray, front_len: float, rear_len: float, half_w: float) -> list[list[list[float]]]:
+    return [
+        [[float(p[0]), float(p[1])] for p in footprint_polygon(pose, front_len, rear_len, half_w)]
+        for pose in traj
+    ]
+
+def image_u8_payload(image: np.ndarray, vmin: float, vmax: float) -> dict:
+    clipped = np.clip((image.astype(np.float32) - vmin) / max(vmax - vmin, 1e-6), 0.0, 1.0)
+    u8 = np.round(clipped * 255.0).astype(np.uint8)
+    return {
+        "width": int(u8.shape[1]),
+        "height": int(u8.shape[0]),
+        "data": u8.ravel().tolist(),
+    }
+
+
+def mask_u8_payload(mask: np.ndarray) -> dict:
+    u8 = np.where(mask, 255, 0).astype(np.uint8)
+    return {
+        "width": int(u8.shape[1]),
+        "height": int(u8.shape[0]),
+        "data": u8.ravel().tolist(),
+    }
+
+
+def plot_result(config: dict, objects: list[SimObject], depth: np.ndarray, obstacle_mask: np.ndarray,
+                esdf: np.ndarray, trajectories: np.ndarray, scores: np.ndarray, costs: np.ndarray,
+                selected_index: int, robot, output_png: Path) -> None:
+    origin = np.asarray(config["grid"]["origin"], dtype=np.float64)
+    resolution = float(config["grid"]["resolution"])
+    extent = [
+        origin[1],
+        origin[1] + obstacle_mask.shape[1] * resolution,
+        origin[0],
+        origin[0] + obstacle_mask.shape[0] * resolution,
+    ]
+    target = np.asarray(config["target"], dtype=np.float64)
+    front_len, rear_len, half_w = robot.footprint_from_control()
+
+    fig, axes = plt.subplots(2, 2, figsize=(14, 11), constrained_layout=True)
+    ax_scene, ax_depth, ax_esdf, ax_traj = axes.ravel()
+
+    ax_scene.set_title("Scene layout")
+    for obj in objects:
+        bmin, bmax = obj.bounds
+        rect = plt.Rectangle((bmin[1], bmin[0]), bmax[1] - bmin[1], bmax[0] - bmin[0],
+                             facecolor="#777777", alpha=0.55, edgecolor="black")
+        ax_scene.add_patch(rect)
+        ax_scene.text(obj.center[1], obj.center[0], obj.name, ha="center", va="center", fontsize=8)
+    ax_scene.scatter([0.0], [0.0], c="tab:green", label="start")
+    ax_scene.scatter([target[1]], [target[0]], c="tab:red", label="target")
+    ax_scene.set_xlabel("world y")
+    ax_scene.set_ylabel("world x")
+    ax_scene.axis("equal")
+    ax_scene.legend(loc="upper right")
+
+    ax_depth.set_title("Synthetic depth")
+    ax_depth.imshow(depth, cmap="magma")
+    ax_depth.set_axis_off()
+
+    ax_esdf.set_title("Perceived obstacles + ESDF")
+    esdf_img = ax_esdf.imshow(esdf, origin="lower", extent=extent, cmap="viridis", vmin=0.0, vmax=1.5)
+    ax_esdf.contour(obstacle_mask.T, levels=[0.5], origin="lower", extent=extent, colors="white", linewidths=0.8)
+    fig.colorbar(esdf_img, ax=ax_esdf, label="clearance (m)")
+    ax_esdf.set_xlabel("world y")
+    ax_esdf.set_ylabel("world x")
+    ax_esdf.axis("equal")
+
+    ax_traj.set_title("Candidate trajectories")
+    ax_traj.imshow(esdf, origin="lower", extent=extent, cmap="Greys", alpha=0.35, vmin=0.0, vmax=1.0)
+    finite_scores = scores[np.isfinite(scores)]
+    score_hi = np.percentile(finite_scores, 80) if len(finite_scores) else 1.0
+    for i, traj in enumerate(trajectories):
+        color = "0.75"
+        alpha = 0.25
+        if np.isfinite(scores[i]):
+            color = plt.cm.plasma(1.0 - min(scores[i] / max(score_hi, 1e-6), 1.0))
+            alpha = 0.45
+        ax_traj.plot(traj[:, 1], traj[:, 0], color=color, alpha=alpha, linewidth=0.8)
+    selected = trajectories[selected_index]
+    ax_traj.plot(selected[:, 1], selected[:, 0], color="#00d5ff", linewidth=3.0, label="selected")
+    poly = footprint_polygon(selected[0], front_len, rear_len, half_w)
+    ax_traj.plot(poly[:, 1], poly[:, 0], color="#00d5ff", linewidth=1.6, label="footprint")
+    ax_traj.scatter([target[1]], [target[0]], c="tab:red")
+    ax_traj.text(
+        0.02,
+        0.98,
+        f"selected={selected_index}\nscore={scores[selected_index]:.3g}\ncost={costs[selected_index]:.1f}",
+        transform=ax_traj.transAxes,
+        va="top",
+        bbox={"facecolor": "white", "alpha": 0.85, "edgecolor": "none"},
+    )
+    ax_traj.set_xlabel("world y")
+    ax_traj.set_ylabel("world x")
+    ax_traj.axis("equal")
+    ax_traj.legend(loc="upper right")
+
+    output_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_png, dpi=160)
+    plt.close(fig)
+
+
+def yaw_from_pose(pose: np.ndarray) -> float:
+    qx, qy, qz, qw = pose[3], pose[4], pose[5], pose[6]
+    fwd_x = 2.0 * (qx * qz + qw * qy)
+    fwd_y = 2.0 * (qy * qz - qw * qx)
+    if abs(fwd_x) < 1e-9 and abs(fwd_y) < 1e-9:
+        return 0.0
+    return float(np.rad2deg(np.arctan2(fwd_y, fwd_x)))
+
+
+def run(
+    config: dict,
+    render_plot: bool = True,
+    write_summary: bool = True,
+    include_images: bool = False,
+    occupancy_grid_state: np.ndarray | None = None,
+    occupancy_fade: float | None = None,
+    return_occupancy_grid: bool = False,
+) -> dict | tuple[dict, np.ndarray]:
+    robot = robot_from_config(config)
+    objects = [SimObject(**obj) for obj in config["objects"]]
+    grid = config["grid"]
+    cam = config["camera"]
+    planner = config["planner"]
+    origin = np.asarray(grid["origin"], dtype=np.float64)
+    grid_shape = tuple(int(v) for v in grid["shape"])
+    resolution = float(grid["resolution"])
+
+    mount_height = float(cam.get("mount_height", cam.get("height", 0.45)))
+    T, init_q = make_camera_pose(
+        config["start"]["xy"],
+        float(config["start"]["yaw_deg"]),
+        mount_height,
+        float(robot.camera_x - robot.control_x),
+        float(getattr(robot, "camera_y", 0.0) - getattr(robot, "control_y", 0.0)),
+    )
+    depth, hit_mask = render_depth(objects, T, cam)
+    new_occupancy = run_synthetic_raycasting(
+        depth,
+        hit_mask,
+        T,
+        grid_shape,
+        float(cam["fx"]),
+        float(cam["fy"]),
+        (int(cam["width"]) - 1) / 2.0,
+        (int(cam.get("image_height", cam.get("height", 100))) - 1) / 2.0,
+        origin,
+        int(cam["ray_step"]),
+        resolution,
+        float(cam["max_range"]),
+    )
+    if occupancy_grid_state is None:
+        occupancy = new_occupancy
+    else:
+        occupancy = occupancy_grid_state
+        occupancy *= 0.994 if occupancy_fade is None else float(occupancy_fade)
+        occupancy += new_occupancy
+        occupancy = np.clip(occupancy, -0.2, 0.2)
+
+    obstacle_config = ObstacleConfig(**config["obstacle"])
+    obstacle_mask = build_obstacle_map(occupancy, origin, resolution, T[2, 3], obstacle_config)
+    esdf = distance_transform_edt(~obstacle_mask).astype(np.float32) * resolution
+
+    init_p = np.array([config["start"]["xy"][0], config["start"]["xy"][1], 0.0], dtype=np.float64)
+    trajectories, params = generate_forward_trajectories(planner, init_p, init_q)
+    reverse_trajs, reverse_params = generate_reverse_trajectories(planner, init_p, init_q)
+    trajectories = np.concatenate([trajectories, reverse_trajs], axis=0)
+    params = np.concatenate([params, reverse_params], axis=0)
+
+    front_len, rear_len, half_w = robot.footprint_from_control()
+    scores, occ_points = score_trajectories_compat(
+        trajectories, esdf, origin, resolution, robot, front_len, rear_len, half_w
+    )
+    scores = np.asarray(scores, dtype=np.float64)
+    front_clearance = front_obstacle_dist(
+        init_p,
+        float(config["start"]["yaw_deg"]),
+        obstacle_mask,
+        origin,
+        resolution,
+        front_len,
+        half_w,
+    )
+    selection = select_trajectory_with_recovery(
+        trajectories,
+        params,
+        scores,
+        esdf,
+        origin,
+        resolution,
+        float(robot.safety_radius),
+        float(robot.comfort_radius),
+        front_len,
+        rear_len,
+        half_w,
+        np.asarray(config["target"], dtype=np.float64),
+        front_clearance,
+        float(planner["front_reverse_threshold"]),
+        float(planner["trajectory_smooth_weight"]),
+        np.asarray(planner["last_param"], dtype=np.float64),
+        0.0,
+        0,
+        top_k=1,
+    )
+    selected_index = selection["selected_index"]
+    costs = selection["costs"]
+
+    output_dir = Path(config["output_dir"])
+    output_png = output_dir / f"{config['name']}.png"
+    if render_plot:
+        plot_result(config, objects, depth, obstacle_mask, esdf, trajectories, scores, costs, selected_index, robot, output_png)
+
+    summary = {
+        "name": config["name"],
+        "output_png": str(output_png),
+        "selected_index": int(selected_index),
+        "selected_param": params[selected_index].round(4).tolist(),
+        "selected_score": float(scores[selected_index]),
+        "selected_cost": float(costs[selected_index]),
+        "should_reverse": bool(selection["should_reverse"]),
+        "all_collision": bool(selection["all_collision"]),
+        "recovery_reason": selection["recovery_reason"],
+        "selected_is_reverse": bool(selection["selected_is_reverse"]),
+        "front_clearance": float(front_clearance),
+        "valid_trajectories": int(np.sum(np.isfinite(scores))),
+        "trajectory_count": int(len(trajectories)),
+        "obstacle_cells": int(np.sum(obstacle_mask)),
+        "selected_closest_step": int(occ_points[selected_index]),
+        "selected_trajectory_xy": trajectory_xy(trajectories[selected_index]),
+        "selected_trajectory_yaw_deg": trajectory_yaw_deg(trajectories[selected_index]),
+        "selected_footprints_xy": footprint_xy_series(trajectories[selected_index], front_len, rear_len, half_w),
+        "candidate_trajectories_xy": [
+            trajectory_xy(trajectories[i])
+            for i in np.argsort(costs, kind="stable")[: min(40, len(trajectories))]
+            if np.isfinite(costs[i])
+        ],
+        "obstacle_outline_xy": [
+            [float(obj.center[0]), float(obj.center[1]), float(obj.size[0]), float(obj.size[1])]
+            for obj in objects
+        ],
+        "robot_footprint": {
+            "front_len": float(front_len),
+            "rear_len": float(rear_len),
+            "half_w": float(half_w),
+        },
+    }
+    if include_images:
+        summary["depth_u8"] = image_u8_payload(depth, 0.0, float(cam["max_range"]))
+        summary["esdf_u8"] = image_u8_payload(esdf, 0.0, 1.5)
+        summary["obstacle_u8"] = mask_u8_payload(obstacle_mask)
+    if write_summary:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        summary_path = output_dir / f"{config['name']}.summary.json"
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        summary["summary_json"] = str(summary_path)
+    if return_occupancy_grid:
+        return summary, occupancy
+    return summary
+
+
+def run_realtime_step(config: dict, advance_step: int = 3) -> dict:
+    """Compute one closed-loop step from the current config pose and scene."""
+    summary = run(config, render_plot=False, write_summary=False, include_images=True)
+    traj = summary["selected_trajectory_xy"]
+    yaws = summary["selected_trajectory_yaw_deg"]
+    footprints = summary["selected_footprints_xy"]
+    idx = min(max(1, int(advance_step)), len(traj) - 1)
+    next_xy = traj[idx]
+    next_yaw = float(yaws[min(idx, len(yaws) - 1)]) if yaws else float(config["start"]["yaw_deg"])
+    frame = {
+        "robot_xy": next_xy,
+        "robot_yaw_deg": next_yaw,
+        "robot_footprint_xy": footprints[idx],
+        "selected_trajectory_xy": summary["selected_trajectory_xy"],
+        "candidate_trajectories_xy": summary["candidate_trajectories_xy"],
+        "obstacle_outline_xy": summary["obstacle_outline_xy"],
+        "selected_param": summary["selected_param"],
+        "should_reverse": summary["should_reverse"],
+        "all_collision": summary["all_collision"],
+        "recovery_reason": summary["recovery_reason"],
+        "selected_is_reverse": summary["selected_is_reverse"],
+        "front_clearance": summary["front_clearance"],
+        "valid_trajectories": summary["valid_trajectories"],
+        "obstacle_cells": summary["obstacle_cells"],
+        "depth_u8": summary["depth_u8"],
+        "esdf_u8": summary["esdf_u8"],
+        "next_start": {
+            "xy": next_xy,
+            "yaw_deg": next_yaw,
+        },
+    }
+    return frame
+
+
+def run_realtime_step_with_grid(
+    config: dict,
+    occupancy_grid_state: np.ndarray | None = None,
+    advance_step: int = 3,
+    occupancy_fade: float = 0.994,
+) -> tuple[dict, np.ndarray]:
+    """Compute one realtime step while preserving planning_node-style occupancy fadeaway."""
+    summary, updated_grid = run(
+        config,
+        render_plot=False,
+        write_summary=False,
+        include_images=True,
+        occupancy_grid_state=occupancy_grid_state,
+        occupancy_fade=occupancy_fade,
+        return_occupancy_grid=True,
+    )
+    traj = summary["selected_trajectory_xy"]
+    yaws = summary["selected_trajectory_yaw_deg"]
+    footprints = summary["selected_footprints_xy"]
+    idx = min(max(1, int(advance_step)), len(traj) - 1)
+    next_xy = traj[idx]
+    next_yaw = float(yaws[min(idx, len(yaws) - 1)]) if yaws else float(config["start"]["yaw_deg"])
+    frame = {
+        "robot_xy": next_xy,
+        "robot_yaw_deg": next_yaw,
+        "robot_footprint_xy": footprints[idx],
+        "selected_trajectory_xy": summary["selected_trajectory_xy"],
+        "candidate_trajectories_xy": summary["candidate_trajectories_xy"],
+        "obstacle_outline_xy": summary["obstacle_outline_xy"],
+        "selected_param": summary["selected_param"],
+        "should_reverse": summary["should_reverse"],
+        "all_collision": summary["all_collision"],
+        "recovery_reason": summary["recovery_reason"],
+        "selected_is_reverse": summary["selected_is_reverse"],
+        "front_clearance": summary["front_clearance"],
+        "valid_trajectories": summary["valid_trajectories"],
+        "obstacle_cells": summary["obstacle_cells"],
+        "depth_u8": summary["depth_u8"],
+        "esdf_u8": summary["esdf_u8"],
+        "obstacle_u8": summary["obstacle_u8"],
+        "next_start": {
+            "xy": next_xy,
+            "yaw_deg": next_yaw,
+        },
+    }
+    return frame, updated_grid
+
+
+def run_rollout(config: dict, steps: int = 30, advance_step: int = 3, render_snapshots: bool = False) -> dict:
+    """Closed-loop rollout: replan from the updated robot pose at every tick."""
+    sim_config = copy.deepcopy(config)
+    frames = []
+    executed_path = []
+    selected_index_history = []
+    selected_param_history = []
+    first_summary = None
+
+    for step in range(max(1, int(steps))):
+        sim_config["name"] = f"{config.get('name', 'web_scene')}_rollout_{step:03d}"
+        summary = run(sim_config, render_plot=render_snapshots, write_summary=False)
+        if first_summary is None:
+            first_summary = summary
+
+        traj = summary["selected_trajectory_xy"]
+        yaws = summary["selected_trajectory_yaw_deg"]
+        footprints = summary["selected_footprints_xy"]
+        idx = min(max(1, int(advance_step)), len(traj) - 1)
+        robot_xy = traj[idx]
+        robot_fp = footprints[idx]
+        executed_path.append(robot_xy)
+        selected_index_history.append(summary["selected_index"])
+        selected_param_history.append(summary["selected_param"])
+        frames.append({
+            "step": step,
+            "robot_xy": robot_xy,
+            "robot_yaw_deg": float(yaws[min(idx, len(yaws) - 1)]) if yaws else float(sim_config["start"]["yaw_deg"]),
+            "robot_footprint_xy": robot_fp,
+            "selected_trajectory_xy": summary["selected_trajectory_xy"],
+            "candidate_trajectories_xy": summary["candidate_trajectories_xy"],
+            "obstacle_outline_xy": summary["obstacle_outline_xy"],
+            "selected_param": summary["selected_param"],
+            "front_clearance": summary["front_clearance"],
+            "valid_trajectories": summary["valid_trajectories"],
+            "obstacle_cells": summary["obstacle_cells"],
+            "diagnostic_png": summary.get("output_png"),
+        })
+
+        # Keep pose update from the trajectory orientation, not from displacement.
+        # Reverse motion has displacement opposite to heading; deriving yaw from dx/dy
+        # would make the simulated robot "turn around" instead of backing up.
+        sim_config["start"]["xy"] = robot_xy
+        if yaws:
+            sim_config["start"]["yaw_deg"] = float(yaws[min(idx, len(yaws) - 1)])
+
+        target = np.asarray(sim_config["target"][:2], dtype=np.float64)
+        if np.linalg.norm(np.asarray(robot_xy, dtype=np.float64) - target) < 0.25:
+            break
+
+    output = {
+        "name": config.get("name", "web_scene"),
+        "frames": frames,
+        "executed_path_xy": executed_path,
+        "selected_index_history": selected_index_history,
+        "selected_param_history": selected_param_history,
+        "frame_count": len(frames),
+    }
+    if first_summary is not None:
+        output["diagnostic_summary"] = first_summary
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", help="Optional JSON scene config. Values override the built-in default.")
+    parser.add_argument("--output-dir", help="Override output directory from config.")
+    parser.add_argument("--write-example", help="Write the default editable JSON config and exit.")
+    args = parser.parse_args()
+
+    if args.write_example:
+        path = Path(args.write_example)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(default_config(), indent=2), encoding="utf-8")
+        print(f"Wrote example config: {path}")
+        return
+
+    config = load_config(args.config)
+    if args.output_dir:
+        config["output_dir"] = args.output_dir
+    summary = run(config)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/simulator/offline_planning_web.py
+++ b/tool/simulator/offline_planning_web.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Browser UI for the offline tinynav planning MVP."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from tool.simulator.offline_planning_mvp import default_config, run, run_realtime_step_with_grid, run_rollout
+
+
+ROOT = Path(__file__).resolve().parent
+STATIC_DIR = ROOT / "offline_planning_web"
+DEFAULT_OUTPUT_DIR = Path("/tinynav/outputs/offline_planning_mvp")
+DEFAULT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+LARGE_SUMMARY_KEYS = {
+    "selected_trajectory_xy",
+    "selected_footprints_xy",
+    "candidate_trajectories_xy",
+    "closest_steps",
+}
+
+
+class RunRequest(BaseModel):
+    config: dict[str, Any]
+    steps: int | None = None
+    advance_step: int | None = None
+    reset: bool | None = None
+
+
+app = FastAPI(title="TinyNav Offline Planning Lab")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+app.mount("/outputs", StaticFiles(directory=DEFAULT_OUTPUT_DIR), name="outputs")
+REALTIME_STATE: dict[str, Any] = {"occupancy_grid": None, "grid_shape": None, "last_param": None}
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> str:
+    return (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+
+
+@app.get("/api/default-config")
+def get_default_config() -> dict[str, Any]:
+    config = default_config()
+    config["output_dir"] = str(DEFAULT_OUTPUT_DIR)
+    return config
+
+
+@app.post("/api/run")
+def run_scene(request: RunRequest) -> dict[str, Any]:
+    config = request.config
+    if not isinstance(config, dict):
+        raise HTTPException(status_code=400, detail="config must be an object")
+    config = json.loads(json.dumps(config))
+    config.setdefault("name", "web_scene")
+    config["output_dir"] = str(DEFAULT_OUTPUT_DIR)
+    try:
+        summary = run(config)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    png_path = Path(summary["output_png"])
+    if not png_path.exists():
+        raise HTTPException(status_code=500, detail=f"missing output image: {png_path}")
+    png_b64 = base64.b64encode(png_path.read_bytes()).decode("ascii")
+    return {
+        "summary": summary,
+        "image_data_url": f"data:image/png;base64,{png_b64}",
+    }
+
+
+@app.post("/api/rollout")
+def rollout_scene(request: RunRequest) -> dict[str, Any]:
+    config = request.config
+    if not isinstance(config, dict):
+        raise HTTPException(status_code=400, detail="config must be an object")
+    config = json.loads(json.dumps(config))
+    config.setdefault("name", "web_scene")
+    config["output_dir"] = str(DEFAULT_OUTPUT_DIR)
+    try:
+        rollout = run_rollout(
+            config,
+            steps=request.steps or 30,
+            advance_step=request.advance_step or 3,
+            render_snapshots=True,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    diagnostic = rollout.get("diagnostic_summary") or {}
+    for frame in rollout.get("frames", []):
+        png_path = frame.get("diagnostic_png")
+        if png_path:
+            frame["diagnostic_image_url"] = f"/outputs/{Path(png_path).name}"
+    if diagnostic:
+        rollout["diagnostic_summary"] = {
+            key: value for key, value in diagnostic.items() if key not in LARGE_SUMMARY_KEYS
+        }
+    return {
+        "rollout": rollout,
+        "summary": rollout.get("diagnostic_summary") or {},
+    }
+
+
+@app.post("/api/realtime-step")
+def realtime_step(request: RunRequest) -> dict[str, Any]:
+    config = request.config
+    if not isinstance(config, dict):
+        raise HTTPException(status_code=400, detail="config must be an object")
+    config = json.loads(json.dumps(config))
+    config.setdefault("name", "web_realtime")
+    config["output_dir"] = str(DEFAULT_OUTPUT_DIR)
+    try:
+        grid_shape = tuple(int(v) for v in config["grid"]["shape"])
+        if request.reset or REALTIME_STATE.get("grid_shape") != grid_shape:
+            REALTIME_STATE["occupancy_grid"] = np.zeros(grid_shape, dtype=np.float64)
+            REALTIME_STATE["grid_shape"] = grid_shape
+            REALTIME_STATE["last_param"] = None
+        if REALTIME_STATE.get("last_param") is not None:
+            config.setdefault("planner", {})["last_param"] = REALTIME_STATE["last_param"]
+        frame, occupancy_grid = run_realtime_step_with_grid(
+            config,
+            occupancy_grid_state=REALTIME_STATE.get("occupancy_grid"),
+            advance_step=request.advance_step or 3,
+        )
+        REALTIME_STATE["occupancy_grid"] = occupancy_grid
+        REALTIME_STATE["last_param"] = frame.get("selected_param")
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"frame": frame}
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8766)
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -15,6 +15,8 @@ const ctx = canvas.getContext("2d");
 const depthCanvas = document.getElementById("depthCanvas");
 const depthCtx = depthCanvas.getContext("2d");
 const statusEl = document.getElementById("status");
+const controlsPanel = document.getElementById("controlsPanel");
+const controlsToggle = document.getElementById("controlsToggle");
 const realtimeButton = document.getElementById("realtimeButton");
 const GRID_STEP_M = 1.0;
 
@@ -344,6 +346,16 @@ function drawU8Canvas(targetCanvas, targetCtx, payload, mode) {
   targetCtx.restore();
 }
 
+function setControlsVisible(visible) {
+  controlsPanel.classList.toggle("is-hidden", !visible);
+  controlsToggle.setAttribute("aria-expanded", String(visible));
+  controlsToggle.textContent = visible ? "Controls" : "Controls";
+}
+
+function syncControlsLayout() {
+  setControlsVisible(window.innerWidth > 1180);
+}
+
 function drawRealtimeFrame(frame) {
   currentFrame = frame;
   drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8, "depth");
@@ -554,6 +566,9 @@ editableFields.forEach((field) => {
 });
 
 realtimeButton.addEventListener("click", toggleRealtime);
+controlsToggle.addEventListener("click", () => {
+  setControlsVisible(controlsPanel.classList.contains("is-hidden"));
+});
 document.getElementById("resetScene").addEventListener("click", loadDefault);
 document.getElementById("applyJson").addEventListener("click", () => {
   const nextConfig = JSON.parse(fields.configText.value);
@@ -640,3 +655,5 @@ canvas.addEventListener("pointerup", () => {
 });
 
 loadDefault();
+syncControlsLayout();
+window.addEventListener("resize", syncControlsLayout);

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -1,3 +1,16 @@
+const REALTIME_TICK_DELAY_MS = 33;
+const GRID_STEP_M = 1.0;
+const SCENE = { xMin: -0.8, xMax: 9.8, yMin: -5.4, yMax: 5.4 };
+const CAM_DEFAULTS = { width: 160, image_height: 100, fx: 80, fy: 25, max_range: 15, mount_height: 0.45 };
+const DEPTH_STOPS = [
+  [0.0, [255, 230, 80]],
+  [0.18, [255, 120, 40]],
+  [0.36, [236, 52, 98]],
+  [0.55, [156, 64, 255]],
+  [0.75, [56, 120, 255]],
+  [1.0, [12, 28, 72]],
+];
+
 let config = null;
 let selectedIndex = 0;
 let dragState = null;
@@ -8,7 +21,6 @@ let realtimePending = false;
 let realtimePath = [];
 let currentFrame = null;
 let realtimeNeedsReset = true;
-const REALTIME_TICK_DELAY_MS = 33;
 
 const canvas = document.getElementById("sceneCanvas");
 const ctx = canvas.getContext("2d");
@@ -18,94 +30,92 @@ const statusEl = document.getElementById("status");
 const controlsPanel = document.getElementById("controlsPanel");
 const controlsToggle = document.getElementById("controlsToggle");
 const realtimeButton = document.getElementById("realtimeButton");
-const GRID_STEP_M = 1.0;
+const $ = (id) => document.getElementById(id);
 
 const fields = {
-  targetX: document.getElementById("targetX"),
-  targetY: document.getElementById("targetY"),
-  camWidth: document.getElementById("camWidth"),
-  camHeight: document.getElementById("camHeight"),
-  camFx: document.getElementById("camFx"),
-  camFy: document.getElementById("camFy"),
-  camMaxRange: document.getElementById("camMaxRange"),
-  camMountHeight: document.getElementById("camMountHeight"),
-  objectName: document.getElementById("objectName"),
-  objectX: document.getElementById("objectX"),
-  objectY: document.getElementById("objectY"),
-  objectSX: document.getElementById("objectSX"),
-  objectSY: document.getElementById("objectSY"),
-  objectSZ: document.getElementById("objectSZ"),
-  configText: document.getElementById("configText"),
-  robotSummary: document.getElementById("robotSummary"),
-  cameraSummary: document.getElementById("cameraSummary"),
+  targetX: $("targetX"),
+  targetY: $("targetY"),
+  camWidth: $("camWidth"),
+  camHeight: $("camHeight"),
+  camFx: $("camFx"),
+  camFy: $("camFy"),
+  camMaxRange: $("camMaxRange"),
+  camMountHeight: $("camMountHeight"),
+  objectName: $("objectName"),
+  objectX: $("objectX"),
+  objectY: $("objectY"),
+  objectSX: $("objectSX"),
+  objectSY: $("objectSY"),
+  objectSZ: $("objectSZ"),
+  configText: $("configText"),
+  robotSummary: $("robotSummary"),
+  cameraSummary: $("cameraSummary"),
 };
 
 const editableFields = [
-  fields.targetX,
-  fields.targetY,
-  fields.camWidth,
-  fields.camHeight,
-  fields.camFx,
-  fields.camFy,
-  fields.camMaxRange,
-  fields.camMountHeight,
-  fields.objectName,
-  fields.objectX,
-  fields.objectY,
-  fields.objectSX,
-  fields.objectSY,
-  fields.objectSZ,
+  fields.targetX, fields.targetY,
+  fields.camWidth, fields.camHeight, fields.camFx, fields.camFy, fields.camMaxRange, fields.camMountHeight,
+  fields.objectName, fields.objectX, fields.objectY, fields.objectSX, fields.objectSY, fields.objectSZ,
 ];
 
-function sceneBounds() {
-  return { xMin: -0.5, xMax: 9.5, yMin: -5.0, yMax: 5.0 };
+function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
 }
 
-function canvasLogicalSize(targetCanvas) {
+function num(el, fallback, min = null, round = false) {
+  let v = Number(el.value);
+  if (!Number.isFinite(v)) v = fallback;
+  if (round) v = Math.round(v);
+  return min == null ? v : Math.max(min, v);
+}
+
+function lerpRGB(a, b, t) {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+function logicalSize(target = canvas) {
   return {
-    width: Math.max(1, targetCanvas.clientWidth || targetCanvas.width),
-    height: Math.max(1, targetCanvas.clientHeight || targetCanvas.height),
+    width: Math.max(1, target.clientWidth || target.width),
+    height: Math.max(1, target.clientHeight || target.height),
   };
 }
 
-function sceneView(targetCanvas) {
-  const b = sceneBounds();
-  const size = canvasLogicalSize(targetCanvas);
-  const worldW = b.yMax - b.yMin;
-  const worldH = b.xMax - b.xMin;
+function sceneView(target = canvas) {
+  const b = SCENE;
+  const { width, height } = logicalSize(target);
   const pad = 12;
-  const availW = Math.max(1, size.width - pad * 2);
-  const availH = Math.max(1, size.height - pad * 2);
-  const scale = Math.min(availW / worldW, availH / worldH);
+  const availW = Math.max(1, width - pad * 2);
+  const availH = Math.max(1, height - pad * 2);
+  const scale = Math.min(availW / (b.yMax - b.yMin), availH / (b.xMax - b.xMin));
   return {
     b,
     scale,
-    offsetX: pad + (availW - worldW * scale) / 2,
-    offsetY: pad + (availH - worldH * scale) / 2,
+    offsetX: pad + (availW - (b.yMax - b.yMin) * scale) / 2,
+    offsetY: pad + (availH - (b.xMax - b.xMin) * scale) / 2,
   };
 }
 
-function worldToCanvasOn(targetCanvas, x, y) {
-  const view = sceneView(targetCanvas);
-  const px = view.offsetX + (y - view.b.yMin) * view.scale;
-  const py = view.offsetY + (view.b.xMax - x) * view.scale;
-  return [px, py];
-}
-
-function worldToCanvas(x, y) {
-  return worldToCanvasOn(canvas, x, y);
+function worldToCanvas(x, y, target = canvas) {
+  const v = sceneView(target);
+  return [v.offsetX + (y - v.b.yMin) * v.scale, v.offsetY + (v.b.xMax - x) * v.scale];
 }
 
 function canvasToWorld(px, py) {
-  const view = sceneView(canvas);
-  const y = view.b.yMin + (px - view.offsetX) / view.scale;
-  const x = view.b.xMax - (py - view.offsetY) / view.scale;
-  return [x, y];
+  const v = sceneView();
+  return [v.b.xMax - (py - v.offsetY) / v.scale, v.b.yMin + (px - v.offsetX) / v.scale];
+}
+
+function pointerPos(event) {
+  const rect = canvas.getBoundingClientRect();
+  return [event.clientX - rect.left, event.clientY - rect.top];
 }
 
 function syncSceneCanvasSize() {
-  const cssW = Math.max(1, Math.round(canvas.clientWidth));
-  const cssH = Math.max(1, Math.round(canvas.clientHeight));
+  const { width: cssW, height: cssH } = logicalSize();
   const dpr = Math.min(window.devicePixelRatio || 1, 2);
   const nextW = Math.max(1, Math.round(cssW * dpr));
   const nextH = Math.max(1, Math.round(cssH * dpr));
@@ -121,220 +131,217 @@ function selectedObject() {
   return config?.objects?.[selectedIndex] || null;
 }
 
-function hitTestTarget(px, py) {
-  const [tx, ty] = config.target;
-  const [tpx, tpy] = worldToCanvas(tx, ty);
-  return Math.hypot(px - tpx, py - tpy) <= 14;
-}
-
-function drawGrid(drawCtx, targetCanvas, mapper) {
-  const size = canvasLogicalSize(targetCanvas);
-  drawCtx.fillStyle = "#fbfcfd";
-  drawCtx.fillRect(0, 0, size.width, size.height);
-  drawCtx.strokeStyle = "#e0e7ee";
-  drawCtx.lineWidth = 1;
-  const b = sceneBounds();
-  const x0 = Math.ceil(b.xMin / GRID_STEP_M) * GRID_STEP_M;
-  const y0 = Math.ceil(b.yMin / GRID_STEP_M) * GRID_STEP_M;
-  for (let x = x0; x <= b.xMax + 1e-9; x += GRID_STEP_M) {
-    const [px0, py] = mapper(x, b.yMin);
-    const [px1] = mapper(x, b.yMax);
-    drawCtx.beginPath();
-    drawCtx.moveTo(px0, py);
-    drawCtx.lineTo(px1, py);
-    drawCtx.stroke();
-  }
-  for (let y = y0; y <= b.yMax + 1e-9; y += GRID_STEP_M) {
-    const [px, py0] = mapper(b.xMin, y);
-    const [, py1] = mapper(b.xMax, y);
-    drawCtx.beginPath();
-    drawCtx.moveTo(px, py0);
-    drawCtx.lineTo(px, py1);
-    drawCtx.stroke();
-  }
-}
-
-function drawObjects(drawCtx, mapper, highlightSelected) {
-  config.objects.forEach((obj, idx) => {
-    const [x, y] = obj.center;
-    const [sx, sy] = obj.size;
-    const [px0, py0] = mapper(x - sx / 2, y - sy / 2);
-    const [px1, py1] = mapper(x + sx / 2, y + sy / 2);
-    const selected = highlightSelected && idx === selectedIndex;
-    drawCtx.fillStyle = selected ? "rgba(16, 107, 103, 0.55)" : "rgba(95, 108, 120, 0.45)";
-    drawCtx.strokeStyle = selected ? "#106b67" : "#56616c";
-    drawCtx.lineWidth = selected ? 3 : 1.5;
-    drawCtx.beginPath();
-    drawCtx.rect(Math.min(px0, px1), Math.min(py0, py1), Math.abs(px1 - px0), Math.abs(py1 - py0));
-    drawCtx.fill();
-    drawCtx.stroke();
-    drawCtx.fillStyle = "#17202a";
-    drawCtx.font = "13px system-ui";
-    drawCtx.textAlign = "center";
-    drawCtx.fillText(obj.name, (px0 + px1) / 2, (py0 + py1) / 2 + 4);
-  });
-}
-
-function drawStartTarget(drawCtx, mapper) {
-  drawCtx.save();
-  drawCtx.textAlign = "center";
-  drawCtx.textBaseline = "alphabetic";
-  const [sx, sy] = config.start.xy;
-  const [spx, spy] = mapper(sx, sy);
-  drawCtx.fillStyle = "#24a148";
-  drawCtx.beginPath();
-  drawCtx.arc(spx, spy, 7, 0, Math.PI * 2);
-  drawCtx.fill();
-  drawCtx.fillText("control", spx, spy - 12);
-
-  const camera = cameraPose();
-  const [cpx, cpy] = mapper(camera.xy[0], camera.xy[1]);
-  drawCtx.fillStyle = "#6d28d9";
-  drawCtx.beginPath();
-  drawCtx.arc(cpx, cpy, 6, 0, Math.PI * 2);
-  drawCtx.fill();
-  drawCtx.fillText("camera", cpx, cpy - 12);
-  drawHeadingArrow(drawCtx, mapper, camera.xy, config.start.yaw_deg, "#6d28d9", 0.32);
-
-  const [tx, ty] = config.target;
-  const [tpx, tpy] = mapper(tx, ty);
-  drawCtx.fillStyle = "#da1e28";
-  drawCtx.beginPath();
-  drawCtx.arc(tpx, tpy, 7, 0, Math.PI * 2);
-  drawCtx.fill();
-  drawCtx.fillText("target", tpx, tpy - 12);
-  drawCtx.restore();
+function objectCanvasRect(obj) {
+  const [x, y] = obj.center;
+  const [sx, sy] = obj.size;
+  const [px0, py0] = worldToCanvas(x - sx / 2, y - sy / 2);
+  const [px1, py1] = worldToCanvas(x + sx / 2, y + sy / 2);
+  return [Math.min(px0, px1), Math.min(py0, py1), Math.abs(px1 - px0), Math.abs(py1 - py0)];
 }
 
 function cameraPose() {
   const yaw = (Number(config.start.yaw_deg || 0) * Math.PI) / 180;
-  const forwardOffset = Number(config.robot.camera_x || 0) - Number(config.robot.control_x || 0);
-  const leftOffset = Number(config.robot.camera_y || 0) - Number(config.robot.control_y || 0);
+  const df = Number(config.robot.camera_x || 0) - Number(config.robot.control_x || 0);
+  const dl = Number(config.robot.camera_y || 0) - Number(config.robot.control_y || 0);
   const forward = [Math.cos(yaw), Math.sin(yaw)];
   const left = [-Math.sin(yaw), Math.cos(yaw)];
   return {
     xy: [
-      config.start.xy[0] + forward[0] * forwardOffset + left[0] * leftOffset,
-      config.start.xy[1] + forward[1] * forwardOffset + left[1] * leftOffset,
+      config.start.xy[0] + forward[0] * df + left[0] * dl,
+      config.start.xy[1] + forward[1] * df + left[1] * dl,
     ],
   };
 }
 
-function robotSummaryHtml() {
-  const robot = config.robot || {};
-  const obstacle = config.obstacle || {};
-  return [
-    `preset: <code>${robot.preset || "go2"}</code>`,
-    `size: <code>${Number(robot.length || 0).toFixed(2)} x ${Number(robot.width || 0).toFixed(2)} m</code>`,
-    `camera/control: <code>${Number(robot.camera_x || 0).toFixed(2)} / ${Number(robot.control_x || 0).toFixed(2)} m</code>`,
-    `safety radius: <code>${Number(robot.safety_radius || 0).toFixed(2)} m</code>`,
-    `obstacle dilation: <code>${Number(obstacle.dilation_cells || 0)}</code>`,
-  ].join("<br />");
+function fovDeg(size, focal) {
+  return (2 * Math.atan((Math.max(1, size) / 2) / Math.max(1e-6, focal)) * 180) / Math.PI;
 }
 
-function cameraFovDeg(size, focal) {
-  const half = Math.max(1, Number(size) || 1) / 2;
-  const f = Math.max(1e-6, Number(focal) || 1);
-  return (2 * Math.atan(half / f) * 180) / Math.PI;
+function summaryLines(lines) {
+  return lines.map(([k, v]) => `${k}: <code>${v}</code>`).join("<br />");
+}
+
+function robotSummaryHtml() {
+  const r = config.robot || {};
+  const o = config.obstacle || {};
+  return summaryLines([
+    ["preset", r.preset || "go2"],
+    ["size", `${Number(r.length || 0).toFixed(2)} x ${Number(r.width || 0).toFixed(2)} m`],
+    ["camera/control", `${Number(r.camera_x || 0).toFixed(2)} / ${Number(r.control_x || 0).toFixed(2)} m`],
+    ["safety radius", `${Number(r.safety_radius || 0).toFixed(2)} m`],
+    ["obstacle dilation", `${Number(o.dilation_cells || 0)}`],
+  ]);
 }
 
 function cameraSummaryHtml() {
   const cam = config.camera || {};
-  const width = Number(cam.width || 0);
-  const height = Number(cam.image_height || cam.height || 0);
+  const w = Number(cam.width || 0);
+  const h = Number(cam.image_height || cam.height || 0);
   const fx = Number(cam.fx || 0);
   const fy = Number(cam.fy || 0);
-  return [
-    `HFOV: <code>${cameraFovDeg(width, fx).toFixed(1)}°</code>`,
-    `VFOV: <code>${cameraFovDeg(height, fy).toFixed(1)}°</code>`,
-    `resolution: <code>${width} x ${height}</code>`,
-  ].join("<br />");
+  return summaryLines([
+    ["HFOV", `${fovDeg(w, fx).toFixed(1)}°`],
+    ["VFOV", `${fovDeg(h, fy).toFixed(1)}°`],
+    ["resolution", `${w} x ${h}`],
+  ]);
 }
 
-function drawScene() {
-  if (!config) return;
-  const size = syncSceneCanvasSize();
-  ctx.clearRect(0, 0, size.width, size.height);
-  drawGrid(ctx, canvas, worldToCanvas);
-  drawEsdfSceneOverlay();
-  drawObjects(ctx, worldToCanvas, true);
-  drawStartTarget(ctx, worldToCanvas);
-  drawRealtimeOverlay();
+function drawGrid() {
+  const { width, height } = logicalSize();
+  ctx.fillStyle = "#fbfcfd";
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = "#e0e7ee";
+  ctx.lineWidth = 1;
+  const b = SCENE;
+  for (let x = Math.ceil(b.xMin / GRID_STEP_M) * GRID_STEP_M; x <= b.xMax + 1e-9; x += GRID_STEP_M) {
+    const [px0, py] = worldToCanvas(x, b.yMin);
+    const [px1] = worldToCanvas(x, b.yMax);
+    ctx.beginPath();
+    ctx.moveTo(px0, py);
+    ctx.lineTo(px1, py);
+    ctx.stroke();
+  }
+  for (let y = Math.ceil(b.yMin / GRID_STEP_M) * GRID_STEP_M; y <= b.yMax + 1e-9; y += GRID_STEP_M) {
+    const [px, py0] = worldToCanvas(b.xMin, y);
+    const [, py1] = worldToCanvas(b.xMax, y);
+    ctx.beginPath();
+    ctx.moveTo(px, py0);
+    ctx.lineTo(px, py1);
+    ctx.stroke();
+  }
+}
+
+function drawGround() {
+  const b = SCENE;
+  const [px0, py0] = worldToCanvas(b.xMin + 0.3, b.yMin + 0.3);
+  const [px1, py1] = worldToCanvas(b.xMax - 0.3, b.yMax - 0.3);
+  ctx.fillStyle = "rgba(226, 232, 220, 0.85)";
+  ctx.fillRect(Math.min(px0, px1), Math.min(py0, py1), Math.abs(px1 - px0), Math.abs(py1 - py0));
+}
+
+function drawObjects() {
+  config.objects.forEach((obj, idx) => {
+    const [x, y, w, h] = objectCanvasRect(obj);
+    const selected = idx === selectedIndex;
+    const fence = String(obj.name || "").startsWith("fence_");
+    ctx.fillStyle = selected ? "rgba(16, 107, 103, 0.55)" : fence ? "rgba(120, 113, 108, 0.55)" : "rgba(95, 108, 120, 0.45)";
+    ctx.strokeStyle = selected ? "#106b67" : fence ? "#57534e" : "#56616c";
+    ctx.lineWidth = selected ? 3 : 1.5;
+    ctx.beginPath();
+    ctx.rect(x, y, w, h);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = "#17202a";
+    ctx.font = "13px system-ui";
+    ctx.textAlign = "center";
+    ctx.fillText(obj.name, x + w / 2, y + h / 2 + 4);
+  });
+}
+
+function drawMarker(xy, label, color, radius = 7) {
+  const [px, py] = worldToCanvas(xy[0], xy[1]);
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.arc(px, py, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillText(label, px, py - 12);
+}
+
+function drawHeadingArrow(xy, yawDeg, color, length = 0.45) {
+  if (!xy || yawDeg == null) return;
+  const yaw = (Number(yawDeg) * Math.PI) / 180;
+  const tip = [xy[0] + Math.cos(yaw) * length, xy[1] + Math.sin(yaw) * length];
+  const [x0, y0] = worldToCanvas(xy[0], xy[1]);
+  const [x1, y1] = worldToCanvas(tip[0], tip[1]);
+  ctx.strokeStyle = ctx.fillStyle = color;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(x0, y0);
+  ctx.lineTo(x1, y1);
+  ctx.stroke();
+  const angle = Math.atan2(y1 - y0, x1 - x0);
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x1 - Math.cos(angle - 0.55) * 12, y1 - Math.sin(angle - 0.55) * 12);
+  ctx.lineTo(x1 - Math.cos(angle + 0.55) * 12, y1 - Math.sin(angle + 0.55) * 12);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function drawStartTarget() {
+  ctx.save();
+  ctx.textAlign = "center";
+  ctx.textBaseline = "alphabetic";
+  drawMarker(config.start.xy, "control", "#24a148");
+  const camera = cameraPose();
+  drawMarker(camera.xy, "camera", "#6d28d9", 6);
+  drawHeadingArrow(camera.xy, config.start.yaw_deg, "#6d28d9", 0.32);
+  drawMarker(config.target, "target", "#da1e28");
+  ctx.restore();
 }
 
 function gridCellToCanvasRect(payload, ix, iy) {
-  const resolution = Number(payload.resolution);
-  const origin = payload.origin;
-  const x0 = origin[0] + ix * resolution;
-  const y0 = origin[1] + iy * resolution;
-  const x1 = origin[0] + (ix + 1) * resolution;
-  const y1 = origin[1] + (iy + 1) * resolution;
-  const [px0, py0] = worldToCanvas(x0, y0);
-  const [px1, py1] = worldToCanvas(x1, y1);
+  const r = Number(payload.resolution);
+  const o = payload.origin;
+  const [px0, py0] = worldToCanvas(o[0] + ix * r, o[1] + iy * r);
+  const [px1, py1] = worldToCanvas(o[0] + (ix + 1) * r, o[1] + (iy + 1) * r);
   return [Math.min(px0, px1), Math.min(py0, py1), Math.abs(px1 - px0), Math.abs(py1 - py0)];
 }
 
 function esdfColor(value, obstacleValue) {
-  const clearance = Math.max(0, Math.min(1, value / 255));
   if (obstacleValue > 0) return "rgba(239, 68, 68, 0.62)";
-  if (clearance < 0.18) {
-    const t = clearance / 0.18;
+  const c = clamp(value / 255, 0, 1);
+  if (c < 0.18) {
+    const t = c / 0.18;
     return `rgba(${Math.round(249 - 80 * t)}, ${Math.round(115 + 80 * t)}, ${Math.round(22 + 20 * t)}, 0.46)`;
   }
-  if (clearance < 0.45) {
-    const t = (clearance - 0.18) / 0.27;
+  if (c < 0.45) {
+    const t = (c - 0.18) / 0.27;
     return `rgba(${Math.round(169 - 80 * t)}, ${Math.round(195 + 35 * t)}, ${Math.round(42 + 85 * t)}, 0.28)`;
   }
   return "rgba(15, 22, 33, 0.10)";
 }
 
+function drawEsdfLegend() {
+  const { width } = logicalSize();
+  const boxW = 154;
+  const x = Math.max(12, width - boxW - 16);
+  const y = 16;
+  ctx.save();
+  ctx.textAlign = "left";
+  ctx.fillStyle = "rgba(255,255,255,0.88)";
+  ctx.fillRect(x, y, boxW, 58);
+  ctx.fillStyle = "#17202a";
+  ctx.font = "12px system-ui";
+  ctx.fillText("ESDF clearance", x + 12, y + 18);
+  ["rgba(239, 68, 68, 0.72)", "rgba(249, 115, 22, 0.62)", "rgba(89, 230, 127, 0.36)", "rgba(15, 22, 33, 0.14)"]
+    .forEach((color, i) => {
+      ctx.fillStyle = color;
+      ctx.fillRect(x + 12 + i * 30, y + 28, 30, 12);
+    });
+  ctx.fillStyle = "#5c6975";
+  ctx.fillText("near", x + 12, y + 53);
+  ctx.fillText("clear", x + 106, y + 53);
+  ctx.restore();
+}
+
 function drawEsdfSceneOverlay() {
   const esdf = currentFrame?.esdf_u8;
-  if (!esdf || !esdf.data) return;
+  if (!esdf?.data) return;
   const obstacle = currentFrame?.obstacle_u8?.data || [];
   ctx.save();
   for (let ix = 0; ix < esdf.height; ix += 1) {
     for (let iy = 0; iy < esdf.width; iy += 1) {
       const idx = ix * esdf.width + iy;
       const value = esdf.data[idx];
-      const obstacleValue = obstacle[idx] || 0;
-      if (value > 150 && obstacleValue === 0) continue;
+      const occ = obstacle[idx] || 0;
+      if (value > 150 && occ === 0) continue;
       const [x, y, w, h] = gridCellToCanvasRect(esdf, ix, iy);
-      ctx.fillStyle = esdfColor(value, obstacleValue);
+      ctx.fillStyle = esdfColor(value, occ);
       ctx.fillRect(x, y, Math.max(w, 1), Math.max(h, 1));
     }
   }
   drawEsdfLegend();
-  ctx.restore();
-}
-
-function drawEsdfLegend() {
-  const size = canvasLogicalSize(canvas);
-  const boxW = 154;
-  const boxH = 58;
-  const x = Math.max(12, size.width - boxW - 16);
-  const y = 16;
-  ctx.save();
-  ctx.textAlign = "left";
-  ctx.textBaseline = "alphabetic";
-  ctx.fillStyle = "rgba(255,255,255,0.88)";
-  ctx.fillRect(x, y, boxW, boxH);
-  ctx.fillStyle = "#17202a";
-  ctx.font = "12px system-ui";
-  ctx.fillText("ESDF clearance", x + 12, y + 18);
-  const colors = [
-    "rgba(239, 68, 68, 0.72)",
-    "rgba(249, 115, 22, 0.62)",
-    "rgba(89, 230, 127, 0.36)",
-    "rgba(15, 22, 33, 0.14)",
-  ];
-  colors.forEach((color, index) => {
-    ctx.fillStyle = color;
-    ctx.fillRect(x + 12 + index * 30, y + 28, 30, 12);
-  });
-  ctx.fillStyle = "#5c6975";
-  ctx.fillText("near", x + 12, y + 53);
-  ctx.fillText("clear", x + 106, y + 53);
   ctx.restore();
 }
 
@@ -345,18 +352,34 @@ function drawPath(points, color, width, alpha = 1) {
   ctx.strokeStyle = color;
   ctx.lineWidth = width;
   ctx.beginPath();
-  points.forEach(([x, y], index) => {
+  points.forEach(([x, y], i) => {
     const [px, py] = worldToCanvas(x, y);
-    if (index === 0) ctx.moveTo(px, py);
+    if (i === 0) ctx.moveTo(px, py);
     else ctx.lineTo(px, py);
   });
   ctx.stroke();
   ctx.restore();
 }
 
+function drawFootprint(footprint) {
+  if (!footprint?.length) return;
+  ctx.fillStyle = "rgba(0, 169, 201, 0.24)";
+  ctx.strokeStyle = "#007d95";
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  footprint.forEach(([x, y], i) => {
+    const [px, py] = worldToCanvas(x, y);
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  });
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+
 function drawHudPanel(lines) {
-  const size = canvasLogicalSize(canvas);
-  const view = sceneView(canvas);
+  const size = logicalSize();
+  const view = sceneView();
   const pad = 10;
   const lineH = 18;
   const boxPadX = 12;
@@ -368,17 +391,15 @@ function drawHudPanel(lines) {
   const textW = Math.max(0, ...lines.map((line) => ctx.measureText(line).width));
   const boxW = Math.min(size.width - pad * 2, Math.ceil(textW + boxPadX * 2));
   const boxH = boxPadY * 2 + lines.length * lineH;
-  const x = Math.min(Math.max(pad, view.offsetX + 8), Math.max(pad, size.width - boxW - pad));
-  const y = Math.min(Math.max(pad, view.offsetY + 8), Math.max(pad, size.height - boxH - pad));
+  const x = clamp(view.offsetX + 8, pad, Math.max(pad, size.width - boxW - pad));
+  const y = clamp(view.offsetY + 8, pad, Math.max(pad, size.height - boxH - pad));
   ctx.fillStyle = "rgba(255,255,255,0.92)";
   ctx.fillRect(x, y, boxW, boxH);
   ctx.beginPath();
   ctx.rect(x, y, boxW, boxH);
   ctx.clip();
   ctx.fillStyle = "#17202a";
-  lines.forEach((line, index) => {
-    ctx.fillText(line, x + boxPadX, y + boxPadY + (index + 1) * lineH - 4);
-  });
+  lines.forEach((line, i) => ctx.fillText(line, x + boxPadX, y + boxPadY + (i + 1) * lineH - 4));
   ctx.restore();
 }
 
@@ -387,19 +408,12 @@ function drawRealtimeOverlay() {
     drawHudPanel(["Click Realtime to start live planning."]);
     return;
   }
-
-  drawPath(realtimePath, "#0f766e", 4, 1);
+  drawPath(realtimePath, "#0f766e", 4);
   (currentFrame.candidate_trajectories_xy || []).forEach((path) => drawPath(path, "#8d99a6", 1.1, 0.32));
   drawPath(currentFrame.selected_trajectory_xy, "#00a9c9", 3, 0.95);
   drawFootprint(currentFrame.robot_footprint_xy || []);
-  drawHeadingArrow(ctx, worldToCanvas, currentFrame.robot_xy, currentFrame.robot_yaw_deg, "#003f4a");
-  if (currentFrame.robot_xy) {
-    const [rx, ry] = worldToCanvas(currentFrame.robot_xy[0], currentFrame.robot_xy[1]);
-    ctx.fillStyle = "#003f4a";
-    ctx.beginPath();
-    ctx.arc(rx, ry, 5, 0, Math.PI * 2);
-    ctx.fill();
-  }
+  drawHeadingArrow(currentFrame.robot_xy, currentFrame.robot_yaw_deg, "#003f4a");
+  if (currentFrame.robot_xy) drawMarker(currentFrame.robot_xy, "", "#003f4a", 5);
 
   const lines = [
     `realtime tick ${Math.max(0, realtimePath.length - 1)}`,
@@ -412,30 +426,39 @@ function drawRealtimeOverlay() {
   drawHudPanel(lines);
 }
 
-function colorize(value, mode) {
-  const t = Math.max(0, Math.min(1, value / 255));
-  if (mode === "depth") {
-    return [
-      Math.round(30 + 220 * t),
-      Math.round(20 + 120 * (1 - Math.abs(t - 0.5) * 2)),
-      Math.round(70 + 160 * (1 - t)),
-    ];
-  }
-  return [
-    Math.round(15 + 25 * t),
-    Math.round(22 + 55 * t),
-    Math.round(33 + 70 * t),
-  ];
+function drawScene() {
+  if (!config) return;
+  const size = syncSceneCanvasSize();
+  ctx.clearRect(0, 0, size.width, size.height);
+  drawGrid();
+  drawGround();
+  drawEsdfSceneOverlay();
+  drawObjects();
+  drawStartTarget();
+  drawRealtimeOverlay();
 }
 
-function drawU8Canvas(targetCanvas, targetCtx, payload, mode) {
-  if (!payload || !payload.data) {
+function depthColor(value) {
+  if (value <= 0) return [10, 12, 20];
+  const t = clamp(value / 255, 0, 1);
+  for (let i = 0; i < DEPTH_STOPS.length - 1; i += 1) {
+    const [t0, c0] = DEPTH_STOPS[i];
+    const [t1, c1] = DEPTH_STOPS[i + 1];
+    if (t <= t1 || i === DEPTH_STOPS.length - 2) {
+      return lerpRGB(c0, c1, (t - t0) / Math.max(1e-6, t1 - t0));
+    }
+  }
+  return DEPTH_STOPS.at(-1)[1];
+}
+
+function drawU8Canvas(targetCanvas, targetCtx, payload) {
+  if (!payload?.data) {
     targetCtx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
     return;
   }
   const image = targetCtx.createImageData(payload.width, payload.height);
   for (let i = 0; i < payload.data.length; i += 1) {
-    const [r, g, b] = colorize(payload.data[i], mode);
+    const [r, g, b] = depthColor(payload.data[i]);
     const j = i * 4;
     image.data[j] = r;
     image.data[j + 1] = g;
@@ -445,8 +468,7 @@ function drawU8Canvas(targetCanvas, targetCtx, payload, mode) {
   const offscreen = document.createElement("canvas");
   offscreen.width = payload.width;
   offscreen.height = payload.height;
-  const offscreenCtx = offscreen.getContext("2d");
-  offscreenCtx.putImageData(image, 0, 0);
+  offscreen.getContext("2d").putImageData(image, 0, 0);
   targetCtx.imageSmoothingEnabled = false;
   targetCtx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
   targetCtx.save();
@@ -468,47 +490,8 @@ function syncControlsLayout() {
 
 function drawRealtimeFrame(frame) {
   currentFrame = frame;
-  drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8, "depth");
+  drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8);
   drawScene();
-}
-
-function drawHeadingArrow(drawCtx, mapper, xy, yawDeg, color, length = 0.45) {
-  if (!xy || yawDeg === undefined || yawDeg === null) return;
-  const yaw = (Number(yawDeg) * Math.PI) / 180;
-  const tip = [xy[0] + Math.cos(yaw) * length, xy[1] + Math.sin(yaw) * length];
-  const [x0, y0] = mapper(xy[0], xy[1]);
-  const [x1, y1] = mapper(tip[0], tip[1]);
-  drawCtx.strokeStyle = color;
-  drawCtx.fillStyle = color;
-  drawCtx.lineWidth = 3;
-  drawCtx.beginPath();
-  drawCtx.moveTo(x0, y0);
-  drawCtx.lineTo(x1, y1);
-  drawCtx.stroke();
-  const angle = Math.atan2(y1 - y0, x1 - x0);
-  drawCtx.beginPath();
-  drawCtx.moveTo(x1, y1);
-  drawCtx.lineTo(x1 - Math.cos(angle - 0.55) * 12, y1 - Math.sin(angle - 0.55) * 12);
-  drawCtx.lineTo(x1 - Math.cos(angle + 0.55) * 12, y1 - Math.sin(angle + 0.55) * 12);
-  drawCtx.closePath();
-  drawCtx.fill();
-}
-
-function drawFootprint(footprint) {
-  if (footprint.length) {
-    ctx.fillStyle = "rgba(0, 169, 201, 0.24)";
-    ctx.strokeStyle = "#007d95";
-    ctx.lineWidth = 3;
-    ctx.beginPath();
-    footprint.forEach(([x, y], i) => {
-      const [px, py] = worldToCanvas(x, y);
-      if (i === 0) ctx.moveTo(px, py);
-      else ctx.lineTo(px, py);
-    });
-    ctx.closePath();
-    ctx.fill();
-    ctx.stroke();
-  }
 }
 
 function refreshFields() {
@@ -516,12 +499,12 @@ function refreshFields() {
   const cam = config.camera || (config.camera = {});
   fields.targetX.value = config.target[0];
   fields.targetY.value = config.target[1];
-  fields.camWidth.value = cam.width ?? 160;
-  fields.camHeight.value = cam.image_height ?? cam.height ?? 100;
-  fields.camFx.value = cam.fx ?? 80;
-  fields.camFy.value = cam.fy ?? 25;
-  fields.camMaxRange.value = cam.max_range ?? 6.0;
-  fields.camMountHeight.value = cam.mount_height ?? 0.45;
+  fields.camWidth.value = cam.width ?? CAM_DEFAULTS.width;
+  fields.camHeight.value = cam.image_height ?? cam.height ?? CAM_DEFAULTS.image_height;
+  fields.camFx.value = cam.fx ?? CAM_DEFAULTS.fx;
+  fields.camFy.value = cam.fy ?? CAM_DEFAULTS.fy;
+  fields.camMaxRange.value = cam.max_range ?? CAM_DEFAULTS.max_range;
+  fields.camMountHeight.value = cam.mount_height ?? CAM_DEFAULTS.mount_height;
   if (obj) {
     fields.objectName.value = obj.name;
     fields.objectX.value = obj.center[0];
@@ -541,12 +524,12 @@ function applyFieldChanges() {
   const cam = config.camera || (config.camera = {});
   config.target[0] = Number(fields.targetX.value);
   config.target[1] = Number(fields.targetY.value);
-  cam.width = Math.max(16, Math.round(Number(fields.camWidth.value) || 160));
-  cam.image_height = Math.max(16, Math.round(Number(fields.camHeight.value) || 100));
-  cam.fx = Math.max(1, Number(fields.camFx.value) || 80);
-  cam.fy = Math.max(1, Number(fields.camFy.value) || 25);
-  cam.max_range = Math.max(0.5, Number(fields.camMaxRange.value) || 6.0);
-  cam.mount_height = Math.max(0.05, Number(fields.camMountHeight.value) || 0.45);
+  cam.width = num(fields.camWidth, CAM_DEFAULTS.width, 16, true);
+  cam.image_height = num(fields.camHeight, CAM_DEFAULTS.image_height, 16, true);
+  cam.fx = num(fields.camFx, CAM_DEFAULTS.fx, 1);
+  cam.fy = num(fields.camFy, CAM_DEFAULTS.fy, 1);
+  cam.max_range = num(fields.camMaxRange, CAM_DEFAULTS.max_range, 0.5);
+  cam.mount_height = num(fields.camMountHeight, CAM_DEFAULTS.mount_height, 0.05);
   if (obj) {
     obj.name = fields.objectName.value || obj.name;
     obj.center[0] = Number(fields.objectX.value);
@@ -558,17 +541,15 @@ function applyFieldChanges() {
   refreshFields();
 }
 
+function hitTestTarget(px, py) {
+  const [tpx, tpy] = worldToCanvas(config.target[0], config.target[1]);
+  return Math.hypot(px - tpx, py - tpy) <= 14;
+}
+
 function hitTestObject(px, py) {
   for (let i = config.objects.length - 1; i >= 0; i -= 1) {
-    const obj = config.objects[i];
-    const [x, y] = obj.center;
-    const [sx, sy] = obj.size;
-    const [px0, py0] = worldToCanvas(x - sx / 2, y - sy / 2);
-    const [px1, py1] = worldToCanvas(x + sx / 2, y + sy / 2);
-    if (px >= Math.min(px0, px1) && px <= Math.max(px0, px1) &&
-        py >= Math.min(py0, py1) && py <= Math.max(py0, py1)) {
-      return i;
-    }
+    const [x, y, w, h] = objectCanvasRect(config.objects[i]);
+    if (px >= x && px <= x + w && py >= y && py <= y + h) return i;
   }
   return -1;
 }
@@ -633,17 +614,8 @@ async function realtimeTick() {
     stopRealtime();
   } finally {
     realtimeBusy = false;
-    if (realtimeRunning) {
-      scheduleRealtimeTick(realtimePending ? 0 : REALTIME_TICK_DELAY_MS);
-    }
+    if (realtimeRunning) scheduleRealtimeTick(realtimePending ? 0 : REALTIME_TICK_DELAY_MS);
   }
-}
-
-async function startRosLoop() {
-  const response = await fetch("/api/start-ros-loop", { method: "POST" });
-  const data = await response.json();
-  if (!response.ok) throw new Error(data.detail || "Failed to start ROS loop");
-  return data;
 }
 
 async function toggleRealtime() {
@@ -655,7 +627,8 @@ async function toggleRealtime() {
   applyFieldChanges();
   statusEl.textContent = "Starting ROS loop...";
   try {
-    await startRosLoop();
+    const response = await fetch("/api/start-ros-loop", { method: "POST" });
+    if (!response.ok) throw new Error((await response.json()).detail || "Failed to start ROS loop");
   } catch (error) {
     statusEl.textContent = "ROS start error";
     return;
@@ -674,13 +647,18 @@ async function toggleRealtime() {
 
 async function loadDefault() {
   stopRealtime();
-  const response = await fetch("/api/default-config");
-  config = await response.json();
+  config = await (await fetch("/api/default-config")).json();
   selectedIndex = 0;
   currentFrame = null;
   realtimePath = [];
   refreshFields();
   statusEl.textContent = "Ready";
+}
+
+function selectObject(index) {
+  selectedIndex = index;
+  refreshFields();
+  noteSceneEdited(true, true);
 }
 
 editableFields.forEach((field) => {
@@ -691,54 +669,39 @@ editableFields.forEach((field) => {
 });
 
 realtimeButton.addEventListener("click", toggleRealtime);
-controlsToggle.addEventListener("click", () => {
-  setControlsVisible(controlsPanel.classList.contains("is-hidden"));
-});
-document.getElementById("resetScene").addEventListener("click", loadDefault);
-document.getElementById("applyJson").addEventListener("click", () => {
-  const nextConfig = JSON.parse(fields.configText.value);
-  nextConfig.robot = config.robot;
-  nextConfig.obstacle = config.obstacle;
-  config = nextConfig;
+controlsToggle.addEventListener("click", () => setControlsVisible(controlsPanel.classList.contains("is-hidden")));
+$("resetScene").addEventListener("click", loadDefault);
+$("applyJson").addEventListener("click", () => {
+  const next = JSON.parse(fields.configText.value);
+  next.robot = config.robot;
+  next.obstacle = config.obstacle;
+  config = next;
   selectedIndex = Math.min(selectedIndex, config.objects.length - 1);
   currentFrame = null;
   refreshFields();
   noteSceneEdited(true, true);
 });
-document.getElementById("addBox").addEventListener("click", () => {
-  config.objects.push({
-    name: `box_${config.objects.length + 1}`,
-    kind: "box",
-    center: [2.0, 0.0, 0.35],
-    size: [0.5, 0.5, 0.8],
-  });
-  selectedIndex = config.objects.length - 1;
-  refreshFields();
-  noteSceneEdited(true, true);
+$("addBox").addEventListener("click", () => {
+  config.objects.push({ name: `box_${config.objects.length + 1}`, kind: "box", center: [2.0, 0.0, 0.35], size: [0.5, 0.5, 0.8] });
+  selectObject(config.objects.length - 1);
 });
-document.getElementById("duplicateObject").addEventListener("click", () => {
+$("duplicateObject").addEventListener("click", () => {
   const obj = selectedObject();
   if (!obj) return;
-  const copy = JSON.parse(JSON.stringify(obj));
+  const copy = structuredClone(obj);
   copy.name = `${copy.name}_copy`;
   copy.center[1] += 0.4;
   config.objects.push(copy);
-  selectedIndex = config.objects.length - 1;
-  refreshFields();
-  noteSceneEdited(true, true);
+  selectObject(config.objects.length - 1);
 });
-document.getElementById("deleteObject").addEventListener("click", () => {
+$("deleteObject").addEventListener("click", () => {
   if (!config.objects.length) return;
   config.objects.splice(selectedIndex, 1);
-  selectedIndex = Math.max(0, selectedIndex - 1);
-  refreshFields();
-  noteSceneEdited(true, true);
+  selectObject(Math.max(0, selectedIndex - 1));
 });
 
 canvas.addEventListener("pointerdown", (event) => {
-  const rect = canvas.getBoundingClientRect();
-  const px = event.clientX - rect.left;
-  const py = event.clientY - rect.top;
+  const [px, py] = pointerPos(event);
   if (hitTestTarget(px, py)) {
     const [wx, wy] = canvasToWorld(px, py);
     dragState = { type: "target", dx: config.target[0] - wx, dy: config.target[1] - wy };
@@ -746,21 +709,18 @@ canvas.addEventListener("pointerdown", (event) => {
     return;
   }
   const hit = hitTestObject(px, py);
-  if (hit >= 0) {
-    selectedIndex = hit;
-    const [wx, wy] = canvasToWorld(px, py);
-    const obj = selectedObject();
-    dragState = { type: "object", dx: obj.center[0] - wx, dy: obj.center[1] - wy };
-    canvas.setPointerCapture(event.pointerId);
-    refreshFields();
-  }
+  if (hit < 0) return;
+  selectedIndex = hit;
+  const [wx, wy] = canvasToWorld(px, py);
+  const obj = selectedObject();
+  dragState = { type: "object", dx: obj.center[0] - wx, dy: obj.center[1] - wy };
+  canvas.setPointerCapture(event.pointerId);
+  refreshFields();
 });
 
 canvas.addEventListener("pointermove", (event) => {
   if (!dragState) return;
-  const rect = canvas.getBoundingClientRect();
-  const px = event.clientX - rect.left;
-  const py = event.clientY - rect.top;
+  const [px, py] = pointerPos(event);
   const [wx, wy] = canvasToWorld(px, py);
   if (dragState.type === "target") {
     config.target[0] = Number((wx + dragState.dx).toFixed(2));

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -163,10 +163,9 @@ function drawScene() {
   drawRealtimeOverlay();
 }
 
-function gridCellToCanvasRect(ix, iy, width, height) {
-  const grid = config.grid;
-  const resolution = Number(grid.resolution);
-  const origin = grid.origin;
+function gridCellToCanvasRect(payload, ix, iy) {
+  const resolution = Number(payload.resolution);
+  const origin = payload.origin;
   const x0 = origin[0] + ix * resolution;
   const y0 = origin[1] + iy * resolution;
   const x1 = origin[0] + (ix + 1) * resolution;
@@ -177,14 +176,14 @@ function gridCellToCanvasRect(ix, iy, width, height) {
 }
 
 function esdfColor(value, obstacleValue) {
-  const d = Math.max(0, Math.min(1, value / 255));
+  const clearance = Math.max(0, Math.min(1, value / 255));
   if (obstacleValue > 0) return "rgba(239, 68, 68, 0.62)";
-  if (d < 0.18) {
-    const t = d / 0.18;
+  if (clearance < 0.18) {
+    const t = clearance / 0.18;
     return `rgba(${Math.round(249 - 80 * t)}, ${Math.round(115 + 80 * t)}, ${Math.round(22 + 20 * t)}, 0.46)`;
   }
-  if (d < 0.45) {
-    const t = (d - 0.18) / 0.27;
+  if (clearance < 0.45) {
+    const t = (clearance - 0.18) / 0.27;
     return `rgba(${Math.round(169 - 80 * t)}, ${Math.round(195 + 35 * t)}, ${Math.round(42 + 85 * t)}, 0.28)`;
   }
   return "rgba(15, 22, 33, 0.10)";
@@ -201,12 +200,36 @@ function drawEsdfSceneOverlay() {
       const value = esdf.data[idx];
       const obstacleValue = obstacle[idx] || 0;
       if (value > 150 && obstacleValue === 0) continue;
-      const [x, y, w, h] = gridCellToCanvasRect(ix, iy, esdf.width, esdf.height);
+      const [x, y, w, h] = gridCellToCanvasRect(esdf, ix, iy);
       ctx.fillStyle = esdfColor(value, obstacleValue);
       ctx.fillRect(x, y, Math.max(w, 1), Math.max(h, 1));
     }
   }
+  drawEsdfLegend();
   ctx.restore();
+}
+
+function drawEsdfLegend() {
+  const x = canvas.width - 178;
+  const y = 16;
+  ctx.fillStyle = "rgba(255,255,255,0.88)";
+  ctx.fillRect(x, y, 154, 58);
+  ctx.fillStyle = "#17202a";
+  ctx.font = "12px system-ui";
+  ctx.fillText("ESDF clearance", x + 12, y + 18);
+  const colors = [
+    "rgba(239, 68, 68, 0.72)",
+    "rgba(249, 115, 22, 0.62)",
+    "rgba(89, 230, 127, 0.36)",
+    "rgba(15, 22, 33, 0.14)",
+  ];
+  colors.forEach((color, index) => {
+    ctx.fillStyle = color;
+    ctx.fillRect(x + 12 + index * 30, y + 28, 30, 12);
+  });
+  ctx.fillStyle = "#5c6975";
+  ctx.fillText("near", x + 12, y + 53);
+  ctx.fillText("clear", x + 106, y + 53);
 }
 
 function drawPath(points, color, width, alpha = 1) {
@@ -309,7 +332,8 @@ function drawRealtimeFrame(frame) {
   currentFrame = frame;
   drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8, "depth");
   drawScene();
-  diagnosticNote.textContent = `Realtime depth updates here; ESDF is fused into the scene. Valid trajectories: ${frame.valid_trajectories}, clearance: ${Number(frame.front_clearance).toFixed(2)}m, reverse: ${frame.selected_is_reverse ? "selected" : frame.should_reverse ? "gated" : "no"}, recovery: ${frame.recovery_reason || "normal"}.`;
+  const esdfState = frame.esdf_u8 ? "ESDF live" : "waiting for ESDF";
+  diagnosticNote.textContent = `${esdfState}; depth updates here. Valid trajectories: ${frame.valid_trajectories}, clearance: ${Number(frame.front_clearance).toFixed(2)}m, reverse: ${frame.selected_is_reverse ? "selected" : frame.should_reverse ? "gated" : "no"}, recovery: ${frame.recovery_reason || "normal"}.`;
 }
 
 function drawHeadingArrow(drawCtx, mapper, xy, yawDeg, color, length = 0.45) {

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -1,0 +1,614 @@
+let config = null;
+let selectedIndex = 0;
+let dragState = null;
+let realtimeRunning = false;
+let realtimeBusy = false;
+let realtimeTimer = null;
+let realtimePending = false;
+let realtimePath = [];
+let currentFrame = null;
+let realtimeNeedsReset = true;
+const REALTIME_TICK_DELAY_MS = 33;
+
+const canvas = document.getElementById("sceneCanvas");
+const ctx = canvas.getContext("2d");
+const depthCanvas = document.getElementById("depthCanvas");
+const depthCtx = depthCanvas.getContext("2d");
+const statusEl = document.getElementById("status");
+const realtimeButton = document.getElementById("realtimeButton");
+const diagnosticNote = document.getElementById("diagnosticNote");
+
+const fields = {
+  robotWidth: document.getElementById("robotWidth"),
+  robotLength: document.getElementById("robotLength"),
+  cameraX: document.getElementById("cameraX"),
+  controlX: document.getElementById("controlX"),
+  safetyRadius: document.getElementById("safetyRadius"),
+  comfortRadius: document.getElementById("comfortRadius"),
+  targetX: document.getElementById("targetX"),
+  targetY: document.getElementById("targetY"),
+  objectName: document.getElementById("objectName"),
+  objectX: document.getElementById("objectX"),
+  objectY: document.getElementById("objectY"),
+  objectSX: document.getElementById("objectSX"),
+  objectSY: document.getElementById("objectSY"),
+  objectSZ: document.getElementById("objectSZ"),
+  configText: document.getElementById("configText"),
+};
+
+function sceneBounds() {
+  return { xMin: -0.5, xMax: 5.0, yMin: -2.8, yMax: 2.8 };
+}
+
+function worldToCanvasOn(targetCanvas, x, y) {
+  const b = sceneBounds();
+  const px = ((y - b.yMin) / (b.yMax - b.yMin)) * targetCanvas.width;
+  const py = targetCanvas.height - ((x - b.xMin) / (b.xMax - b.xMin)) * targetCanvas.height;
+  return [px, py];
+}
+
+function worldToCanvas(x, y) {
+  return worldToCanvasOn(canvas, x, y);
+}
+
+function canvasToWorld(px, py) {
+  const b = sceneBounds();
+  const y = b.yMin + (px / canvas.width) * (b.yMax - b.yMin);
+  const x = b.xMin + ((canvas.height - py) / canvas.height) * (b.xMax - b.xMin);
+  return [x, y];
+}
+
+function selectedObject() {
+  return config?.objects?.[selectedIndex] || null;
+}
+
+function hitTestTarget(px, py) {
+  const [tx, ty] = config.target;
+  const [tpx, tpy] = worldToCanvas(tx, ty);
+  return Math.hypot(px - tpx, py - tpy) <= 14;
+}
+
+function drawGrid(drawCtx, targetCanvas, mapper) {
+  drawCtx.fillStyle = "#fbfcfd";
+  drawCtx.fillRect(0, 0, targetCanvas.width, targetCanvas.height);
+  drawCtx.strokeStyle = "#e0e7ee";
+  drawCtx.lineWidth = 1;
+  for (let x = 0; x <= 5; x += 1) {
+    const [px0, py] = mapper(x, -2.8);
+    const [px1] = mapper(x, 2.8);
+    drawCtx.beginPath();
+    drawCtx.moveTo(px0, py);
+    drawCtx.lineTo(px1, py);
+    drawCtx.stroke();
+  }
+  for (let y = -2; y <= 2; y += 1) {
+    const [px, py0] = mapper(-0.5, y);
+    const [, py1] = mapper(5.0, y);
+    drawCtx.beginPath();
+    drawCtx.moveTo(px, py0);
+    drawCtx.lineTo(px, py1);
+    drawCtx.stroke();
+  }
+}
+
+function drawObjects(drawCtx, mapper, highlightSelected) {
+  config.objects.forEach((obj, idx) => {
+    const [x, y] = obj.center;
+    const [sx, sy] = obj.size;
+    const [px0, py0] = mapper(x - sx / 2, y - sy / 2);
+    const [px1, py1] = mapper(x + sx / 2, y + sy / 2);
+    const selected = highlightSelected && idx === selectedIndex;
+    drawCtx.fillStyle = selected ? "rgba(16, 107, 103, 0.55)" : "rgba(95, 108, 120, 0.45)";
+    drawCtx.strokeStyle = selected ? "#106b67" : "#56616c";
+    drawCtx.lineWidth = selected ? 3 : 1.5;
+    drawCtx.beginPath();
+    drawCtx.rect(Math.min(px0, px1), Math.min(py0, py1), Math.abs(px1 - px0), Math.abs(py1 - py0));
+    drawCtx.fill();
+    drawCtx.stroke();
+    drawCtx.fillStyle = "#17202a";
+    drawCtx.font = "13px system-ui";
+    drawCtx.textAlign = "center";
+    drawCtx.fillText(obj.name, (px0 + px1) / 2, (py0 + py1) / 2 + 4);
+  });
+}
+
+function drawStartTarget(drawCtx, mapper) {
+  const [sx, sy] = config.start.xy;
+  const [spx, spy] = mapper(sx, sy);
+  drawCtx.fillStyle = "#24a148";
+  drawCtx.beginPath();
+  drawCtx.arc(spx, spy, 7, 0, Math.PI * 2);
+  drawCtx.fill();
+  drawCtx.fillText("control", spx, spy - 12);
+
+  const camera = cameraPose();
+  const [cpx, cpy] = mapper(camera.xy[0], camera.xy[1]);
+  drawCtx.fillStyle = "#6d28d9";
+  drawCtx.beginPath();
+  drawCtx.arc(cpx, cpy, 6, 0, Math.PI * 2);
+  drawCtx.fill();
+  drawCtx.fillText("camera", cpx, cpy - 12);
+  drawHeadingArrow(drawCtx, mapper, camera.xy, config.start.yaw_deg, "#6d28d9", 0.32);
+
+  const [tx, ty] = config.target;
+  const [tpx, tpy] = mapper(tx, ty);
+  drawCtx.fillStyle = "#da1e28";
+  drawCtx.beginPath();
+  drawCtx.arc(tpx, tpy, 7, 0, Math.PI * 2);
+  drawCtx.fill();
+  drawCtx.fillText("target", tpx, tpy - 12);
+}
+
+function cameraPose() {
+  const yaw = (Number(config.start.yaw_deg || 0) * Math.PI) / 180;
+  const forwardOffset = Number(config.robot.camera_x || 0) - Number(config.robot.control_x || 0);
+  const leftOffset = Number(config.robot.camera_y || 0) - Number(config.robot.control_y || 0);
+  const forward = [Math.cos(yaw), Math.sin(yaw)];
+  const left = [-Math.sin(yaw), Math.cos(yaw)];
+  return {
+    xy: [
+      config.start.xy[0] + forward[0] * forwardOffset + left[0] * leftOffset,
+      config.start.xy[1] + forward[1] * forwardOffset + left[1] * leftOffset,
+    ],
+  };
+}
+
+function drawScene() {
+  if (!config) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawGrid(ctx, canvas, worldToCanvas);
+  drawEsdfSceneOverlay();
+  drawObjects(ctx, worldToCanvas, true);
+  drawStartTarget(ctx, worldToCanvas);
+  drawRealtimeOverlay();
+}
+
+function gridCellToCanvasRect(ix, iy, width, height) {
+  const grid = config.grid;
+  const resolution = Number(grid.resolution);
+  const origin = grid.origin;
+  const x0 = origin[0] + ix * resolution;
+  const y0 = origin[1] + iy * resolution;
+  const x1 = origin[0] + (ix + 1) * resolution;
+  const y1 = origin[1] + (iy + 1) * resolution;
+  const [px0, py0] = worldToCanvas(x0, y0);
+  const [px1, py1] = worldToCanvas(x1, y1);
+  return [Math.min(px0, px1), Math.min(py0, py1), Math.abs(px1 - px0), Math.abs(py1 - py0)];
+}
+
+function esdfColor(value, obstacleValue) {
+  const d = Math.max(0, Math.min(1, value / 255));
+  if (obstacleValue > 0) return "rgba(239, 68, 68, 0.62)";
+  if (d < 0.18) {
+    const t = d / 0.18;
+    return `rgba(${Math.round(249 - 80 * t)}, ${Math.round(115 + 80 * t)}, ${Math.round(22 + 20 * t)}, 0.46)`;
+  }
+  if (d < 0.45) {
+    const t = (d - 0.18) / 0.27;
+    return `rgba(${Math.round(169 - 80 * t)}, ${Math.round(195 + 35 * t)}, ${Math.round(42 + 85 * t)}, 0.28)`;
+  }
+  return "rgba(15, 22, 33, 0.10)";
+}
+
+function drawEsdfSceneOverlay() {
+  const esdf = currentFrame?.esdf_u8;
+  if (!esdf || !esdf.data) return;
+  const obstacle = currentFrame?.obstacle_u8?.data || [];
+  ctx.save();
+  for (let ix = 0; ix < esdf.height; ix += 1) {
+    for (let iy = 0; iy < esdf.width; iy += 1) {
+      const idx = ix * esdf.width + iy;
+      const value = esdf.data[idx];
+      const obstacleValue = obstacle[idx] || 0;
+      if (value > 150 && obstacleValue === 0) continue;
+      const [x, y, w, h] = gridCellToCanvasRect(ix, iy, esdf.width, esdf.height);
+      ctx.fillStyle = esdfColor(value, obstacleValue);
+      ctx.fillRect(x, y, Math.max(w, 1), Math.max(h, 1));
+    }
+  }
+  ctx.restore();
+}
+
+function drawPath(points, color, width, alpha = 1) {
+  if (!points || points.length < 2) return;
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+  ctx.beginPath();
+  points.forEach(([x, y], index) => {
+    const [px, py] = worldToCanvas(x, y);
+    if (index === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  });
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawRealtimeOverlay() {
+  if (!currentFrame) {
+    ctx.fillStyle = "#5c6975";
+    ctx.font = "15px system-ui";
+    ctx.fillText("Click Realtime to start live planning.", 22, 30);
+    return;
+  }
+
+  drawPath(realtimePath, "#0f766e", 4, 1);
+  (currentFrame.candidate_trajectories_xy || []).forEach((path) => drawPath(path, "#8d99a6", 1.1, 0.32));
+  drawPath(currentFrame.selected_trajectory_xy, "#00a9c9", 3, 0.95);
+  drawFootprint(currentFrame.robot_footprint_xy || []);
+  drawHeadingArrow(ctx, worldToCanvas, currentFrame.robot_xy, currentFrame.robot_yaw_deg, "#003f4a");
+  if (currentFrame.robot_xy) {
+    const [rx, ry] = worldToCanvas(currentFrame.robot_xy[0], currentFrame.robot_xy[1]);
+    ctx.fillStyle = "#003f4a";
+    ctx.beginPath();
+    ctx.arc(rx, ry, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.fillStyle = "rgba(255,255,255,0.9)";
+  ctx.fillRect(12, 12, 210, currentFrame.should_reverse || currentFrame.selected_is_reverse ? 92 : 72);
+  ctx.fillStyle = "#17202a";
+  ctx.font = "13px system-ui";
+  ctx.fillText(`realtime tick ${Math.max(0, realtimePath.length - 1)}`, 24, 34);
+  ctx.fillText(`cmd [${currentFrame.selected_param.map((v) => Number(v).toFixed(2)).join(", ")}]`, 24, 54);
+  ctx.fillText(`clearance ${Number(currentFrame.front_clearance).toFixed(2)}m`, 24, 74);
+  if (currentFrame.should_reverse || currentFrame.selected_is_reverse) {
+    ctx.fillText(`reverse ${currentFrame.selected_is_reverse ? "selected" : "gated"}`, 24, 94);
+  }
+}
+
+function drawDiagnostic(step = 0) {
+  if (!currentFrame) {
+    diagnosticNote.textContent = "Run the closed-loop simulation to generate per-step perception snapshots.";
+    return;
+  }
+  diagnosticNote.textContent = "Depth updates here; ESDF safety layer is fused into the scene canvas.";
+}
+
+function colorize(value, mode) {
+  const t = Math.max(0, Math.min(1, value / 255));
+  if (mode === "depth") {
+    return [
+      Math.round(30 + 220 * t),
+      Math.round(20 + 120 * (1 - Math.abs(t - 0.5) * 2)),
+      Math.round(70 + 160 * (1 - t)),
+    ];
+  }
+  return [
+    Math.round(15 + 25 * t),
+    Math.round(22 + 55 * t),
+    Math.round(33 + 70 * t),
+  ];
+}
+
+function drawU8Canvas(targetCanvas, targetCtx, payload, mode) {
+  if (!payload || !payload.data) {
+    targetCtx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
+    return;
+  }
+  const image = targetCtx.createImageData(payload.width, payload.height);
+  for (let i = 0; i < payload.data.length; i += 1) {
+    const [r, g, b] = colorize(payload.data[i], mode);
+    const j = i * 4;
+    image.data[j] = r;
+    image.data[j + 1] = g;
+    image.data[j + 2] = b;
+    image.data[j + 3] = 255;
+  }
+  const offscreen = document.createElement("canvas");
+  offscreen.width = payload.width;
+  offscreen.height = payload.height;
+  const offscreenCtx = offscreen.getContext("2d");
+  offscreenCtx.putImageData(image, 0, 0);
+  targetCtx.imageSmoothingEnabled = false;
+  targetCtx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
+  targetCtx.drawImage(offscreen, 0, 0, targetCanvas.width, targetCanvas.height);
+}
+
+function drawRealtimeFrame(frame) {
+  currentFrame = frame;
+  drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8, "depth");
+  drawScene();
+  diagnosticNote.textContent = `Realtime depth updates here; ESDF is fused into the scene. Valid trajectories: ${frame.valid_trajectories}, clearance: ${Number(frame.front_clearance).toFixed(2)}m, reverse: ${frame.selected_is_reverse ? "selected" : frame.should_reverse ? "gated" : "no"}, recovery: ${frame.recovery_reason || "normal"}.`;
+}
+
+function drawHeadingArrow(drawCtx, mapper, xy, yawDeg, color, length = 0.45) {
+  if (!xy || yawDeg === undefined || yawDeg === null) return;
+  const yaw = (Number(yawDeg) * Math.PI) / 180;
+  const tip = [xy[0] + Math.cos(yaw) * length, xy[1] + Math.sin(yaw) * length];
+  const [x0, y0] = mapper(xy[0], xy[1]);
+  const [x1, y1] = mapper(tip[0], tip[1]);
+  drawCtx.strokeStyle = color;
+  drawCtx.fillStyle = color;
+  drawCtx.lineWidth = 3;
+  drawCtx.beginPath();
+  drawCtx.moveTo(x0, y0);
+  drawCtx.lineTo(x1, y1);
+  drawCtx.stroke();
+  const angle = Math.atan2(y1 - y0, x1 - x0);
+  drawCtx.beginPath();
+  drawCtx.moveTo(x1, y1);
+  drawCtx.lineTo(x1 - Math.cos(angle - 0.55) * 12, y1 - Math.sin(angle - 0.55) * 12);
+  drawCtx.lineTo(x1 - Math.cos(angle + 0.55) * 12, y1 - Math.sin(angle + 0.55) * 12);
+  drawCtx.closePath();
+  drawCtx.fill();
+}
+
+function drawFootprint(footprint) {
+  if (footprint.length) {
+    ctx.fillStyle = "rgba(0, 169, 201, 0.24)";
+    ctx.strokeStyle = "#007d95";
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    footprint.forEach(([x, y], i) => {
+      const [px, py] = worldToCanvas(x, y);
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    });
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  }
+}
+
+function refreshFields() {
+  const obj = selectedObject();
+  fields.robotWidth.value = config.robot.width;
+  fields.robotLength.value = config.robot.length;
+  fields.cameraX.value = config.robot.camera_x;
+  fields.controlX.value = config.robot.control_x;
+  fields.safetyRadius.value = config.robot.safety_radius;
+  fields.comfortRadius.value = config.robot.comfort_radius;
+  fields.targetX.value = config.target[0];
+  fields.targetY.value = config.target[1];
+  if (obj) {
+    fields.objectName.value = obj.name;
+    fields.objectX.value = obj.center[0];
+    fields.objectY.value = obj.center[1];
+    fields.objectSX.value = obj.size[0];
+    fields.objectSY.value = obj.size[1];
+    fields.objectSZ.value = obj.size[2];
+  }
+  fields.configText.value = JSON.stringify(config, null, 2);
+  drawScene();
+}
+
+function applyFieldChanges() {
+  const obj = selectedObject();
+  config.robot.width = Number(fields.robotWidth.value);
+  config.robot.length = Number(fields.robotLength.value);
+  config.robot.camera_x = Number(fields.cameraX.value);
+  config.robot.control_x = Number(fields.controlX.value);
+  config.robot.safety_radius = Number(fields.safetyRadius.value);
+  config.robot.comfort_radius = Number(fields.comfortRadius.value);
+  config.target[0] = Number(fields.targetX.value);
+  config.target[1] = Number(fields.targetY.value);
+  if (obj) {
+    obj.name = fields.objectName.value || obj.name;
+    obj.center[0] = Number(fields.objectX.value);
+    obj.center[1] = Number(fields.objectY.value);
+    obj.size[0] = Number(fields.objectSX.value);
+    obj.size[1] = Number(fields.objectSY.value);
+    obj.size[2] = Number(fields.objectSZ.value);
+  }
+  refreshFields();
+}
+
+function hitTestObject(px, py) {
+  for (let i = config.objects.length - 1; i >= 0; i -= 1) {
+    const obj = config.objects[i];
+    const [x, y] = obj.center;
+    const [sx, sy] = obj.size;
+    const [px0, py0] = worldToCanvas(x - sx / 2, y - sy / 2);
+    const [px1, py1] = worldToCanvas(x + sx / 2, y + sy / 2);
+    if (px >= Math.min(px0, px1) && px <= Math.max(px0, px1) &&
+        py >= Math.min(py0, py1) && py <= Math.max(py0, py1)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function stopRealtime() {
+  realtimeRunning = false;
+  realtimePending = false;
+  if (realtimeTimer !== null) {
+    clearTimeout(realtimeTimer);
+    realtimeTimer = null;
+  }
+  realtimeButton.textContent = "Realtime";
+  realtimeButton.classList.add("primary");
+}
+
+function scheduleRealtimeTick(delay = REALTIME_TICK_DELAY_MS) {
+  if (!realtimeRunning) return;
+  if (realtimeBusy) {
+    realtimePending = true;
+    return;
+  }
+  if (realtimeTimer !== null) clearTimeout(realtimeTimer);
+  realtimeTimer = setTimeout(() => {
+    realtimeTimer = null;
+    realtimeTick();
+  }, delay);
+}
+
+function noteSceneEdited(resetOccupancy = false, immediate = true) {
+  if (resetOccupancy) realtimeNeedsReset = true;
+  if (realtimeRunning && immediate) scheduleRealtimeTick(0);
+}
+
+async function realtimeTick() {
+  if (!realtimeRunning) return;
+  if (realtimeBusy) {
+    realtimePending = true;
+    return;
+  }
+  realtimeBusy = true;
+  realtimePending = false;
+  applyFieldChanges();
+  try {
+    const response = await fetch("/api/realtime-step", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config, advance_step: 3, reset: realtimeNeedsReset }),
+    });
+    realtimeNeedsReset = false;
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.detail || "Realtime step failed");
+    const frame = data.frame;
+    config.start.xy = frame.next_start.xy;
+    config.start.yaw_deg = frame.next_start.yaw_deg;
+    realtimePath.push(frame.robot_xy);
+    if (realtimePath.length > 300) realtimePath = realtimePath.slice(-300);
+    drawRealtimeFrame(frame);
+    refreshFields();
+    statusEl.textContent = "Realtime running";
+  } catch (error) {
+    statusEl.textContent = "Realtime error";
+    stopRealtime();
+  } finally {
+    realtimeBusy = false;
+    if (realtimeRunning) {
+      scheduleRealtimeTick(realtimePending ? 0 : REALTIME_TICK_DELAY_MS);
+    }
+  }
+}
+
+async function startRosLoop() {
+  const response = await fetch("/api/start-ros-loop", { method: "POST" });
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.detail || "Failed to start ROS loop");
+  return data;
+}
+
+async function toggleRealtime() {
+  if (realtimeRunning) {
+    stopRealtime();
+    statusEl.textContent = "Realtime stopped";
+    return;
+  }
+  applyFieldChanges();
+  statusEl.textContent = "Starting ROS loop...";
+  try {
+    await startRosLoop();
+  } catch (error) {
+    statusEl.textContent = "ROS start error";
+    return;
+  }
+  realtimeRunning = true;
+  realtimeBusy = false;
+  realtimePending = false;
+  realtimeNeedsReset = true;
+  realtimePath = [config.start.xy.slice()];
+  currentFrame = null;
+  realtimeButton.textContent = "Stop";
+  realtimeButton.classList.remove("primary");
+  statusEl.textContent = "Realtime starting...";
+  realtimeTick();
+}
+
+async function loadDefault() {
+  stopRealtime();
+  const response = await fetch("/api/default-config");
+  config = await response.json();
+  selectedIndex = 0;
+  currentFrame = null;
+  realtimePath = [];
+  refreshFields();
+  statusEl.textContent = "Ready";
+}
+
+Object.values(fields).forEach((field) => {
+  if (field !== fields.configText) {
+    field.addEventListener("change", () => {
+      applyFieldChanges();
+      noteSceneEdited(true, true);
+    });
+  }
+});
+
+realtimeButton.addEventListener("click", toggleRealtime);
+document.getElementById("resetScene").addEventListener("click", loadDefault);
+document.getElementById("applyJson").addEventListener("click", () => {
+  config = JSON.parse(fields.configText.value);
+  selectedIndex = Math.min(selectedIndex, config.objects.length - 1);
+  currentFrame = null;
+  refreshFields();
+  noteSceneEdited(true, true);
+});
+document.getElementById("addBox").addEventListener("click", () => {
+  config.objects.push({
+    name: `box_${config.objects.length + 1}`,
+    kind: "box",
+    center: [2.0, 0.0, 0.35],
+    size: [0.5, 0.5, 0.8],
+  });
+  selectedIndex = config.objects.length - 1;
+  refreshFields();
+  noteSceneEdited(true, true);
+});
+document.getElementById("duplicateObject").addEventListener("click", () => {
+  const obj = selectedObject();
+  if (!obj) return;
+  const copy = JSON.parse(JSON.stringify(obj));
+  copy.name = `${copy.name}_copy`;
+  copy.center[1] += 0.4;
+  config.objects.push(copy);
+  selectedIndex = config.objects.length - 1;
+  refreshFields();
+  noteSceneEdited(true, true);
+});
+document.getElementById("deleteObject").addEventListener("click", () => {
+  if (!config.objects.length) return;
+  config.objects.splice(selectedIndex, 1);
+  selectedIndex = Math.max(0, selectedIndex - 1);
+  refreshFields();
+  noteSceneEdited(true, true);
+});
+
+canvas.addEventListener("pointerdown", (event) => {
+  const rect = canvas.getBoundingClientRect();
+  const px = ((event.clientX - rect.left) / rect.width) * canvas.width;
+  const py = ((event.clientY - rect.top) / rect.height) * canvas.height;
+  if (hitTestTarget(px, py)) {
+    const [wx, wy] = canvasToWorld(px, py);
+    dragState = { type: "target", dx: config.target[0] - wx, dy: config.target[1] - wy };
+    canvas.setPointerCapture(event.pointerId);
+    return;
+  }
+  const hit = hitTestObject(px, py);
+  if (hit >= 0) {
+    selectedIndex = hit;
+    const [wx, wy] = canvasToWorld(px, py);
+    const obj = selectedObject();
+    dragState = { type: "object", dx: obj.center[0] - wx, dy: obj.center[1] - wy };
+    canvas.setPointerCapture(event.pointerId);
+    refreshFields();
+  }
+});
+
+canvas.addEventListener("pointermove", (event) => {
+  if (!dragState) return;
+  const rect = canvas.getBoundingClientRect();
+  const px = ((event.clientX - rect.left) / rect.width) * canvas.width;
+  const py = ((event.clientY - rect.top) / rect.height) * canvas.height;
+  const [wx, wy] = canvasToWorld(px, py);
+  if (dragState.type === "target") {
+    config.target[0] = Number((wx + dragState.dx).toFixed(2));
+    config.target[1] = Number((wy + dragState.dy).toFixed(2));
+    noteSceneEdited(false, true);
+  } else {
+    const obj = selectedObject();
+    obj.center[0] = Number((wx + dragState.dx).toFixed(2));
+    obj.center[1] = Number((wy + dragState.dy).toFixed(2));
+    noteSceneEdited(true, true);
+  }
+  refreshFields();
+});
+
+canvas.addEventListener("pointerup", () => {
+  dragState = null;
+});
+
+loadDefault();

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -23,6 +23,12 @@ const GRID_STEP_M = 1.0;
 const fields = {
   targetX: document.getElementById("targetX"),
   targetY: document.getElementById("targetY"),
+  camWidth: document.getElementById("camWidth"),
+  camHeight: document.getElementById("camHeight"),
+  camFx: document.getElementById("camFx"),
+  camFy: document.getElementById("camFy"),
+  camMaxRange: document.getElementById("camMaxRange"),
+  camMountHeight: document.getElementById("camMountHeight"),
   objectName: document.getElementById("objectName"),
   objectX: document.getElementById("objectX"),
   objectY: document.getElementById("objectY"),
@@ -31,11 +37,18 @@ const fields = {
   objectSZ: document.getElementById("objectSZ"),
   configText: document.getElementById("configText"),
   robotSummary: document.getElementById("robotSummary"),
+  cameraSummary: document.getElementById("cameraSummary"),
 };
 
 const editableFields = [
   fields.targetX,
   fields.targetY,
+  fields.camWidth,
+  fields.camHeight,
+  fields.camFx,
+  fields.camFy,
+  fields.camMaxRange,
+  fields.camMountHeight,
   fields.objectName,
   fields.objectX,
   fields.objectY,
@@ -48,10 +61,34 @@ function sceneBounds() {
   return { xMin: -0.5, xMax: 9.5, yMin: -5.0, yMax: 5.0 };
 }
 
-function worldToCanvasOn(targetCanvas, x, y) {
+function canvasLogicalSize(targetCanvas) {
+  return {
+    width: Math.max(1, targetCanvas.clientWidth || targetCanvas.width),
+    height: Math.max(1, targetCanvas.clientHeight || targetCanvas.height),
+  };
+}
+
+function sceneView(targetCanvas) {
   const b = sceneBounds();
-  const px = ((y - b.yMin) / (b.yMax - b.yMin)) * targetCanvas.width;
-  const py = targetCanvas.height - ((x - b.xMin) / (b.xMax - b.xMin)) * targetCanvas.height;
+  const size = canvasLogicalSize(targetCanvas);
+  const worldW = b.yMax - b.yMin;
+  const worldH = b.xMax - b.xMin;
+  const pad = 12;
+  const availW = Math.max(1, size.width - pad * 2);
+  const availH = Math.max(1, size.height - pad * 2);
+  const scale = Math.min(availW / worldW, availH / worldH);
+  return {
+    b,
+    scale,
+    offsetX: pad + (availW - worldW * scale) / 2,
+    offsetY: pad + (availH - worldH * scale) / 2,
+  };
+}
+
+function worldToCanvasOn(targetCanvas, x, y) {
+  const view = sceneView(targetCanvas);
+  const px = view.offsetX + (y - view.b.yMin) * view.scale;
+  const py = view.offsetY + (view.b.xMax - x) * view.scale;
   return [px, py];
 }
 
@@ -60,10 +97,24 @@ function worldToCanvas(x, y) {
 }
 
 function canvasToWorld(px, py) {
-  const b = sceneBounds();
-  const y = b.yMin + (px / canvas.width) * (b.yMax - b.yMin);
-  const x = b.xMin + ((canvas.height - py) / canvas.height) * (b.xMax - b.xMin);
+  const view = sceneView(canvas);
+  const y = view.b.yMin + (px - view.offsetX) / view.scale;
+  const x = view.b.xMax - (py - view.offsetY) / view.scale;
   return [x, y];
+}
+
+function syncSceneCanvasSize() {
+  const cssW = Math.max(1, Math.round(canvas.clientWidth));
+  const cssH = Math.max(1, Math.round(canvas.clientHeight));
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const nextW = Math.max(1, Math.round(cssW * dpr));
+  const nextH = Math.max(1, Math.round(cssH * dpr));
+  if (canvas.width !== nextW || canvas.height !== nextH) {
+    canvas.width = nextW;
+    canvas.height = nextH;
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { width: cssW, height: cssH };
 }
 
 function selectedObject() {
@@ -77,8 +128,9 @@ function hitTestTarget(px, py) {
 }
 
 function drawGrid(drawCtx, targetCanvas, mapper) {
+  const size = canvasLogicalSize(targetCanvas);
   drawCtx.fillStyle = "#fbfcfd";
-  drawCtx.fillRect(0, 0, targetCanvas.width, targetCanvas.height);
+  drawCtx.fillRect(0, 0, size.width, size.height);
   drawCtx.strokeStyle = "#e0e7ee";
   drawCtx.lineWidth = 1;
   const b = sceneBounds();
@@ -124,6 +176,9 @@ function drawObjects(drawCtx, mapper, highlightSelected) {
 }
 
 function drawStartTarget(drawCtx, mapper) {
+  drawCtx.save();
+  drawCtx.textAlign = "center";
+  drawCtx.textBaseline = "alphabetic";
   const [sx, sy] = config.start.xy;
   const [spx, spy] = mapper(sx, sy);
   drawCtx.fillStyle = "#24a148";
@@ -148,6 +203,7 @@ function drawStartTarget(drawCtx, mapper) {
   drawCtx.arc(tpx, tpy, 7, 0, Math.PI * 2);
   drawCtx.fill();
   drawCtx.fillText("target", tpx, tpy - 12);
+  drawCtx.restore();
 }
 
 function cameraPose() {
@@ -176,9 +232,29 @@ function robotSummaryHtml() {
   ].join("<br />");
 }
 
+function cameraFovDeg(size, focal) {
+  const half = Math.max(1, Number(size) || 1) / 2;
+  const f = Math.max(1e-6, Number(focal) || 1);
+  return (2 * Math.atan(half / f) * 180) / Math.PI;
+}
+
+function cameraSummaryHtml() {
+  const cam = config.camera || {};
+  const width = Number(cam.width || 0);
+  const height = Number(cam.image_height || cam.height || 0);
+  const fx = Number(cam.fx || 0);
+  const fy = Number(cam.fy || 0);
+  return [
+    `HFOV: <code>${cameraFovDeg(width, fx).toFixed(1)}°</code>`,
+    `VFOV: <code>${cameraFovDeg(height, fy).toFixed(1)}°</code>`,
+    `resolution: <code>${width} x ${height}</code>`,
+  ].join("<br />");
+}
+
 function drawScene() {
   if (!config) return;
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const size = syncSceneCanvasSize();
+  ctx.clearRect(0, 0, size.width, size.height);
   drawGrid(ctx, canvas, worldToCanvas);
   drawEsdfSceneOverlay();
   drawObjects(ctx, worldToCanvas, true);
@@ -233,10 +309,16 @@ function drawEsdfSceneOverlay() {
 }
 
 function drawEsdfLegend() {
-  const x = canvas.width - 178;
+  const size = canvasLogicalSize(canvas);
+  const boxW = 154;
+  const boxH = 58;
+  const x = Math.max(12, size.width - boxW - 16);
   const y = 16;
+  ctx.save();
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
   ctx.fillStyle = "rgba(255,255,255,0.88)";
-  ctx.fillRect(x, y, 154, 58);
+  ctx.fillRect(x, y, boxW, boxH);
   ctx.fillStyle = "#17202a";
   ctx.font = "12px system-ui";
   ctx.fillText("ESDF clearance", x + 12, y + 18);
@@ -253,6 +335,7 @@ function drawEsdfLegend() {
   ctx.fillStyle = "#5c6975";
   ctx.fillText("near", x + 12, y + 53);
   ctx.fillText("clear", x + 106, y + 53);
+  ctx.restore();
 }
 
 function drawPath(points, color, width, alpha = 1) {
@@ -271,11 +354,37 @@ function drawPath(points, color, width, alpha = 1) {
   ctx.restore();
 }
 
+function drawHudPanel(lines) {
+  const size = canvasLogicalSize(canvas);
+  const view = sceneView(canvas);
+  const pad = 10;
+  const lineH = 18;
+  const boxPadX = 12;
+  const boxPadY = 10;
+  ctx.save();
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
+  ctx.font = "13px system-ui";
+  const textW = Math.max(0, ...lines.map((line) => ctx.measureText(line).width));
+  const boxW = Math.min(size.width - pad * 2, Math.ceil(textW + boxPadX * 2));
+  const boxH = boxPadY * 2 + lines.length * lineH;
+  const x = Math.min(Math.max(pad, view.offsetX + 8), Math.max(pad, size.width - boxW - pad));
+  const y = Math.min(Math.max(pad, view.offsetY + 8), Math.max(pad, size.height - boxH - pad));
+  ctx.fillStyle = "rgba(255,255,255,0.92)";
+  ctx.fillRect(x, y, boxW, boxH);
+  ctx.beginPath();
+  ctx.rect(x, y, boxW, boxH);
+  ctx.clip();
+  ctx.fillStyle = "#17202a";
+  lines.forEach((line, index) => {
+    ctx.fillText(line, x + boxPadX, y + boxPadY + (index + 1) * lineH - 4);
+  });
+  ctx.restore();
+}
+
 function drawRealtimeOverlay() {
   if (!currentFrame) {
-    ctx.fillStyle = "#5c6975";
-    ctx.font = "15px system-ui";
-    ctx.fillText("Click Realtime to start live planning.", 22, 30);
+    drawHudPanel(["Click Realtime to start live planning."]);
     return;
   }
 
@@ -291,16 +400,16 @@ function drawRealtimeOverlay() {
     ctx.arc(rx, ry, 5, 0, Math.PI * 2);
     ctx.fill();
   }
-  ctx.fillStyle = "rgba(255,255,255,0.9)";
-  ctx.fillRect(12, 12, 210, currentFrame.should_reverse || currentFrame.selected_is_reverse ? 92 : 72);
-  ctx.fillStyle = "#17202a";
-  ctx.font = "13px system-ui";
-  ctx.fillText(`realtime tick ${Math.max(0, realtimePath.length - 1)}`, 24, 34);
-  ctx.fillText(`cmd [${currentFrame.selected_param.map((v) => Number(v).toFixed(2)).join(", ")}]`, 24, 54);
-  ctx.fillText(`clearance ${Number(currentFrame.front_clearance).toFixed(2)}m`, 24, 74);
+
+  const lines = [
+    `realtime tick ${Math.max(0, realtimePath.length - 1)}`,
+    `cmd [${(currentFrame.selected_param || []).map((v) => Number(v).toFixed(2)).join(", ")}]`,
+    `clearance ${Number(currentFrame.front_clearance || 0).toFixed(2)}m`,
+  ];
   if (currentFrame.should_reverse || currentFrame.selected_is_reverse) {
-    ctx.fillText(`reverse ${currentFrame.selected_is_reverse ? "selected" : "gated"}`, 24, 94);
+    lines.push(`reverse ${currentFrame.selected_is_reverse ? "selected" : "gated"}`);
   }
+  drawHudPanel(lines);
 }
 
 function colorize(value, mode) {
@@ -404,8 +513,15 @@ function drawFootprint(footprint) {
 
 function refreshFields() {
   const obj = selectedObject();
+  const cam = config.camera || (config.camera = {});
   fields.targetX.value = config.target[0];
   fields.targetY.value = config.target[1];
+  fields.camWidth.value = cam.width ?? 160;
+  fields.camHeight.value = cam.image_height ?? cam.height ?? 100;
+  fields.camFx.value = cam.fx ?? 80;
+  fields.camFy.value = cam.fy ?? 25;
+  fields.camMaxRange.value = cam.max_range ?? 6.0;
+  fields.camMountHeight.value = cam.mount_height ?? 0.45;
   if (obj) {
     fields.objectName.value = obj.name;
     fields.objectX.value = obj.center[0];
@@ -416,13 +532,21 @@ function refreshFields() {
   }
   fields.configText.value = JSON.stringify(config, null, 2);
   fields.robotSummary.innerHTML = robotSummaryHtml();
+  fields.cameraSummary.innerHTML = cameraSummaryHtml();
   drawScene();
 }
 
 function applyFieldChanges() {
   const obj = selectedObject();
+  const cam = config.camera || (config.camera = {});
   config.target[0] = Number(fields.targetX.value);
   config.target[1] = Number(fields.targetY.value);
+  cam.width = Math.max(16, Math.round(Number(fields.camWidth.value) || 160));
+  cam.image_height = Math.max(16, Math.round(Number(fields.camHeight.value) || 100));
+  cam.fx = Math.max(1, Number(fields.camFx.value) || 80);
+  cam.fy = Math.max(1, Number(fields.camFy.value) || 25);
+  cam.max_range = Math.max(0.5, Number(fields.camMaxRange.value) || 6.0);
+  cam.mount_height = Math.max(0.05, Number(fields.camMountHeight.value) || 0.45);
   if (obj) {
     obj.name = fields.objectName.value || obj.name;
     obj.center[0] = Number(fields.objectX.value);
@@ -613,8 +737,8 @@ document.getElementById("deleteObject").addEventListener("click", () => {
 
 canvas.addEventListener("pointerdown", (event) => {
   const rect = canvas.getBoundingClientRect();
-  const px = ((event.clientX - rect.left) / rect.width) * canvas.width;
-  const py = ((event.clientY - rect.top) / rect.height) * canvas.height;
+  const px = event.clientX - rect.left;
+  const py = event.clientY - rect.top;
   if (hitTestTarget(px, py)) {
     const [wx, wy] = canvasToWorld(px, py);
     dragState = { type: "target", dx: config.target[0] - wx, dy: config.target[1] - wy };
@@ -635,8 +759,8 @@ canvas.addEventListener("pointerdown", (event) => {
 canvas.addEventListener("pointermove", (event) => {
   if (!dragState) return;
   const rect = canvas.getBoundingClientRect();
-  const px = ((event.clientX - rect.left) / rect.width) * canvas.width;
-  const py = ((event.clientY - rect.top) / rect.height) * canvas.height;
+  const px = event.clientX - rect.left;
+  const py = event.clientY - rect.top;
   const [wx, wy] = canvasToWorld(px, py);
   if (dragState.type === "target") {
     config.target[0] = Number((wx + dragState.dx).toFixed(2));
@@ -657,3 +781,10 @@ canvas.addEventListener("pointerup", () => {
 
 loadDefault();
 syncControlsLayout();
+window.addEventListener("resize", () => {
+  syncControlsLayout();
+  drawScene();
+});
+if (typeof ResizeObserver !== "undefined") {
+  new ResizeObserver(() => drawScene()).observe(canvas);
+}

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -17,14 +17,9 @@ const depthCtx = depthCanvas.getContext("2d");
 const statusEl = document.getElementById("status");
 const realtimeButton = document.getElementById("realtimeButton");
 const diagnosticNote = document.getElementById("diagnosticNote");
+const GRID_DIVISIONS = 20;
 
 const fields = {
-  robotWidth: document.getElementById("robotWidth"),
-  robotLength: document.getElementById("robotLength"),
-  cameraX: document.getElementById("cameraX"),
-  controlX: document.getElementById("controlX"),
-  safetyRadius: document.getElementById("safetyRadius"),
-  comfortRadius: document.getElementById("comfortRadius"),
   targetX: document.getElementById("targetX"),
   targetY: document.getElementById("targetY"),
   objectName: document.getElementById("objectName"),
@@ -34,6 +29,7 @@ const fields = {
   objectSY: document.getElementById("objectSY"),
   objectSZ: document.getElementById("objectSZ"),
   configText: document.getElementById("configText"),
+  robotSummary: document.getElementById("robotSummary"),
 };
 
 function sceneBounds() {
@@ -73,17 +69,20 @@ function drawGrid(drawCtx, targetCanvas, mapper) {
   drawCtx.fillRect(0, 0, targetCanvas.width, targetCanvas.height);
   drawCtx.strokeStyle = "#e0e7ee";
   drawCtx.lineWidth = 1;
-  for (let x = 0; x <= 5; x += 1) {
-    const [px0, py] = mapper(x, -2.8);
-    const [px1] = mapper(x, 2.8);
+  const b = sceneBounds();
+  for (let i = 0; i <= GRID_DIVISIONS; i += 1) {
+    const x = b.xMin + ((b.xMax - b.xMin) * i) / GRID_DIVISIONS;
+    const [px0, py] = mapper(x, b.yMin);
+    const [px1] = mapper(x, b.yMax);
     drawCtx.beginPath();
     drawCtx.moveTo(px0, py);
     drawCtx.lineTo(px1, py);
     drawCtx.stroke();
   }
-  for (let y = -2; y <= 2; y += 1) {
-    const [px, py0] = mapper(-0.5, y);
-    const [, py1] = mapper(5.0, y);
+  for (let i = 0; i <= GRID_DIVISIONS; i += 1) {
+    const y = b.yMin + ((b.yMax - b.yMin) * i) / GRID_DIVISIONS;
+    const [px, py0] = mapper(b.xMin, y);
+    const [, py1] = mapper(b.xMax, y);
     drawCtx.beginPath();
     drawCtx.moveTo(px, py0);
     drawCtx.lineTo(px, py1);
@@ -151,6 +150,18 @@ function cameraPose() {
       config.start.xy[1] + forward[1] * forwardOffset + left[1] * leftOffset,
     ],
   };
+}
+
+function robotSummaryHtml() {
+  const robot = config.robot || {};
+  const obstacle = config.obstacle || {};
+  return [
+    `preset: <code>${robot.preset || "go2"}</code>`,
+    `size: <code>${Number(robot.length || 0).toFixed(2)} x ${Number(robot.width || 0).toFixed(2)} m</code>`,
+    `camera/control: <code>${Number(robot.camera_x || 0).toFixed(2)} / ${Number(robot.control_x || 0).toFixed(2)} m</code>`,
+    `safety radius: <code>${Number(robot.safety_radius || 0).toFixed(2)} m</code>`,
+    `obstacle dilation: <code>${Number(obstacle.dilation_cells || 0)}</code>`,
+  ].join("<br />");
 }
 
 function drawScene() {
@@ -377,12 +388,6 @@ function drawFootprint(footprint) {
 
 function refreshFields() {
   const obj = selectedObject();
-  fields.robotWidth.value = config.robot.width;
-  fields.robotLength.value = config.robot.length;
-  fields.cameraX.value = config.robot.camera_x;
-  fields.controlX.value = config.robot.control_x;
-  fields.safetyRadius.value = config.robot.safety_radius;
-  fields.comfortRadius.value = config.robot.comfort_radius;
   fields.targetX.value = config.target[0];
   fields.targetY.value = config.target[1];
   if (obj) {
@@ -394,17 +399,12 @@ function refreshFields() {
     fields.objectSZ.value = obj.size[2];
   }
   fields.configText.value = JSON.stringify(config, null, 2);
+  fields.robotSummary.innerHTML = robotSummaryHtml();
   drawScene();
 }
 
 function applyFieldChanges() {
   const obj = selectedObject();
-  config.robot.width = Number(fields.robotWidth.value);
-  config.robot.length = Number(fields.robotLength.value);
-  config.robot.camera_x = Number(fields.cameraX.value);
-  config.robot.control_x = Number(fields.controlX.value);
-  config.robot.safety_radius = Number(fields.safetyRadius.value);
-  config.robot.comfort_radius = Number(fields.comfortRadius.value);
   config.target[0] = Number(fields.targetX.value);
   config.target[1] = Number(fields.targetY.value);
   if (obj) {
@@ -544,9 +544,11 @@ async function loadDefault() {
 }
 
 Object.values(fields).forEach((field) => {
-  if (field !== fields.configText) {
+  if (field !== fields.configText && typeof field.addEventListener === "function") {
     field.addEventListener("change", () => {
-      applyFieldChanges();
+      if (field === fields.targetX || field === fields.targetY || field === fields.objectName || field === fields.objectX || field === fields.objectY || field === fields.objectSX || field === fields.objectSY || field === fields.objectSZ) {
+        applyFieldChanges();
+      }
       noteSceneEdited(true, true);
     });
   }
@@ -555,7 +557,10 @@ Object.values(fields).forEach((field) => {
 realtimeButton.addEventListener("click", toggleRealtime);
 document.getElementById("resetScene").addEventListener("click", loadDefault);
 document.getElementById("applyJson").addEventListener("click", () => {
-  config = JSON.parse(fields.configText.value);
+  const nextConfig = JSON.parse(fields.configText.value);
+  nextConfig.robot = config.robot;
+  nextConfig.obstacle = config.obstacle;
+  config = nextConfig;
   selectedIndex = Math.min(selectedIndex, config.objects.length - 1);
   currentFrame = null;
   refreshFields();

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -16,8 +16,7 @@ const depthCanvas = document.getElementById("depthCanvas");
 const depthCtx = depthCanvas.getContext("2d");
 const statusEl = document.getElementById("status");
 const realtimeButton = document.getElementById("realtimeButton");
-const diagnosticNote = document.getElementById("diagnosticNote");
-const GRID_DIVISIONS = 20;
+const GRID_STEP_M = 1.0;
 
 const fields = {
   targetX: document.getElementById("targetX"),
@@ -32,8 +31,19 @@ const fields = {
   robotSummary: document.getElementById("robotSummary"),
 };
 
+const editableFields = [
+  fields.targetX,
+  fields.targetY,
+  fields.objectName,
+  fields.objectX,
+  fields.objectY,
+  fields.objectSX,
+  fields.objectSY,
+  fields.objectSZ,
+];
+
 function sceneBounds() {
-  return { xMin: -0.5, xMax: 5.0, yMin: -2.8, yMax: 2.8 };
+  return { xMin: -0.5, xMax: 9.5, yMin: -5.0, yMax: 5.0 };
 }
 
 function worldToCanvasOn(targetCanvas, x, y) {
@@ -70,8 +80,9 @@ function drawGrid(drawCtx, targetCanvas, mapper) {
   drawCtx.strokeStyle = "#e0e7ee";
   drawCtx.lineWidth = 1;
   const b = sceneBounds();
-  for (let i = 0; i <= GRID_DIVISIONS; i += 1) {
-    const x = b.xMin + ((b.xMax - b.xMin) * i) / GRID_DIVISIONS;
+  const x0 = Math.ceil(b.xMin / GRID_STEP_M) * GRID_STEP_M;
+  const y0 = Math.ceil(b.yMin / GRID_STEP_M) * GRID_STEP_M;
+  for (let x = x0; x <= b.xMax + 1e-9; x += GRID_STEP_M) {
     const [px0, py] = mapper(x, b.yMin);
     const [px1] = mapper(x, b.yMax);
     drawCtx.beginPath();
@@ -79,8 +90,7 @@ function drawGrid(drawCtx, targetCanvas, mapper) {
     drawCtx.lineTo(px1, py);
     drawCtx.stroke();
   }
-  for (let i = 0; i <= GRID_DIVISIONS; i += 1) {
-    const y = b.yMin + ((b.yMax - b.yMin) * i) / GRID_DIVISIONS;
+  for (let y = y0; y <= b.yMax + 1e-9; y += GRID_STEP_M) {
     const [px, py0] = mapper(b.xMin, y);
     const [, py1] = mapper(b.xMax, y);
     drawCtx.beginPath();
@@ -291,14 +301,6 @@ function drawRealtimeOverlay() {
   }
 }
 
-function drawDiagnostic(step = 0) {
-  if (!currentFrame) {
-    diagnosticNote.textContent = "Run the closed-loop simulation to generate per-step perception snapshots.";
-    return;
-  }
-  diagnosticNote.textContent = "Depth updates here; ESDF safety layer is fused into the scene canvas.";
-}
-
 function colorize(value, mode) {
   const t = Math.max(0, Math.min(1, value / 255));
   if (mode === "depth") {
@@ -336,15 +338,16 @@ function drawU8Canvas(targetCanvas, targetCtx, payload, mode) {
   offscreenCtx.putImageData(image, 0, 0);
   targetCtx.imageSmoothingEnabled = false;
   targetCtx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
-  targetCtx.drawImage(offscreen, 0, 0, targetCanvas.width, targetCanvas.height);
+  targetCtx.save();
+  targetCtx.scale(-1, 1);
+  targetCtx.drawImage(offscreen, -targetCanvas.width, 0, targetCanvas.width, targetCanvas.height);
+  targetCtx.restore();
 }
 
 function drawRealtimeFrame(frame) {
   currentFrame = frame;
   drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8, "depth");
   drawScene();
-  const esdfState = frame.esdf_u8 ? "ESDF live" : "waiting for ESDF";
-  diagnosticNote.textContent = `${esdfState}; depth updates here. Valid trajectories: ${frame.valid_trajectories}, clearance: ${Number(frame.front_clearance).toFixed(2)}m, reverse: ${frame.selected_is_reverse ? "selected" : frame.should_reverse ? "gated" : "no"}, recovery: ${frame.recovery_reason || "normal"}.`;
 }
 
 function drawHeadingArrow(drawCtx, mapper, xy, yawDeg, color, length = 0.45) {
@@ -543,15 +546,11 @@ async function loadDefault() {
   statusEl.textContent = "Ready";
 }
 
-Object.values(fields).forEach((field) => {
-  if (field !== fields.configText && typeof field.addEventListener === "function") {
-    field.addEventListener("change", () => {
-      if (field === fields.targetX || field === fields.targetY || field === fields.objectName || field === fields.objectX || field === fields.objectY || field === fields.objectSX || field === fields.objectSY || field === fields.objectSZ) {
-        applyFieldChanges();
-      }
-      noteSceneEdited(true, true);
-    });
-  }
+editableFields.forEach((field) => {
+  field.addEventListener("change", () => {
+    applyFieldChanges();
+    noteSceneEdited(true, true);
+  });
 });
 
 realtimeButton.addEventListener("click", toggleRealtime);

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -348,8 +348,9 @@ function drawU8Canvas(targetCanvas, targetCtx, payload, mode) {
 
 function setControlsVisible(visible) {
   controlsPanel.classList.toggle("is-hidden", !visible);
+  controlsPanel.classList.toggle("is-visible", visible);
   controlsToggle.setAttribute("aria-expanded", String(visible));
-  controlsToggle.textContent = visible ? "Controls" : "Controls";
+  controlsToggle.textContent = visible ? "Hide Controls" : "Show Controls";
 }
 
 function syncControlsLayout() {
@@ -656,4 +657,3 @@ canvas.addEventListener("pointerup", () => {
 
 loadDefault();
 syncControlsLayout();
-window.addEventListener("resize", syncControlsLayout);

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TinyNav Planning Lab</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="panel scene-panel">
+        <div class="panel-head">
+          <div>
+            <h1>TinyNav Planning Lab</h1>
+            <p>Drag objects, tune footprint, run the perception-to-planning loop.</p>
+          </div>
+          <div class="header-actions">
+            <button id="realtimeButton" class="primary">Realtime</button>
+          </div>
+        </div>
+        <canvas id="sceneCanvas" width="760" height="640" aria-label="Scene editor"></canvas>
+        <div class="toolbar">
+          <button id="addBox">Add Box</button>
+          <button id="duplicateObject">Duplicate</button>
+          <button id="deleteObject" class="danger">Delete</button>
+          <button id="resetScene">Reset</button>
+        </div>
+      </section>
+
+      <section class="panel controls">
+        <h2>Robot</h2>
+        <label>Width <input id="robotWidth" type="number" step="0.05" min="0.1" /></label>
+        <label>Length <input id="robotLength" type="number" step="0.05" min="0.1" /></label>
+        <label>Camera X <input id="cameraX" type="number" step="0.05" /></label>
+        <label>Control X <input id="controlX" type="number" step="0.05" /></label>
+        <label>Safety radius <input id="safetyRadius" type="number" step="0.02" min="0" /></label>
+        <label>Comfort radius <input id="comfortRadius" type="number" step="0.05" min="0" /></label>
+
+        <h2>Target</h2>
+        <label>Target X <input id="targetX" type="number" step="0.1" /></label>
+        <label>Target Y <input id="targetY" type="number" step="0.1" /></label>
+
+        <h2>Selected Object</h2>
+        <label>Name <input id="objectName" type="text" /></label>
+        <label>Center X <input id="objectX" type="number" step="0.1" /></label>
+        <label>Center Y <input id="objectY" type="number" step="0.1" /></label>
+        <label>Size X <input id="objectSX" type="number" step="0.1" min="0.05" /></label>
+        <label>Size Y <input id="objectSY" type="number" step="0.1" min="0.05" /></label>
+        <label>Height <input id="objectSZ" type="number" step="0.1" min="0.05" /></label>
+
+        <details>
+          <summary>Raw JSON</summary>
+          <textarea id="configText" spellcheck="false"></textarea>
+          <button id="applyJson">Apply JSON</button>
+        </details>
+      </section>
+
+      <section class="panel result-panel">
+        <div class="panel-head compact">
+          <h2>Perception</h2>
+          <span id="status">Ready</span>
+        </div>
+        <details class="diagnostics" open>
+          <summary>Perception / Planning Diagnostics</summary>
+          <div id="diagnosticNote" class="diagnostic-note">Run the closed-loop simulation to generate per-step perception snapshots.</div>
+          <div class="image-grid">
+            <div>
+              <h3>Depth</h3>
+              <canvas id="depthCanvas" width="320" height="200" aria-label="Depth image"></canvas>
+            </div>
+          </div>
+        </details>
+      </section>
+    </main>
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -15,6 +15,7 @@
             <p>Drag objects, tune footprint, run the perception-to-planning loop.</p>
           </div>
           <div class="header-actions">
+            <button id="controlsToggle" class="secondary controls-toggle" type="button" aria-expanded="true">Controls</button>
             <button id="realtimeButton" class="primary">Realtime</button>
           </div>
         </div>
@@ -27,7 +28,7 @@
         </div>
       </section>
 
-      <section class="panel controls">
+      <section class="panel controls" id="controlsPanel">
         <h2>Robot</h2>
         <p class="robot-note">Robot geometry and planner safety settings are read from <code>planning_node.py</code>.</p>
         <div class="robot-summary" id="robotSummary"></div>

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -73,6 +73,11 @@
             <div>
               <h3>Depth</h3>
               <canvas id="depthCanvas" width="320" height="200" aria-label="Depth image"></canvas>
+              <div class="depth-legend" aria-hidden="true">
+                <span>near</span>
+                <div class="depth-legend-bar"></div>
+                <span>far</span>
+              </div>
             </div>
           </div>
         </details>

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -29,12 +29,8 @@
 
       <section class="panel controls">
         <h2>Robot</h2>
-        <label>Width <input id="robotWidth" type="number" step="0.05" min="0.1" /></label>
-        <label>Length <input id="robotLength" type="number" step="0.05" min="0.1" /></label>
-        <label>Camera X <input id="cameraX" type="number" step="0.05" /></label>
-        <label>Control X <input id="controlX" type="number" step="0.05" /></label>
-        <label>Safety radius <input id="safetyRadius" type="number" step="0.02" min="0" /></label>
-        <label>Comfort radius <input id="comfortRadius" type="number" step="0.05" min="0" /></label>
+        <p class="robot-note">Robot geometry and planner safety settings are read from <code>planning_node.py</code>.</p>
+        <div class="robot-summary" id="robotSummary"></div>
 
         <h2>Target</h2>
         <label>Target X <input id="targetX" type="number" step="0.1" /></label>

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -19,7 +19,7 @@
             <button id="realtimeButton" class="primary">Realtime</button>
           </div>
         </div>
-        <canvas id="sceneCanvas" width="760" height="640" aria-label="Scene editor"></canvas>
+        <canvas id="sceneCanvas" width="720" height="720" aria-label="Scene editor"></canvas>
         <div class="toolbar">
           <button id="addBox">Add Box</button>
           <button id="duplicateObject">Duplicate</button>
@@ -32,6 +32,16 @@
         <h2>Robot</h2>
         <p class="robot-note">Robot geometry and planner safety settings are read from <code>planning_node.py</code>.</p>
         <div class="robot-summary" id="robotSummary"></div>
+
+        <h2>Camera</h2>
+        <p class="robot-note">Pinhole intrinsics used for synthetic depth and <code>CameraInfo</code>. FOV is derived from width/height and fx/fy.</p>
+        <label>Width <input id="camWidth" type="number" step="1" min="16" /></label>
+        <label>Height <input id="camHeight" type="number" step="1" min="16" /></label>
+        <label>fx <input id="camFx" type="number" step="1" min="1" /></label>
+        <label>fy <input id="camFy" type="number" step="1" min="1" /></label>
+        <label>Max range (m) <input id="camMaxRange" type="number" step="0.1" min="0.5" /></label>
+        <label>Mount height (m) <input id="camMountHeight" type="number" step="0.01" min="0.05" /></label>
+        <div class="robot-summary" id="cameraSummary"></div>
 
         <h2>Target</h2>
         <label>Target X <input id="targetX" type="number" step="0.1" /></label>

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -58,7 +58,6 @@
         </div>
         <details class="diagnostics" open>
           <summary>Perception / Planning Diagnostics</summary>
-          <div id="diagnosticNote" class="diagnostic-note">Run the closed-loop simulation to generate per-step perception snapshots.</div>
           <div class="image-grid">
             <div>
               <h3>Depth</h3>

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -30,6 +30,13 @@ body {
   box-shadow: 0 1px 2px rgba(20, 30, 40, 0.05);
 }
 
+.scene-panel {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 32px);
+  overflow: hidden;
+}
+
 .panel-head {
   display: flex;
   align-items: center;
@@ -106,8 +113,11 @@ button.danger {
 }
 
 #sceneCanvas {
-  width: 100%;
-  aspect-ratio: 19 / 16;
+  width: min(100%, calc(100vh - 190px));
+  max-width: 100%;
+  aspect-ratio: 1 / 1;
+  height: auto;
+  max-height: calc(100vh - 190px);
   display: block;
   border: 1px solid #ccd6df;
   border-radius: 6px;

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -223,7 +223,34 @@ textarea {
   display: block;
   border: 1px solid #d8e0e7;
   border-radius: 6px;
-  background: #101820;
+  background: #0b1020;
+  image-rendering: pixelated;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.depth-legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: #5c6975;
+}
+
+.depth-legend-bar {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  border: 1px solid #d0d7df;
+  background: linear-gradient(
+    90deg,
+    #ffe650 0%,
+    #ff7828 18%,
+    #ec3462 36%,
+    #9c40ff 55%,
+    #3878ff 75%,
+    #0c1c48 100%
+  );
 }
 
 #status {

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -90,6 +90,10 @@ button.primary {
   gap: 8px;
 }
 
+button.secondary {
+  background: #f3f6f9;
+}
+
 button.danger {
   color: #9d1b1b;
 }
@@ -112,6 +116,14 @@ button.danger {
 
 .controls {
   overflow: auto;
+}
+
+.controls.is-hidden {
+  display: none;
+}
+
+.controls-toggle {
+  display: none;
 }
 
 .robot-note {
@@ -211,5 +223,18 @@ textarea {
 @media (max-width: 1180px) {
   .app {
     grid-template-columns: 1fr;
+  }
+
+  .controls-toggle {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .controls {
+    display: none;
+  }
+
+  .controls.is-visible {
+    display: block;
   }
 }

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -1,0 +1,199 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f5f7f9;
+  color: #17202a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(520px, 1.2fr) 320px minmax(420px, 0.9fr);
+  gap: 16px;
+  min-height: 100vh;
+  padding: 16px;
+}
+
+.panel {
+  background: #ffffff;
+  border: 1px solid #dce3ea;
+  border-radius: 8px;
+  padding: 16px;
+  min-width: 0;
+  box-shadow: 0 1px 2px rgba(20, 30, 40, 0.05);
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.panel-head.compact {
+  margin-bottom: 10px;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 22px;
+}
+
+h2 {
+  font-size: 15px;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+
+p {
+  color: #5c6975;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+button {
+  border: 1px solid #b8c5d2;
+  background: #fff;
+  color: #17202a;
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+button:hover {
+  background: #eef4f8;
+}
+
+button.primary {
+  background: #106b67;
+  color: white;
+  border-color: #106b67;
+  min-width: 86px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+button.danger {
+  color: #9d1b1b;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+#sceneCanvas {
+  width: 100%;
+  aspect-ratio: 19 / 16;
+  display: block;
+  border: 1px solid #ccd6df;
+  border-radius: 6px;
+  background: #fbfcfd;
+}
+
+.controls {
+  overflow: auto;
+}
+
+label {
+  display: grid;
+  grid-template-columns: 1fr 112px;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0;
+  font-size: 13px;
+  color: #43505c;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid #c7d1da;
+  border-radius: 6px;
+  padding: 7px 8px;
+  font: inherit;
+  color: #17202a;
+  background: #fff;
+}
+
+summary {
+  cursor: pointer;
+  margin-top: 18px;
+  font-size: 13px;
+  color: #43505c;
+}
+
+textarea {
+  height: 240px;
+  resize: vertical;
+  margin-top: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.diagnostics {
+  margin-top: 12px;
+}
+
+.diagnostics summary {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.diagnostic-note {
+  color: #5c6975;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.image-grid h3 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  color: #43505c;
+}
+
+.image-grid canvas {
+  width: 100%;
+  aspect-ratio: 8 / 5;
+  display: block;
+  border: 1px solid #d8e0e7;
+  border-radius: 6px;
+  background: #101820;
+}
+
+#status {
+  font-size: 13px;
+  color: #5c6975;
+}
+
+@media (max-width: 1180px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -114,6 +114,28 @@ button.danger {
   overflow: auto;
 }
 
+.robot-note {
+  margin-top: 4px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: #5c6975;
+}
+
+.robot-summary {
+  padding: 10px 12px;
+  border: 1px solid #d8e0e7;
+  border-radius: 6px;
+  background: #f8fafc;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #33404b;
+}
+
+.robot-summary code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+
 label {
   display: grid;
   grid-template-columns: 1fr 112px;

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -181,12 +181,6 @@ textarea {
   margin-bottom: 8px;
 }
 
-.diagnostic-note {
-  color: #5c6975;
-  font-size: 13px;
-  margin-bottom: 8px;
-}
-
 .image-grid {
   display: grid;
   grid-template-columns: 1fr;

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -123,7 +123,8 @@ button.danger {
 }
 
 .controls-toggle {
-  display: none;
+  display: inline-flex;
+  align-items: center;
 }
 
 .robot-note {
@@ -223,11 +224,6 @@ textarea {
 @media (max-width: 1180px) {
   .app {
     grid-template-columns: 1fr;
-  }
-
-  .controls-toggle {
-    display: inline-flex;
-    align-items: center;
   }
 
   .controls {

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 """ROS-backed planning simulator web server.
 
-The web UI owns the editable scene. This process publishes synthetic
-/slam/depth, /slam/odometry_visual, /slam/odometry and /control/target_pose,
-then renders outputs from the real planning_node + cmd_vel_control loop.
+Web UI edits the scene. This process publishes synthetic /slam/depth,
+/slam/odometry(_visual), /control/target_pose, then mirrors outputs from the
+real planning_node + cmd_vel_control loop.
 """
 
 from __future__ import annotations
 
 import copy
-import json
 import math
 import os
 import subprocess
@@ -25,23 +24,26 @@ from cv_bridge import CvBridge
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
-from geometry_msgs.msg import Point32, Twist
+from geometry_msgs.msg import Twist
 from nav_msgs.msg import OccupancyGrid, Odometry, Path as RosPath
+from pydantic import BaseModel
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile
 from scipy.spatial.transform import Rotation as R
 from sensor_msgs.msg import CameraInfo, Image, PointCloud
 from std_msgs.msg import Bool
-from pydantic import BaseModel
 
 from tinynav.core.planning_node import GO2_CONFIG, ObstacleConfig
-
 
 ROOT = Path(__file__).resolve().parent
 STATIC_DIR = ROOT / "offline_planning_web"
 PLANNING_ROBOT_DEFAULT = asdict(GO2_CONFIG)
 PLANNING_OBSTACLE_DEFAULT = asdict(ObstacleConfig())
+
+
+def _box(name: str, center: list[float], size: list[float]) -> dict[str, Any]:
+    return {"name": name, "kind": "box", "center": center, "size": size}
 
 
 @dataclass
@@ -59,6 +61,8 @@ class SimObject:
 
 
 def default_config() -> dict[str, Any]:
+    # Fences + ground plane give valid depth so free-space carving works when
+    # boxes move (planning core stays unchanged).
     return {
         "name": "ros_planning_sim",
         "robot": copy.deepcopy(PLANNING_ROBOT_DEFAULT),
@@ -67,59 +71,70 @@ def default_config() -> dict[str, Any]:
             "image_height": 100,
             "fx": 80.0,
             "fy": 25.0,
-            "max_range": 6.0,
+            "max_range": 15.0,
             "mount_height": 0.45,
         },
         "start": {"xy": [0.0, 0.0], "yaw_deg": 0.0},
         "target": [4.0, 0.0, 0.0],
         "obstacle": copy.deepcopy(PLANNING_OBSTACLE_DEFAULT),
         "objects": [
-            {"name": "left_wall", "kind": "box", "center": [2.0, 1.0, 0.35], "size": [3.2, 0.25, 1.3]},
-            {"name": "right_wall", "kind": "box", "center": [2.0, -1.0, 0.35], "size": [3.2, 0.25, 1.3]},
-            {"name": "center_box", "kind": "box", "center": [1.65, 0.0, 0.25], "size": [0.45, 0.55, 0.5]},
+            _box("fence_back", [-0.35, 0.0, 0.6], [0.2, 10.2, 1.2]),
+            _box("fence_front", [9.35, 0.0, 0.6], [0.2, 10.2, 1.2]),
+            _box("fence_left", [4.5, 5.05, 0.6], [10.0, 0.2, 1.2]),
+            _box("fence_right", [4.5, -5.05, 0.6], [10.0, 0.2, 1.2]),
+            _box("left_wall", [2.0, 1.0, 0.35], [3.2, 0.25, 1.3]),
+            _box("right_wall", [2.0, -1.0, 0.35], [3.2, 0.25, 1.3]),
+            _box("center_box", [1.65, 0.0, 0.25], [0.45, 0.55, 0.5]),
         ],
     }
 
 
+def cam_size(cam: dict[str, Any]) -> tuple[int, int]:
+    return int(cam["width"]), int(cam.get("image_height", cam.get("height", 100)))
+
+
 def make_camera_pose(control_xy: list[float], yaw_deg: float, robot: dict[str, Any], cam: dict[str, Any]) -> np.ndarray:
     yaw = math.radians(float(yaw_deg))
-    forward = np.array([math.cos(yaw), math.sin(yaw), 0.0], dtype=np.float64)
-    left = np.array([-math.sin(yaw), math.cos(yaw), 0.0], dtype=np.float64)
-    right = np.array([math.sin(yaw), -math.cos(yaw), 0.0], dtype=np.float64)
-    down = np.array([0.0, 0.0, -1.0], dtype=np.float64)
-    rot = np.column_stack([right, down, forward])
-    pos = np.array([control_xy[0], control_xy[1], 0.0], dtype=np.float64)
-    pos += forward * (float(robot.get("camera_x", 0.0)) - float(robot.get("control_x", 0.0)))
-    pos += left * (float(robot.get("camera_y", 0.0)) - float(robot.get("control_y", 0.0)))
-    pos[2] = float(cam.get("mount_height", 0.45))
-    T = np.eye(4, dtype=np.float64)
-    T[:3, :3] = rot
+    forward = np.array([math.cos(yaw), math.sin(yaw), 0.0])
+    left = np.array([-math.sin(yaw), math.cos(yaw), 0.0])
+    right = np.array([math.sin(yaw), -math.cos(yaw), 0.0])
+    down = np.array([0.0, 0.0, -1.0])
+    pos = np.array([control_xy[0], control_xy[1], float(cam.get("mount_height", 0.45))])
+    pos[:2] += forward[:2] * (float(robot.get("camera_x", 0.0)) - float(robot.get("control_x", 0.0)))
+    pos[:2] += left[:2] * (float(robot.get("camera_y", 0.0)) - float(robot.get("control_y", 0.0)))
+    T = np.eye(4)
+    T[:3, :3] = np.column_stack([right, down, forward])
     T[:3, 3] = pos
     return T
 
 
 def render_depth(objects: list[SimObject], T_cam_to_world: np.ndarray, cam: dict[str, Any]) -> np.ndarray:
-    width = int(cam["width"])
-    height = int(cam.get("image_height", cam.get("height", 100)))
-    fx = float(cam["fx"])
-    fy = float(cam["fy"])
-    cx = (width - 1) / 2.0
-    cy = (height - 1) / 2.0
+    width, height = cam_size(cam)
+    fx, fy = float(cam["fx"]), float(cam["fy"])
     max_range = float(cam["max_range"])
+    cx, cy = (width - 1) / 2.0, (height - 1) / 2.0
+
     us, vs = np.meshgrid(np.arange(width, dtype=np.float64), np.arange(height, dtype=np.float64))
     rays_cam = np.stack([(us - cx) / fx, (vs - cy) / fy, np.ones_like(us)], axis=-1)
     rays_cam /= np.linalg.norm(rays_cam, axis=-1, keepdims=True)
-    rays_world = rays_cam @ T_cam_to_world[:3, :3].T
-    rays_flat = rays_world.reshape((-1, 3))
-    z_flat = rays_cam[..., 2].reshape(-1)
-    best = np.full(rays_flat.shape[0], np.inf, dtype=np.float64)
+    rays = (rays_cam @ T_cam_to_world[:3, :3].T).reshape((-1, 3))
+    z_cam = rays_cam[..., 2].reshape(-1)
     origin = T_cam_to_world[:3, 3]
+    best = np.full(rays.shape[0], np.inf)
+
+    # Ground plane z=0 → valid returns for downward rays.
+    ground_z = float(cam.get("ground_z", 0.0))
+    dz = rays[:, 2]
+    down = dz < -1e-9
+    t_ground = np.full(rays.shape[0], np.inf)
+    t_ground[down] = (ground_z - origin[2]) / dz[down]
+    hit_ground = down & (t_ground > 1e-4) & (t_ground <= max_range)
+    best = np.where(hit_ground, t_ground, best)
 
     for obj in objects:
         box_min, box_max = obj.bounds
-        inv_d = np.divide(1.0, rays_flat, out=np.full_like(rays_flat, np.inf), where=np.abs(rays_flat) > 1e-9)
-        t0 = (box_min - origin) * inv_d
-        t1 = (box_max - origin) * inv_d
+        inv = np.divide(1.0, rays, out=np.full_like(rays, np.inf), where=np.abs(rays) > 1e-9)
+        t0, t1 = (box_min - origin) * inv, (box_max - origin) * inv
         t_near = np.maximum.reduce(np.minimum(t0, t1), axis=1)
         t_far = np.minimum.reduce(np.maximum(t0, t1), axis=1)
         hit = np.where(t_near > 0.0, t_near, t_far)
@@ -127,14 +142,14 @@ def render_depth(objects: list[SimObject], T_cam_to_world: np.ndarray, cam: dict
         best = np.where(valid & (hit < best), hit, best)
 
     depth = np.zeros(best.shape[0], dtype=np.float32)
-    finite = np.isfinite(best)
-    depth[finite] = (best[finite] * z_flat[finite]).astype(np.float32)
+    ok = np.isfinite(best)
+    depth[ok] = (best[ok] * z_cam[ok]).astype(np.float32)
     return depth.reshape((height, width))
 
 
 def image_u8_payload(image: np.ndarray, vmin: float, vmax: float) -> dict[str, Any]:
-    clipped = np.clip((image.astype(np.float32) - vmin) / max(vmax - vmin, 1e-6), 0.0, 1.0)
-    u8 = np.round(clipped * 255.0).astype(np.uint8)
+    u8 = np.clip((image.astype(np.float32) - vmin) / max(vmax - vmin, 1e-6), 0.0, 1.0)
+    u8 = np.round(u8 * 255.0).astype(np.uint8)
     return {"width": int(u8.shape[1]), "height": int(u8.shape[0]), "data": u8.ravel().tolist()}
 
 
@@ -144,14 +159,19 @@ def odom_from_T(T: np.ndarray, stamp, frame_id: str = "world", child_frame_id: s
     msg.header.stamp = stamp
     msg.header.frame_id = frame_id
     msg.child_frame_id = child_frame_id
-    msg.pose.pose.position.x = float(T[0, 3])
-    msg.pose.pose.position.y = float(T[1, 3])
-    msg.pose.pose.position.z = float(T[2, 3])
-    msg.pose.pose.orientation.x = float(quat[0])
-    msg.pose.pose.orientation.y = float(quat[1])
-    msg.pose.pose.orientation.z = float(quat[2])
-    msg.pose.pose.orientation.w = float(quat[3])
+    msg.pose.pose.position.x, msg.pose.pose.position.y, msg.pose.pose.position.z = map(float, T[:3, 3])
+    msg.pose.pose.orientation.x, msg.pose.pose.orientation.y, msg.pose.pose.orientation.z, msg.pose.pose.orientation.w = map(float, quat)
     return msg
+
+
+def grid_payload(msg: OccupancyGrid, data_u8: np.ndarray) -> dict[str, Any]:
+    return {
+        "width": int(data_u8.shape[1]),
+        "height": int(data_u8.shape[0]),
+        "data": data_u8.ravel().tolist(),
+        "origin": [float(msg.info.origin.position.x), float(msg.info.origin.position.y)],
+        "resolution": float(msg.info.resolution),
+    }
 
 
 class RosPlanningSimNode(Node):
@@ -176,17 +196,16 @@ class RosPlanningSimNode(Node):
         self.odom_pub = self.create_publisher(Odometry, "/slam/odometry", 10)
         self.target_pub = self.create_publisher(Odometry, "/control/target_pose", 10)
         self.camera_info_pub = self.create_publisher(CameraInfo, "/camera/camera/infra2/camera_info", 10)
-        latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
-        self.nav_active_pub = self.create_publisher(Bool, "/nav/active", latched_qos)
-        self.nav_paused_pub = self.create_publisher(Bool, "/nav/paused", latched_qos)
+        latched = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.nav_active_pub = self.create_publisher(Bool, "/nav/active", latched)
+        self.nav_paused_pub = self.create_publisher(Bool, "/nav/paused", latched)
 
         self.create_subscription(Twist, "/cmd_vel", self.cmd_callback, 10)
         self.create_subscription(RosPath, "/planning/trajectory_path", self.path_callback, 10)
         self.create_subscription(PointCloud, "/planning/footprint", self.footprint_callback, 10)
         self.create_subscription(OccupancyGrid, "/planning/obstacle_mask", self.obstacle_callback, 10)
         self.create_subscription(OccupancyGrid, "/planning/occupancy_grid", self.esdf_callback, 10)
-
-        self.timer = self.create_timer(1.0 / 8.0, self.tick)
+        self.create_timer(1.0 / 8.0, self.tick)
 
     def set_config(self, config: dict[str, Any], reset: bool = False) -> None:
         with self.lock:
@@ -212,52 +231,31 @@ class RosPlanningSimNode(Node):
 
     def footprint_callback(self, msg: PointCloud) -> None:
         with self.lock:
-            # PlanningNode publishes 21 points per edge. Keep corners for UI.
-            points = msg.points
-            if len(points) >= 64:
-                idxs = [0, 21, 42, 63, 0]
-                self.last_footprint = [[float(points[i].x), float(points[i].y)] for i in idxs]
-            else:
-                self.last_footprint = [[float(p.x), float(p.y)] for p in points]
+            pts = msg.points
+            # PlanningNode publishes 21 samples/edge; keep corners for UI.
+            idxs = [0, 21, 42, 63, 0] if len(pts) >= 64 else range(len(pts))
+            self.last_footprint = [[float(pts[i].x), float(pts[i].y)] for i in idxs]
 
     def obstacle_callback(self, msg: OccupancyGrid) -> None:
         data = np.asarray(msg.data, dtype=np.int16).reshape((msg.info.width, msg.info.height), order="F")
-        u8 = np.where(data > 0, 255, 0).astype(np.uint8)
         with self.lock:
-            self.last_obstacle_mask = {
-                "width": int(u8.shape[1]),
-                "height": int(u8.shape[0]),
-                "data": u8.ravel().tolist(),
-                "origin": [float(msg.info.origin.position.x), float(msg.info.origin.position.y)],
-                "resolution": float(msg.info.resolution),
-            }
+            self.last_obstacle_mask = grid_payload(msg, np.where(data > 0, 255, 0).astype(np.uint8))
 
     def esdf_callback(self, msg: OccupancyGrid) -> None:
         data = np.asarray(msg.data, dtype=np.int16).reshape((msg.info.width, msg.info.height), order="F")
-        risk = np.clip(data, 0, 120).astype(np.float32) / 120.0
-        clearance_u8 = np.round((1.0 - risk) * 255.0).astype(np.uint8)
+        clearance = np.round((1.0 - np.clip(data, 0, 120).astype(np.float32) / 120.0) * 255.0).astype(np.uint8)
         with self.lock:
-            self.last_esdf_grid = {
-                "width": int(clearance_u8.shape[1]),
-                "height": int(clearance_u8.shape[0]),
-                "data": clearance_u8.ravel().tolist(),
-                "origin": [float(msg.info.origin.position.x), float(msg.info.origin.position.y)],
-                "resolution": float(msg.info.resolution),
-            }
+            self.last_esdf_grid = grid_payload(msg, clearance)
 
     def publish_camera_info(self, stamp, config: dict[str, Any]) -> None:
         cam = config["camera"]
-        width = int(cam["width"])
-        height = int(cam.get("image_height", cam.get("height", 100)))
-        fx = float(cam["fx"])
-        fy = float(cam["fy"])
-        cx = (width - 1) / 2.0
-        cy = (height - 1) / 2.0
+        width, height = cam_size(cam)
+        fx, fy = float(cam["fx"]), float(cam["fy"])
+        cx, cy = (width - 1) / 2.0, (height - 1) / 2.0
         msg = CameraInfo()
         msg.header.stamp = stamp
         msg.header.frame_id = "camera"
-        msg.width = width
-        msg.height = height
+        msg.width, msg.height = width, height
         msg.k = [fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0]
         msg.p = [fx, 0.0, cx, 0.0, 0.0, fy, cy, -0.06 * fx, 0.0, 0.0, 1.0, 0.0]
         self.camera_info_pub.publish(msg)
@@ -275,12 +273,10 @@ class RosPlanningSimNode(Node):
         self.target_pub.publish(msg)
 
     def integrate_cmd(self, dt: float) -> None:
-        vx = float(self.last_cmd.linear.x)
-        wz = float(self.last_cmd.angular.z)
         yaw = math.radians(self.yaw_deg)
-        self.control_xy[0] += math.cos(yaw) * vx * dt
-        self.control_xy[1] += math.sin(yaw) * vx * dt
-        self.yaw_deg = (self.yaw_deg + math.degrees(wz * dt) + 180.0) % 360.0 - 180.0
+        self.control_xy[0] += math.cos(yaw) * self.last_cmd.linear.x * dt
+        self.control_xy[1] += math.sin(yaw) * self.last_cmd.linear.x * dt
+        self.yaw_deg = (self.yaw_deg + math.degrees(self.last_cmd.angular.z * dt) + 180.0) % 360.0 - 180.0
 
     def tick(self) -> None:
         with self.lock:
@@ -298,7 +294,6 @@ class RosPlanningSimNode(Node):
         objects = [SimObject(**obj) for obj in config.get("objects", [])]
         T_cam = make_camera_pose(config["start"]["xy"], yaw_deg, config["robot"], config["camera"])
         depth = render_depth(objects, T_cam, config["camera"])
-
         with self.lock:
             self.last_depth = depth
 
@@ -317,9 +312,9 @@ class RosPlanningSimNode(Node):
 
     def frame(self) -> dict[str, Any]:
         with self.lock:
-            cam = self.config["camera"]
+            xy = [float(self.control_xy[0]), float(self.control_xy[1])]
             return {
-                "robot_xy": [float(self.control_xy[0]), float(self.control_xy[1])],
+                "robot_xy": xy,
                 "robot_yaw_deg": float(self.yaw_deg),
                 "robot_footprint_xy": copy.deepcopy(self.last_footprint),
                 "selected_trajectory_xy": copy.deepcopy(self.last_path),
@@ -328,10 +323,10 @@ class RosPlanningSimNode(Node):
                 "front_clearance": 0.0,
                 "valid_trajectories": len(self.last_path),
                 "obstacle_cells": int(sum(1 for v in (self.last_obstacle_mask or {}).get("data", []) if v)),
-                "depth_u8": image_u8_payload(self.last_depth, 0.0, float(cam["max_range"])),
+                "depth_u8": image_u8_payload(self.last_depth, 0.0, float(self.config["camera"]["max_range"])),
                 "obstacle_u8": self.last_obstacle_mask,
                 "esdf_u8": self.last_esdf_grid,
-                "next_start": {"xy": [float(self.control_xy[0]), float(self.control_xy[1])], "yaw_deg": float(self.yaw_deg)},
+                "next_start": {"xy": xy, "yaw_deg": float(self.yaw_deg)},
             }
 
 
@@ -345,20 +340,25 @@ app = FastAPI(title="TinyNav ROS Planning Simulator")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 SIM_NODE: RosPlanningSimNode | None = None
 EXECUTOR: MultiThreadedExecutor | None = None
-ROS_THREAD: threading.Thread | None = None
 PROCS: list[subprocess.Popen] = []
 
 
 def start_ros() -> None:
-    global SIM_NODE, EXECUTOR, ROS_THREAD
+    global SIM_NODE, EXECUTOR
     if SIM_NODE is not None:
         return
     rclpy.init(args=None)
     SIM_NODE = RosPlanningSimNode()
     EXECUTOR = MultiThreadedExecutor(num_threads=4)
     EXECUTOR.add_node(SIM_NODE)
-    ROS_THREAD = threading.Thread(target=EXECUTOR.spin, daemon=True)
-    ROS_THREAD.start()
+    threading.Thread(target=EXECUTOR.spin, daemon=True).start()
+
+
+def _spawn_if_needed(script: str, cwd: Path, env: dict[str, str]) -> None:
+    marker = script
+    if any(p.poll() is None and marker in " ".join(p.args) for p in PROCS):
+        return
+    PROCS.append(subprocess.Popen(["uv", "run", "python", script], cwd=str(cwd), env=env))
 
 
 @app.on_event("startup")
@@ -394,23 +394,19 @@ def realtime_step(request: RunRequest) -> dict[str, Any]:
         raise HTTPException(status_code=503, detail="ROS simulator is not ready")
     if not isinstance(request.config, dict):
         raise HTTPException(status_code=400, detail="config must be an object")
-    SIM_NODE.set_config(json.loads(json.dumps(request.config)), reset=bool(request.reset))
+    SIM_NODE.set_config(copy.deepcopy(request.config), reset=bool(request.reset))
     return {"frame": SIM_NODE.frame()}
 
 
 @app.post("/api/start-ros-loop")
 def start_ros_loop() -> dict[str, Any]:
     cwd = ROOT.parents[1]
-    child_env = os.environ.copy()
-    child_env.setdefault("OPENBLAS_NUM_THREADS", "1")
-    child_env.setdefault("OMP_NUM_THREADS", "1")
-    child_env.setdefault("MKL_NUM_THREADS", "1")
-    child_env.setdefault("NUMEXPR_NUM_THREADS", "1")
-    if not any(proc.poll() is None and "planning_node.py" in " ".join(proc.args) for proc in PROCS):
-        PROCS.append(subprocess.Popen(["uv", "run", "python", "tinynav/core/planning_node.py"], cwd=str(cwd), env=child_env))
-    if not any(proc.poll() is None and "cmd_vel_control.py" in " ".join(proc.args) for proc in PROCS):
-        PROCS.append(subprocess.Popen(["uv", "run", "python", "tinynav/platforms/cmd_vel_control.py"], cwd=str(cwd), env=child_env))
-    return {"ok": True, "process_count": sum(1 for proc in PROCS if proc.poll() is None)}
+    env = os.environ.copy()
+    for key in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+        env.setdefault(key, "1")
+    _spawn_if_needed("tinynav/core/planning_node.py", cwd, env)
+    _spawn_if_needed("tinynav/platforms/cmd_vel_control.py", cwd, env)
+    return {"ok": True, "process_count": sum(p.poll() is None for p in PROCS)}
 
 
 @app.get("/api/sim-state")

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""ROS-backed planning simulator web server.
+
+The web UI owns the editable scene. This process publishes synthetic
+/slam/depth, /slam/odometry_visual, /slam/odometry and /control/target_pose,
+then renders outputs from the real planning_node + cmd_vel_control loop.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import os
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import rclpy
+from cv_bridge import CvBridge
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from geometry_msgs.msg import Point32, Twist
+from nav_msgs.msg import OccupancyGrid, Odometry, Path as RosPath
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile
+from scipy.spatial.transform import Rotation as R
+from sensor_msgs.msg import CameraInfo, Image, PointCloud
+from std_msgs.msg import Bool
+from pydantic import BaseModel
+
+
+ROOT = Path(__file__).resolve().parent
+STATIC_DIR = ROOT / "offline_planning_web"
+
+
+@dataclass
+class SimObject:
+    name: str
+    kind: str
+    center: tuple[float, float, float]
+    size: tuple[float, float, float]
+
+    @property
+    def bounds(self) -> tuple[np.ndarray, np.ndarray]:
+        center = np.asarray(self.center, dtype=np.float64)
+        half = np.asarray(self.size, dtype=np.float64) / 2.0
+        return center - half, center + half
+
+
+def default_config() -> dict[str, Any]:
+    return {
+        "name": "ros_planning_sim",
+        "robot": {
+            "preset": "b2",
+            "length": 1.0,
+            "width": 0.5,
+            "camera_x": 0.5,
+            "control_x": 0.5,
+            "camera_y": 0.0,
+            "control_y": 0.0,
+            "safety_radius": 0.1,
+            "comfort_radius": 0.1,
+        },
+        "camera": {
+            "width": 160,
+            "image_height": 100,
+            "fx": 120.0,
+            "fy": 120.0,
+            "max_range": 6.0,
+            "mount_height": 0.45,
+        },
+        "start": {"xy": [0.0, 0.0], "yaw_deg": 0.0},
+        "target": [4.0, 0.0, 0.0],
+        "objects": [
+            {"name": "left_wall", "kind": "box", "center": [2.0, 1.0, 0.35], "size": [3.2, 0.25, 1.3]},
+            {"name": "right_wall", "kind": "box", "center": [2.0, -1.0, 0.35], "size": [3.2, 0.25, 1.3]},
+            {"name": "center_box", "kind": "box", "center": [1.65, 0.0, 0.25], "size": [0.45, 0.55, 0.5]},
+        ],
+    }
+
+
+def intersect_box(origin: np.ndarray, direction: np.ndarray, obj: SimObject, max_range: float) -> float:
+    box_min, box_max = obj.bounds
+    inv_d = np.divide(1.0, direction, out=np.full(3, np.inf), where=np.abs(direction) > 1e-9)
+    t0 = (box_min - origin) * inv_d
+    t1 = (box_max - origin) * inv_d
+    t_near = np.maximum.reduce(np.minimum(t0, t1))
+    t_far = np.minimum.reduce(np.maximum(t0, t1))
+    if t_far < 0.0 or t_near > t_far:
+        return np.inf
+    hit = t_near if t_near > 0.0 else t_far
+    return hit if 0.0 < hit <= max_range else np.inf
+
+
+def make_camera_pose(control_xy: list[float], yaw_deg: float, robot: dict[str, Any], cam: dict[str, Any]) -> np.ndarray:
+    yaw = math.radians(float(yaw_deg))
+    forward = np.array([math.cos(yaw), math.sin(yaw), 0.0], dtype=np.float64)
+    left = np.array([-math.sin(yaw), math.cos(yaw), 0.0], dtype=np.float64)
+    right = np.array([math.sin(yaw), -math.cos(yaw), 0.0], dtype=np.float64)
+    down = np.array([0.0, 0.0, -1.0], dtype=np.float64)
+    rot = np.column_stack([right, down, forward])
+    pos = np.array([control_xy[0], control_xy[1], 0.0], dtype=np.float64)
+    pos += forward * (float(robot.get("camera_x", 0.0)) - float(robot.get("control_x", 0.0)))
+    pos += left * (float(robot.get("camera_y", 0.0)) - float(robot.get("control_y", 0.0)))
+    pos[2] = float(cam.get("mount_height", 0.45))
+    T = np.eye(4, dtype=np.float64)
+    T[:3, :3] = rot
+    T[:3, 3] = pos
+    return T
+
+
+def render_depth(objects: list[SimObject], T_cam_to_world: np.ndarray, cam: dict[str, Any]) -> np.ndarray:
+    width = int(cam["width"])
+    height = int(cam.get("image_height", cam.get("height", 100)))
+    fx = float(cam["fx"])
+    fy = float(cam["fy"])
+    cx = (width - 1) / 2.0
+    cy = (height - 1) / 2.0
+    max_range = float(cam["max_range"])
+    us, vs = np.meshgrid(np.arange(width, dtype=np.float64), np.arange(height, dtype=np.float64))
+    rays_cam = np.stack([(us - cx) / fx, (vs - cy) / fy, np.ones_like(us)], axis=-1)
+    rays_cam /= np.linalg.norm(rays_cam, axis=-1, keepdims=True)
+    rays_world = rays_cam @ T_cam_to_world[:3, :3].T
+    rays_flat = rays_world.reshape((-1, 3))
+    z_flat = rays_cam[..., 2].reshape(-1)
+    best = np.full(rays_flat.shape[0], np.inf, dtype=np.float64)
+    origin = T_cam_to_world[:3, 3]
+
+    for obj in objects:
+        box_min, box_max = obj.bounds
+        inv_d = np.divide(1.0, rays_flat, out=np.full_like(rays_flat, np.inf), where=np.abs(rays_flat) > 1e-9)
+        t0 = (box_min - origin) * inv_d
+        t1 = (box_max - origin) * inv_d
+        t_near = np.maximum.reduce(np.minimum(t0, t1), axis=1)
+        t_far = np.minimum.reduce(np.maximum(t0, t1), axis=1)
+        hit = np.where(t_near > 0.0, t_near, t_far)
+        valid = (t_far >= 0.0) & (t_near <= t_far) & (hit > 0.0) & (hit <= max_range)
+        best = np.where(valid & (hit < best), hit, best)
+
+    depth = np.zeros(best.shape[0], dtype=np.float32)
+    finite = np.isfinite(best)
+    depth[finite] = (best[finite] * z_flat[finite]).astype(np.float32)
+    return depth.reshape((height, width))
+
+
+def image_u8_payload(image: np.ndarray, vmin: float, vmax: float) -> dict[str, Any]:
+    clipped = np.clip((image.astype(np.float32) - vmin) / max(vmax - vmin, 1e-6), 0.0, 1.0)
+    u8 = np.round(clipped * 255.0).astype(np.uint8)
+    return {"width": int(u8.shape[1]), "height": int(u8.shape[0]), "data": u8.ravel().tolist()}
+
+
+def odom_from_T(T: np.ndarray, stamp, frame_id: str = "world", child_frame_id: str = "camera") -> Odometry:
+    quat = R.from_matrix(T[:3, :3]).as_quat()
+    msg = Odometry()
+    msg.header.stamp = stamp
+    msg.header.frame_id = frame_id
+    msg.child_frame_id = child_frame_id
+    msg.pose.pose.position.x = float(T[0, 3])
+    msg.pose.pose.position.y = float(T[1, 3])
+    msg.pose.pose.position.z = float(T[2, 3])
+    msg.pose.pose.orientation.x = float(quat[0])
+    msg.pose.pose.orientation.y = float(quat[1])
+    msg.pose.pose.orientation.z = float(quat[2])
+    msg.pose.pose.orientation.w = float(quat[3])
+    return msg
+
+
+class RosPlanningSimNode(Node):
+    def __init__(self):
+        super().__init__("tinynav_ros_planning_sim")
+        self.bridge = CvBridge()
+        self.lock = threading.RLock()
+        self.config = default_config()
+        self.control_xy = list(self.config["start"]["xy"])
+        self.yaw_deg = float(self.config["start"]["yaw_deg"])
+        self.last_update = time.monotonic()
+        self.last_depth = np.zeros((100, 160), dtype=np.float32)
+        self.last_cmd = Twist()
+        self.last_path: list[list[float]] = []
+        self.last_footprint: list[list[float]] = []
+        self.last_obstacle_mask: dict[str, Any] | None = None
+        self.running = True
+
+        self.depth_pub = self.create_publisher(Image, "/slam/depth", 10)
+        self.odom_visual_pub = self.create_publisher(Odometry, "/slam/odometry_visual", 10)
+        self.odom_pub = self.create_publisher(Odometry, "/slam/odometry", 10)
+        self.target_pub = self.create_publisher(Odometry, "/control/target_pose", 10)
+        self.camera_info_pub = self.create_publisher(CameraInfo, "/camera/camera/infra2/camera_info", 10)
+        latched_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.nav_active_pub = self.create_publisher(Bool, "/nav/active", latched_qos)
+        self.nav_paused_pub = self.create_publisher(Bool, "/nav/paused", latched_qos)
+
+        self.create_subscription(Twist, "/cmd_vel", self.cmd_callback, 10)
+        self.create_subscription(RosPath, "/planning/trajectory_path", self.path_callback, 10)
+        self.create_subscription(PointCloud, "/planning/footprint", self.footprint_callback, 10)
+        self.create_subscription(OccupancyGrid, "/planning/obstacle_mask", self.obstacle_callback, 10)
+
+        self.timer = self.create_timer(1.0 / 8.0, self.tick)
+
+    def set_config(self, config: dict[str, Any], reset: bool = False) -> None:
+        with self.lock:
+            self.config = copy.deepcopy(config)
+            if reset:
+                self.control_xy = list(self.config.get("start", {}).get("xy", [0.0, 0.0]))
+                self.yaw_deg = float(self.config.get("start", {}).get("yaw_deg", 0.0))
+                self.last_cmd = Twist()
+                self.last_path = []
+
+    def cmd_callback(self, msg: Twist) -> None:
+        with self.lock:
+            self.last_cmd = msg
+
+    def path_callback(self, msg: RosPath) -> None:
+        with self.lock:
+            self.last_path = [[float(p.pose.position.x), float(p.pose.position.y)] for p in msg.poses]
+
+    def footprint_callback(self, msg: PointCloud) -> None:
+        with self.lock:
+            # PlanningNode publishes 21 points per edge. Keep corners for UI.
+            points = msg.points
+            if len(points) >= 64:
+                idxs = [0, 21, 42, 63, 0]
+                self.last_footprint = [[float(points[i].x), float(points[i].y)] for i in idxs]
+            else:
+                self.last_footprint = [[float(p.x), float(p.y)] for p in points]
+
+    def obstacle_callback(self, msg: OccupancyGrid) -> None:
+        data = np.asarray(msg.data, dtype=np.int16).reshape((msg.info.width, msg.info.height), order="F")
+        u8 = np.where(data > 0, 255, 0).astype(np.uint8)
+        with self.lock:
+            self.last_obstacle_mask = {
+                "width": int(u8.shape[1]),
+                "height": int(u8.shape[0]),
+                "data": u8.ravel().tolist(),
+                "origin": [float(msg.info.origin.position.x), float(msg.info.origin.position.y)],
+                "resolution": float(msg.info.resolution),
+            }
+
+    def publish_camera_info(self, stamp, config: dict[str, Any]) -> None:
+        cam = config["camera"]
+        width = int(cam["width"])
+        height = int(cam.get("image_height", cam.get("height", 100)))
+        fx = float(cam["fx"])
+        fy = float(cam["fy"])
+        cx = (width - 1) / 2.0
+        cy = (height - 1) / 2.0
+        msg = CameraInfo()
+        msg.header.stamp = stamp
+        msg.header.frame_id = "camera"
+        msg.width = width
+        msg.height = height
+        msg.k = [fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0]
+        msg.p = [fx, 0.0, cx, 0.0, 0.0, fy, cy, -0.06 * fx, 0.0, 0.0, 1.0, 0.0]
+        self.camera_info_pub.publish(msg)
+
+    def publish_target(self, stamp, config: dict[str, Any]) -> None:
+        target = config.get("target", [4.0, 0.0, 0.0])
+        msg = Odometry()
+        msg.header.stamp = stamp
+        msg.header.frame_id = "world"
+        msg.child_frame_id = "target"
+        msg.pose.pose.position.x = float(target[0])
+        msg.pose.pose.position.y = float(target[1])
+        msg.pose.pose.position.z = float(target[2] if len(target) > 2 else 0.0)
+        msg.pose.pose.orientation.w = 1.0
+        self.target_pub.publish(msg)
+
+    def integrate_cmd(self, dt: float) -> None:
+        vx = float(self.last_cmd.linear.x)
+        wz = float(self.last_cmd.angular.z)
+        yaw = math.radians(self.yaw_deg)
+        self.control_xy[0] += math.cos(yaw) * vx * dt
+        self.control_xy[1] += math.sin(yaw) * vx * dt
+        self.yaw_deg = (self.yaw_deg + math.degrees(wz * dt) + 180.0) % 360.0 - 180.0
+
+    def tick(self) -> None:
+        with self.lock:
+            if not self.running:
+                return
+            now = time.monotonic()
+            dt = max(1e-3, min(0.2, now - self.last_update))
+            self.last_update = now
+            self.integrate_cmd(dt)
+            config = copy.deepcopy(self.config)
+            config.setdefault("start", {})["xy"] = [float(self.control_xy[0]), float(self.control_xy[1])]
+            config["start"]["yaw_deg"] = float(self.yaw_deg)
+            yaw_deg = float(self.yaw_deg)
+
+        objects = [SimObject(**obj) for obj in config.get("objects", [])]
+        T_cam = make_camera_pose(config["start"]["xy"], yaw_deg, config["robot"], config["camera"])
+        depth = render_depth(objects, T_cam, config["camera"])
+
+        with self.lock:
+            self.last_depth = depth
+
+        stamp = self.get_clock().now().to_msg()
+        depth_msg = self.bridge.cv2_to_imgmsg(depth, encoding="32FC1")
+        depth_msg.header.stamp = stamp
+        depth_msg.header.frame_id = "camera"
+        odom_msg = odom_from_T(T_cam, stamp)
+        self.depth_pub.publish(depth_msg)
+        self.odom_visual_pub.publish(odom_msg)
+        self.odom_pub.publish(odom_msg)
+        self.publish_camera_info(stamp, config)
+        self.publish_target(stamp, config)
+        self.nav_active_pub.publish(Bool(data=True))
+        self.nav_paused_pub.publish(Bool(data=False))
+
+    def frame(self) -> dict[str, Any]:
+        with self.lock:
+            cam = self.config["camera"]
+            return {
+                "robot_xy": [float(self.control_xy[0]), float(self.control_xy[1])],
+                "robot_yaw_deg": float(self.yaw_deg),
+                "robot_footprint_xy": copy.deepcopy(self.last_footprint),
+                "selected_trajectory_xy": copy.deepcopy(self.last_path),
+                "candidate_trajectories_xy": [],
+                "selected_param": [float(self.last_cmd.linear.x), float(self.last_cmd.angular.z)],
+                "front_clearance": 0.0,
+                "valid_trajectories": len(self.last_path),
+                "obstacle_cells": int(sum(1 for v in (self.last_obstacle_mask or {}).get("data", []) if v)),
+                "depth_u8": image_u8_payload(self.last_depth, 0.0, float(cam["max_range"])),
+                "obstacle_u8": self.last_obstacle_mask,
+                "next_start": {"xy": [float(self.control_xy[0]), float(self.control_xy[1])], "yaw_deg": float(self.yaw_deg)},
+            }
+
+
+class RunRequest(BaseModel):
+    config: dict[str, Any]
+    reset: bool | None = None
+    advance_step: int | None = None
+
+
+app = FastAPI(title="TinyNav ROS Planning Simulator")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+SIM_NODE: RosPlanningSimNode | None = None
+EXECUTOR: MultiThreadedExecutor | None = None
+ROS_THREAD: threading.Thread | None = None
+PROCS: list[subprocess.Popen] = []
+
+
+def start_ros() -> None:
+    global SIM_NODE, EXECUTOR, ROS_THREAD
+    if SIM_NODE is not None:
+        return
+    rclpy.init(args=None)
+    SIM_NODE = RosPlanningSimNode()
+    EXECUTOR = MultiThreadedExecutor(num_threads=4)
+    EXECUTOR.add_node(SIM_NODE)
+    ROS_THREAD = threading.Thread(target=EXECUTOR.spin, daemon=True)
+    ROS_THREAD.start()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    start_ros()
+
+
+@app.on_event("shutdown")
+def shutdown() -> None:
+    for proc in PROCS:
+        proc.terminate()
+    if EXECUTOR is not None:
+        EXECUTOR.shutdown()
+    if SIM_NODE is not None:
+        SIM_NODE.destroy_node()
+    if rclpy.ok():
+        rclpy.shutdown()
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> str:
+    return (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+
+
+@app.get("/api/default-config")
+def get_default_config() -> dict[str, Any]:
+    return default_config()
+
+
+@app.post("/api/realtime-step")
+def realtime_step(request: RunRequest) -> dict[str, Any]:
+    if SIM_NODE is None:
+        raise HTTPException(status_code=503, detail="ROS simulator is not ready")
+    if not isinstance(request.config, dict):
+        raise HTTPException(status_code=400, detail="config must be an object")
+    SIM_NODE.set_config(json.loads(json.dumps(request.config)), reset=bool(request.reset))
+    return {"frame": SIM_NODE.frame()}
+
+
+@app.post("/api/start-ros-loop")
+def start_ros_loop() -> dict[str, Any]:
+    cwd = ROOT.parents[1]
+    child_env = os.environ.copy()
+    child_env.setdefault("OPENBLAS_NUM_THREADS", "1")
+    child_env.setdefault("OMP_NUM_THREADS", "1")
+    child_env.setdefault("MKL_NUM_THREADS", "1")
+    child_env.setdefault("NUMEXPR_NUM_THREADS", "1")
+    if not any(proc.poll() is None and "planning_node.py" in " ".join(proc.args) for proc in PROCS):
+        PROCS.append(subprocess.Popen(["uv", "run", "python", "tinynav/core/planning_node.py"], cwd=str(cwd), env=child_env))
+    if not any(proc.poll() is None and "cmd_vel_control.py" in " ".join(proc.args) for proc in PROCS):
+        PROCS.append(subprocess.Popen(["uv", "run", "python", "tinynav/platforms/cmd_vel_control.py"], cwd=str(cwd), env=child_env))
+    return {"ok": True, "process_count": sum(1 for proc in PROCS if proc.poll() is None)}
+
+
+@app.get("/api/sim-state")
+def sim_state() -> dict[str, Any]:
+    if SIM_NODE is None:
+        raise HTTPException(status_code=503, detail="ROS simulator is not ready")
+    return {"frame": SIM_NODE.frame()}
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8766)
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -15,7 +15,7 @@ import os
 import subprocess
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -35,9 +35,13 @@ from sensor_msgs.msg import CameraInfo, Image, PointCloud
 from std_msgs.msg import Bool
 from pydantic import BaseModel
 
+from tinynav.core.planning_node import GO2_CONFIG, ObstacleConfig
+
 
 ROOT = Path(__file__).resolve().parent
 STATIC_DIR = ROOT / "offline_planning_web"
+PLANNING_ROBOT_DEFAULT = asdict(GO2_CONFIG)
+PLANNING_OBSTACLE_DEFAULT = asdict(ObstacleConfig())
 
 
 @dataclass
@@ -57,17 +61,7 @@ class SimObject:
 def default_config() -> dict[str, Any]:
     return {
         "name": "ros_planning_sim",
-        "robot": {
-            "preset": "b2",
-            "length": 1.0,
-            "width": 0.5,
-            "camera_x": 0.5,
-            "control_x": 0.5,
-            "camera_y": 0.0,
-            "control_y": 0.0,
-            "safety_radius": 0.1,
-            "comfort_radius": 0.1,
-        },
+        "robot": copy.deepcopy(PLANNING_ROBOT_DEFAULT),
         "camera": {
             "width": 160,
             "image_height": 100,
@@ -78,25 +72,13 @@ def default_config() -> dict[str, Any]:
         },
         "start": {"xy": [0.0, 0.0], "yaw_deg": 0.0},
         "target": [4.0, 0.0, 0.0],
+        "obstacle": copy.deepcopy(PLANNING_OBSTACLE_DEFAULT),
         "objects": [
             {"name": "left_wall", "kind": "box", "center": [2.0, 1.0, 0.35], "size": [3.2, 0.25, 1.3]},
             {"name": "right_wall", "kind": "box", "center": [2.0, -1.0, 0.35], "size": [3.2, 0.25, 1.3]},
             {"name": "center_box", "kind": "box", "center": [1.65, 0.0, 0.25], "size": [0.45, 0.55, 0.5]},
         ],
     }
-
-
-def intersect_box(origin: np.ndarray, direction: np.ndarray, obj: SimObject, max_range: float) -> float:
-    box_min, box_max = obj.bounds
-    inv_d = np.divide(1.0, direction, out=np.full(3, np.inf), where=np.abs(direction) > 1e-9)
-    t0 = (box_min - origin) * inv_d
-    t1 = (box_max - origin) * inv_d
-    t_near = np.maximum.reduce(np.minimum(t0, t1))
-    t_far = np.minimum.reduce(np.maximum(t0, t1))
-    if t_far < 0.0 or t_near > t_far:
-        return np.inf
-    hit = t_near if t_near > 0.0 else t_far
-    return hit if 0.0 < hit <= max_range else np.inf
 
 
 def make_camera_pose(control_xy: list[float], yaw_deg: float, robot: dict[str, Any], cam: dict[str, Any]) -> np.ndarray:
@@ -209,6 +191,8 @@ class RosPlanningSimNode(Node):
     def set_config(self, config: dict[str, Any], reset: bool = False) -> None:
         with self.lock:
             self.config = copy.deepcopy(config)
+            self.config["robot"] = copy.deepcopy(PLANNING_ROBOT_DEFAULT)
+            self.config["obstacle"] = copy.deepcopy(PLANNING_OBSTACLE_DEFAULT)
             if reset:
                 self.control_xy = list(self.config.get("start", {}).get("xy", [0.0, 0.0]))
                 self.yaw_deg = float(self.config.get("start", {}).get("yaw_deg", 0.0))

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -186,6 +186,7 @@ class RosPlanningSimNode(Node):
         self.last_path: list[list[float]] = []
         self.last_footprint: list[list[float]] = []
         self.last_obstacle_mask: dict[str, Any] | None = None
+        self.last_esdf_grid: dict[str, Any] | None = None
         self.running = True
 
         self.depth_pub = self.create_publisher(Image, "/slam/depth", 10)
@@ -201,6 +202,7 @@ class RosPlanningSimNode(Node):
         self.create_subscription(RosPath, "/planning/trajectory_path", self.path_callback, 10)
         self.create_subscription(PointCloud, "/planning/footprint", self.footprint_callback, 10)
         self.create_subscription(OccupancyGrid, "/planning/obstacle_mask", self.obstacle_callback, 10)
+        self.create_subscription(OccupancyGrid, "/planning/occupancy_grid", self.esdf_callback, 10)
 
         self.timer = self.create_timer(1.0 / 8.0, self.tick)
 
@@ -212,6 +214,9 @@ class RosPlanningSimNode(Node):
                 self.yaw_deg = float(self.config.get("start", {}).get("yaw_deg", 0.0))
                 self.last_cmd = Twist()
                 self.last_path = []
+                self.last_footprint = []
+                self.last_obstacle_mask = None
+                self.last_esdf_grid = None
 
     def cmd_callback(self, msg: Twist) -> None:
         with self.lock:
@@ -239,6 +244,19 @@ class RosPlanningSimNode(Node):
                 "width": int(u8.shape[1]),
                 "height": int(u8.shape[0]),
                 "data": u8.ravel().tolist(),
+                "origin": [float(msg.info.origin.position.x), float(msg.info.origin.position.y)],
+                "resolution": float(msg.info.resolution),
+            }
+
+    def esdf_callback(self, msg: OccupancyGrid) -> None:
+        data = np.asarray(msg.data, dtype=np.int16).reshape((msg.info.width, msg.info.height), order="F")
+        risk = np.clip(data, 0, 120).astype(np.float32) / 120.0
+        clearance_u8 = np.round((1.0 - risk) * 255.0).astype(np.uint8)
+        with self.lock:
+            self.last_esdf_grid = {
+                "width": int(clearance_u8.shape[1]),
+                "height": int(clearance_u8.shape[0]),
+                "data": clearance_u8.ravel().tolist(),
                 "origin": [float(msg.info.origin.position.x), float(msg.info.origin.position.y)],
                 "resolution": float(msg.info.resolution),
             }
@@ -328,6 +346,7 @@ class RosPlanningSimNode(Node):
                 "obstacle_cells": int(sum(1 for v in (self.last_obstacle_mask or {}).get("data", []) if v)),
                 "depth_u8": image_u8_payload(self.last_depth, 0.0, float(cam["max_range"])),
                 "obstacle_u8": self.last_obstacle_mask,
+                "esdf_u8": self.last_esdf_grid,
                 "next_start": {"xy": [float(self.control_xy[0]), float(self.control_xy[1])], "yaw_deg": float(self.yaw_deg)},
             }
 

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -65,8 +65,8 @@ def default_config() -> dict[str, Any]:
         "camera": {
             "width": 160,
             "image_height": 100,
-            "fx": 120.0,
-            "fy": 120.0,
+            "fx": 80.0,
+            "fy": 25.0,
             "max_range": 6.0,
             "mount_height": 0.45,
         },


### PR DESCRIPTION
## Summary
- Add a lightweight ROS-backed web simulator (`ros_planning_web.py` + Planning Lab UI) that synthesizes depth/odom, drives the real `planning_node` + `cmd_vel_control` loop, and visualizes trajectories/ESDF in-browser.
- Make scene editing and camera intrinsics interactive (FOV derived from fx/fy/resolution), with ground + perimeter fences and a longer max range so free-space carving behaves more like an indoor scene.
- Include a launch script (`scripts/run_offline_planning_web.sh`) so planning/control can be debugged quickly without Gazebo or the full perception stack.

## Motivation
Faster, more convenient iteration when debugging `planning_node` and `cmd_vel_control`: edit obstacles/target in the browser, inspect depth/ESDF/trajectory overlays, and exercise the real ROS control loop without standing up the full sim.

## Test plan
- [x] In `tinynav-dev`, run `bash scripts/run_offline_planning_web.sh` and open `http://localhost:8766`
- [x] Click **Realtime** and confirm `planning_node` + `cmd_vel_control` start and a trajectory appears
- [x] Drag the front box away and confirm depth updates; ESDF clears along rays that hit ground/fences
- [x] Tune camera `fx`/`fy`/max range in Controls and verify HFOV/VFOV + depth colormap update
- [x] Resize / mobile layout: scene canvas stays fully visible; Controls toggle works
- [x] Confirm no changes to `tinynav/core` planning logic

## 

https://github.com/user-attachments/assets/13f68530-e1cf-44cd-a3d5-8094145e7c6a

