### PR TITLE
fix(sim): import GO2_CONFIG from robot_specs in ROS planning web

### DIFF
--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -34,7 +34,8 @@ from scipy.spatial.transform import Rotation as R
 from sensor_msgs.msg import CameraInfo, Image, PointCloud
 from std_msgs.msg import Bool
 
-from tinynav.core.planning_node import GO2_CONFIG, ObstacleConfig
+from tinynav.core.planning_node import ObstacleConfig
+from tinynav.core.robot_specs import GO2_CONFIG
 from tool.simulator.planning_scene import (
     SimObject,
     box,


### PR DESCRIPTION
## Summary
- After robot presets moved to `robot_specs`, ROS planning web still imported `GO2_CONFIG` from `planning_node`, which crashed startup with `ImportError`.
- Point the import at `tinynav.core.robot_specs` so `./scripts/run_ros_planning_web.sh` can start again.

## Test plan
- [ ] In `tinynav-dev`, run `./scripts/run_ros_planning_web.sh` and confirm it no longer raises `ImportError` for `GO2_CONFIG`
- [ ] Open the planning web UI and confirm default robot config still loads


Made with [Cursor](https://cursor.com)