### PR TITLE
feat(nav): force a replan when stalled on-path despite low deviation

### DIFF
--- a/tests/test_map_node.py
+++ b/tests/test_map_node.py
@@ -3,7 +3,10 @@ sys.path.append(".")
 sys.path.append("/tinynav/tinynav/core")
 
 from tinynav.tinynav_cpp_bind import pose_graph_solve
-from tinynav.core.math_utils import theta_star, stall_check
+# theta_star was removed from math_utils.py in #208 (nav rewritten onto sdf_map);
+# this test was left behind orphaned. Commented out rather than deleted for now.
+# from tinynav.core.math_utils import theta_star
+from tinynav.core.math_utils import stall_check
 import numpy as np
 
 def angle_diff_from_two_rotation_matrix(R1, R2):
@@ -64,27 +67,27 @@ def test_pose_graph_solve():
         assert translation_error < 1e-6, f"Translation error {translation_error} for camera {camera_timestamp} is too high."
         assert rotation_error < 1e-6, f"Rotation error {rotation_error} for camera {camera_timestamp} is too high."
 
-def test_theta_star():
-    cost_map = np.array([
-        [1.0, 0.0, 0.5, 0.5, 1.0],
-        [1.0, 1.0, 0.5, 1.0, 1.0],
-        [0.5, 0.5, 0.5, 0.5, 1.0],
-        [0.5, 0.5, 0.5, 0.5, 1.0],
-        [0.5, 0.5, 0.5, 0.5, 1.0],
-        [0.5, 0.5, 0.5, 0.5, 1.0],
-        [0.5, 0.5, 0.5, 0.5, 1.0],
-        [0.5, 0.7, 0.6, 0.5, 1.0],
-        [1.0, 1.0, 0.6, 0.5, 1.0],
-        [0.0, 0.5, 0.6, 0.5, 1.0],
-        [1.0, 1.0, 0, 0.5, 1.0],
-    ])
-    start = (0, 1)
-    goal = (9, 0)
-    path = theta_star(cost_map, start, goal, obstacles_cost=1.0)
-    ground_truth_path = [(0, 1), (1, 2), (8, 2), (9, 1), (9, 0)]
-    for i,point in enumerate(path):
-        assert point[0] == ground_truth_path[i][0]
-        assert point[1] == ground_truth_path[i][1]
+# def test_theta_star():
+#     cost_map = np.array([
+#         [1.0, 0.0, 0.5, 0.5, 1.0],
+#         [1.0, 1.0, 0.5, 1.0, 1.0],
+#         [0.5, 0.5, 0.5, 0.5, 1.0],
+#         [0.5, 0.5, 0.5, 0.5, 1.0],
+#         [0.5, 0.5, 0.5, 0.5, 1.0],
+#         [0.5, 0.5, 0.5, 0.5, 1.0],
+#         [0.5, 0.5, 0.5, 0.5, 1.0],
+#         [0.5, 0.7, 0.6, 0.5, 1.0],
+#         [1.0, 1.0, 0.6, 0.5, 1.0],
+#         [0.0, 0.5, 0.6, 0.5, 1.0],
+#         [1.0, 1.0, 0, 0.5, 1.0],
+#     ])
+#     start = (0, 1)
+#     goal = (9, 0)
+#     path = theta_star(cost_map, start, goal, obstacles_cost=1.0)
+#     ground_truth_path = [(0, 1), (1, 2), (8, 2), (9, 1), (9, 0)]
+#     for i,point in enumerate(path):
+#         assert point[0] == ground_truth_path[i][0]
+#         assert point[1] == ground_truth_path[i][1]
 
 def test_stall_check_progress_resets_timer():
     # steady progress: each call drops remaining by more than the eps, never stalls
@@ -121,8 +124,8 @@ if __name__ == "__main__":
     print("Running pose graph solve test...")
     test_pose_graph_solve()
     print("Pose graph solve test passed.")
-    test_theta_star()
-    print("A* test passed.")
+    # test_theta_star()
+    # print("A* test passed.")
     test_stall_check_progress_resets_timer()
     test_stall_check_under_timeout_does_not_stall()
     test_stall_check_forces_replan_after_timeout()

--- a/tests/test_map_node.py
+++ b/tests/test_map_node.py
@@ -3,7 +3,7 @@ sys.path.append(".")
 sys.path.append("/tinynav/tinynav/core")
 
 from tinynav.tinynav_cpp_bind import pose_graph_solve
-from tinynav.core.math_utils import theta_star
+from tinynav.core.math_utils import theta_star, stall_check
 import numpy as np
 
 def angle_diff_from_two_rotation_matrix(R1, R2):
@@ -86,9 +86,44 @@ def test_theta_star():
         assert point[0] == ground_truth_path[i][0]
         assert point[1] == ground_truth_path[i][1]
 
+def test_stall_check_progress_resets_timer():
+    # steady progress: each call drops remaining by more than the eps, never stalls
+    last_remaining, last_time = None, None
+    for t, remaining in [(0.0, 5.0), (1.0, 4.0), (2.0, 3.0)]:
+        last_remaining, last_time, stalled = stall_check(
+            last_remaining, last_time, remaining, t, progress_eps=0.05, timeout_s=8.0,
+        )
+        assert not stalled
+        assert last_remaining == remaining
+        assert last_time == t
+
+def test_stall_check_under_timeout_does_not_stall():
+    last_remaining, last_time, stalled = stall_check(
+        5.0, 0.0, 5.0, 5.0, progress_eps=0.05, timeout_s=8.0,
+    )
+    assert not stalled
+    # unchanged: still no progress, but timeout hasn't elapsed
+    assert last_remaining == 5.0
+    assert last_time == 0.0
+
+def test_stall_check_forces_replan_after_timeout():
+    last_remaining, last_time, stalled = stall_check(
+        5.0, 0.0, 5.0, 9.0, progress_eps=0.05, timeout_s=8.0,
+    )
+    assert stalled
+    # tiny wobble, well under progress_eps, must not be read as progress
+    last_remaining, last_time, stalled = stall_check(
+        5.0, 0.0, 4.98, 9.0, progress_eps=0.05, timeout_s=8.0,
+    )
+    assert stalled
+
 if __name__ == "__main__":
     print("Running pose graph solve test...")
     test_pose_graph_solve()
     print("Pose graph solve test passed.")
     test_theta_star()
     print("A* test passed.")
+    test_stall_check_progress_resets_timer()
+    test_stall_check_under_timeout_does_not_stall()
+    test_stall_check_forces_replan_after_timeout()
+    print("Stall check tests passed.")

--- a/tests/test_map_node_stall_integration.py
+++ b/tests/test_map_node_stall_integration.py
@@ -1,0 +1,113 @@
+"""Exercises MapNode.nav_target_timer_callback's replan/stall decision directly,
+without booting SLAM/vision, TF, or loading a real built map.
+
+Unlike test_map_node.py (which avoids importing tinynav.core.map_node because it
+pulls in TensorRT/rclpy at module load), this file does import it, so it needs the
+full tinynav environment. Run it inside the uniflexai/tinynav container, e.g.:
+
+    docker exec <container> bash -lc '
+      source /opt/ros/humble/setup.bash
+      cd /tinynav && uv run --python /opt/venv/bin/python pytest \
+        tests/test_map_node_stall_integration.py -v
+    '
+
+MapNode is built via __new__ (skipping __init__, which loads TensorRT models and a
+map directory) and hand-filled with only the state nav_target_timer_callback reads
+or writes. generate_nav_path_in_map -- the expensive SDF search over a real map --
+is stubbed out with a canned straight-line path, since this test is about the
+replan/stall decision, not the path search itself.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from builtin_interfaces.msg import Time
+
+sys.path.insert(0, ".")
+from tinynav.core.map_node import MapNode
+
+
+def make_bare_map_node(poi_xyz, start_xyz):
+    node = MapNode.__new__(MapNode)
+    node.get_logger = MagicMock(return_value=MagicMock())
+    node.get_clock = MagicMock(return_value=MagicMock(
+        now=MagicMock(return_value=MagicMock(to_msg=MagicMock(return_value=Time())))
+    ))
+    for pub in (
+        "current_pose_in_map_pub", "nav_progress_pub", "poi_change_pub",
+        "nav_done_pub", "global_plan_pub", "target_pose_pub",
+    ):
+        setattr(node, pub, MagicMock())
+    node.tf_broadcaster = MagicMock()
+
+    node.T_from_map_to_odom = np.eye(4)
+    node.latest_odom_pose = np.eye(4)
+    node.latest_odom_pose[:3, 3] = start_xyz
+    node.pois = {0: np.array(poi_xyz)}
+    node.poi_index = 0
+    node._nav_completed = False
+    node.cached_nav_path_in_map = None
+    node.cached_nav_path_poi_index = -1
+    node._leg_initial_length = None
+    node._leg_start_time = None
+    node._speed_estimate = None
+    node._last_progress_remaining = None
+    node._last_progress_time = None
+    node.stall_progress_eps = 0.05
+    node.stall_timeout_s = 8.0
+    return node
+
+
+def straight_path(start_xyz, goal_xyz, n=51):
+    start = np.asarray(start_xyz, dtype=float)
+    goal = np.asarray(goal_xyz, dtype=float)
+    return np.array([start + (goal - start) * t for t in np.linspace(0.0, 1.0, n)])
+
+
+def test_stall_forces_a_replan_when_stuck_on_path():
+    poi = [5.0, 0.0, 0.0]
+    node = make_bare_map_node(poi_xyz=poi, start_xyz=[0.0, 0.0, 0.0])
+    node.generate_nav_path_in_map = MagicMock(return_value=straight_path([0.0, 0.0, 0.0], poi))
+
+    with patch("tinynav.core.map_node.time.time") as fake_time:
+        fake_time.return_value = 0.0
+        node.nav_target_timer_callback()
+        assert node.generate_nav_path_in_map.call_count == 1  # first tick always replans
+
+        fake_time.return_value = 1.0  # robot hasn't moved; well under the timeout
+        node.nav_target_timer_callback()
+        assert node.generate_nav_path_in_map.call_count == 1  # no replan yet
+
+        fake_time.return_value = 10.0  # still hasn't moved; past stall_timeout_s
+        node.nav_target_timer_callback()
+        assert node.generate_nav_path_in_map.call_count == 2  # stall forced a replan
+        node.get_logger().warning.assert_called()
+        assert node._last_progress_remaining is None  # reset after the forced replan
+
+
+def test_steady_progress_never_stalls():
+    poi = [5.0, 0.0, 0.0]
+    node = make_bare_map_node(poi_xyz=poi, start_xyz=[0.0, 0.0, 0.0])
+    node.generate_nav_path_in_map = MagicMock(return_value=straight_path([0.0, 0.0, 0.0], poi))
+
+    with patch("tinynav.core.map_node.time.time") as fake_time:
+        fake_time.return_value = 0.0
+        node.nav_target_timer_callback()
+        assert node.generate_nav_path_in_map.call_count == 1
+
+        # advance both the clock (past stall_timeout_s each tick) and the robot's
+        # position (real progress along the path) every tick -- should never stall
+        for i in range(1, 6):
+            fake_time.return_value = float(i) * 10.0
+            node.latest_odom_pose[:3, 3] = [float(i) * 0.5, 0.0, 0.0]
+            node.nav_target_timer_callback()
+
+        assert node.generate_nav_path_in_map.call_count == 1  # never re-triggered
+        assert node._last_progress_remaining is not None
+
+
+if __name__ == "__main__":
+    test_stall_forces_a_replan_when_stuck_on_path()
+    print("Stall integration test passed.")
+    test_steady_progress_never_stalls()
+    print("Steady-progress integration test passed.")

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -10,7 +10,7 @@ import sys
 import json
 
 import heapq
-from tinynav.core.math_utils import matrix_to_quat, msg2np, np2msg, estimate_pose, np2tf, rerank_by_pnp_inliers
+from tinynav.core.math_utils import matrix_to_quat, msg2np, np2msg, estimate_pose, np2tf, rerank_by_pnp_inliers, stall_check
 from sensor_msgs.msg import Image, CameraInfo
 from message_filters import TimeSynchronizer, Subscriber
 from cv_bridge import CvBridge
@@ -274,6 +274,13 @@ class MapNode(Node):
         self._speed_estimate: float | None = None
         self.cached_nav_path_in_map = None
         self.cached_nav_path_poi_index = -1
+        # Deviation-based replan (below) only catches drift off the path. This catches
+        # the case where the robot is stuck on-path -- e.g. a new obstacle it cannot
+        # get around without a fresh route.
+        self._last_progress_remaining: float | None = None
+        self._last_progress_time: float | None = None
+        self.stall_progress_eps = 0.05  # m, noise floor below which movement isn't progress
+        self.stall_timeout_s = 8.0
 
         self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
         self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
@@ -316,6 +323,8 @@ class MapNode(Node):
             self._speed_estimate = None
             self.cached_nav_path_in_map = None
             self.cached_nav_path_poi_index = -1
+            self._last_progress_remaining = None
+            self._last_progress_time = None
             self.get_logger().info(f"Parsed POIs: {self.pois}")
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
@@ -657,6 +666,8 @@ class MapNode(Node):
             self._speed_estimate = None
             self.cached_nav_path_in_map = None
             self.cached_nav_path_poi_index = -1
+            self._last_progress_remaining = None
+            self._last_progress_time = None
             self.poi_change_pub.publish(np2msg(np.eye(4), self.get_clock().now().to_msg(), "world", "map"))
             if self.poi_index >= len(self.pois) and not self._nav_completed:
                 self._nav_completed = True
@@ -673,12 +684,28 @@ class MapNode(Node):
             closest_idx = int(np.argmin(np.linalg.norm(paths[:, :2] - pos[:2], axis=1)))
             if np.linalg.norm(paths[closest_idx, :2] - pos[:2]) > 0.5:
                 needs_replan = True
+            else:
+                remaining_now = sum(
+                    np.linalg.norm(paths[i + 1] - paths[i])
+                    for i in range(closest_idx, len(paths) - 1)
+                ) if closest_idx < len(paths) - 1 else 0.0
+                self._last_progress_remaining, self._last_progress_time, stalled = stall_check(
+                    self._last_progress_remaining, self._last_progress_time, remaining_now,
+                    time.time(), self.stall_progress_eps, self.stall_timeout_s,
+                )
+                if stalled:
+                    self.get_logger().warning(
+                        f"No progress for {self.stall_timeout_s:.0f}s despite being on-path, forcing replan"
+                    )
+                    needs_replan = True
 
         if needs_replan:
             paths = self.generate_nav_path_in_map(pose_in_map=pose_in_map, target_poi=poi)
             if paths is not None:
                 self.cached_nav_path_in_map = paths
                 self.cached_nav_path_poi_index = self.poi_index
+                self._last_progress_remaining = None
+                self._last_progress_time = None
             else:
                 self.cached_nav_path_in_map = None
                 self.cached_nav_path_poi_index = -1

--- a/tinynav/core/math_utils.py
+++ b/tinynav/core/math_utils.py
@@ -310,3 +310,17 @@ def uf_all_sets_list(uf, min_component_size=1):
         if part.size >= int(min_component_size):
             out.append(np.sort(part).tolist())
     return out
+
+
+def stall_check(last_remaining, last_time, remaining_now, now, progress_eps, timeout_s):
+    """
+    Track path-following progress and flag a stall: no drop in remaining route length
+    for timeout_s, despite deviation from the path staying within its own replan
+    threshold -- e.g. the robot stopped in front of a newly observed obstacle.
+    :return: (new_last_remaining, new_last_time, stalled)
+    """
+    if last_remaining is None or last_remaining - remaining_now > progress_eps:
+        return remaining_now, now, False
+    if now - last_time > timeout_s:
+        return last_remaining, last_time, True
+    return last_remaining, last_time, False


### PR DESCRIPTION
## Summary
- Track the remaining route length each `nav_target_timer_callback` cycle; if it hasn't dropped by more than a small noise threshold (`stall_progress_eps`, 0.05m) for `stall_timeout_s` (8s), force a replan even though deviation from the cached path is still within its own 0.5m threshold.
- Add `stall_check` as a small pure function in `math_utils.py` (not `map_node.py`, so it can be unit-tested without pulling in `map_node.py`'s TensorRT/rclpy dependencies).

## Motivation
The existing replan trigger only fires on deviation from the cached path. It never fires when the robot is stopped on (or near) the path in front of a newly observed obstacle it can't get around without a fresh route -- a deadlock that used to require manual intervention (or waiting for `poi_change`/a new leg).

## Test plan
- [x] `python tests/test_map_node.py` -- `stall_check` unit tests. (Also comments out, not deletes, the orphaned `test_theta_star`: `theta_star` was removed from `math_utils.py` in #208 but the test was left behind, breaking every test in this file at import time -- unrelated pre-existing issue, fixed here since it blocked verifying this PR.)
- [x] `python tests/test_map_node_stall_integration.py` -- builds a real `MapNode` (via `__new__`, skipping `__init__`'s model/map loading) and calls the real `nav_target_timer_callback` directly, with `generate_nav_path_in_map` stubbed to a canned path and `time.time()` mocked. Verified against the actual `uniflexai/tinynav` image:
  - Robot stuck on-path (no movement) for 8s -> `generate_nav_path_in_map` is called again (forced replan) and a warning is logged.
  - Robot makes steady progress along the path, even with >8s real gaps between ticks -> never flagged as stalled, `generate_nav_path_in_map` is called only once (the initial plan).
- [ ] Real-hardware acceptance: with a built map and a POI leg in progress, place a physical obstacle directly in the robot's path (deviation stays under 0.5m) and confirm `map_node` logs "No progress for 8s..." and a replan happens instead of the robot idling indefinitely. Confirm normal navigation (no obstacle) never logs that warning.