### PR TITLE
fix(unitree): stand up before standing down when sitting a quadruped

### DIFF
--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -103,8 +103,10 @@ class Ros2UnitreeManagerNode(Node):
             action_key = msg.data.split(" ")[1]
             if action_key == "sit":
                 if self.is_quadruped:
-                    code = self.sport_client.StandDown()
-                    self.logger.info(f"Sitting: StandDown code={code}")
+                    code1 = self.sport_client.StandUp()
+                    time.sleep(0.5)
+                    code2 = self.sport_client.StandDown()
+                    self.logger.info(f"Sitting: StandDown code={code2}")
                 else:
                     code = self.sport_client.StandUp2Squat()
                     self.logger.info(f"Sitting: StandUp2Squat code={code}")


### PR DESCRIPTION
## Summary
- In `Ros2UnitreeManagerNode.ActionMessageHandler`'s `sit` action, call `StandUp()` (and wait 0.5s) before `StandDown()` for quadrupeds, instead of calling `StandDown()` directly.

## Motivation
Calling `StandDown()` directly from an arbitrary prior state isn't reliable on the quadruped SDK -- forcing a `StandUp()` first gives the sit command a known starting posture before commanding the sit-down.

## Test plan
- [x] On a real quadruped (e.g. Go2/B2), publish a `play sit` action from a non-standing posture and confirm the robot stands up then sits down cleanly, without the erratic behavior seen when `StandDown()` was called directly
- [x] Confirm the biped path (`StandUp2Squat`) is unaffected
