### PR TITLE
refactor(planning): move ObstacleConfig into per-robot specs

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -5,7 +5,6 @@ from nav_msgs.msg import Path, Odometry, OccupancyGrid
 from cv_bridge import CvBridge
 import numpy as np
 from scipy.ndimage import distance_transform_edt, binary_dilation
-from dataclasses import dataclass
 from numba import njit
 import message_filters
 from rclpy.time import Time
@@ -16,7 +15,7 @@ from std_msgs.msg import Header
 from codetiming import Timer
 import cv2
 from tinynav.core.math_utils import rotvec_to_matrix, quat_to_matrix, matrix_to_quat, msg2np
-from tinynav.core.robot_specs import ROBOT_CONFIG
+from tinynav.core.robot_specs import ROBOT_CONFIG, ObstacleConfig
 
 # === Helper functions ===
 @njit(cache=True)
@@ -100,15 +99,6 @@ def run_raycasting_loopy(depth_image, T_cam_to_world, grid_shape, fx, fy, cx, cy
                     occupancy_grid[i, j, k] = 0.1
 
     return occupancy_grid
-
-
-@dataclass
-class ObstacleConfig:
-    robot_z_bottom: float = -0.4
-    robot_z_top: float = 0.4
-    occ_threshold: float = 0.1
-    min_wall_span_m: float = 0.2
-    dilation_cells: int = 2
 
 
 def build_obstacle_map(occupancy_grid, origin, resolution, robot_z, config=None):
@@ -308,7 +298,8 @@ class PlanningNode(Node):
             f"Robot: {ROBOT_CONFIG.name} ({ROBOT_CONFIG.shape} {ROBOT_CONFIG.length}x{ROBOT_CONFIG.width}m, "
             f"cam=({ROBOT_CONFIG.camera_x},{ROBOT_CONFIG.camera_y}), "
             f"ctrl=({ROBOT_CONFIG.control_x},{ROBOT_CONFIG.control_y}), "
-            f"safety_r={ROBOT_CONFIG.safety_radius}m)"
+            f"safety_r={ROBOT_CONFIG.safety_radius}m, "
+            f"z_band=[{ROBOT_CONFIG.obstacle.robot_z_bottom}, {ROBOT_CONFIG.obstacle.robot_z_top}]m)"
         )
         self.bridge = CvBridge()
         self.path_pub = self.create_publisher(Path, '/planning/trajectory_path', 10)
@@ -334,7 +325,7 @@ class PlanningNode(Node):
         self.baseline = None
         self.last_T = None
         self.last_param = (0.0, 0.0) # acc and gyro
-        self.obstacle_config = ObstacleConfig()
+        self.obstacle_config = ROBOT_CONFIG.obstacle
         self.stamp = None
         self.current_pose = None  # Store the latest pose from odometry
 

--- a/tinynav/core/robot_specs.py
+++ b/tinynav/core/robot_specs.py
@@ -1,6 +1,20 @@
 import os
 import numpy as np
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ObstacleConfig:
+    """Height band + occupancy filters used by planning_node.build_obstacle_map.
+
+    z-band is relative to camera height (T[2, 3]). Taller robots need a wider
+    band so hanging obstacles and low walls still count as collisions.
+    """
+    robot_z_bottom: float = -0.4
+    robot_z_top: float = 0.4
+    occ_threshold: float = 0.1
+    min_wall_span_m: float = 0.2
+    dilation_cells: int = 2
 
 
 @dataclass
@@ -28,6 +42,7 @@ class RobotConfig:
     max_linear_vel: float = 1.0
     min_angular_vel: float = 0.1
     max_angular_vel: float = 0.75
+    obstacle: ObstacleConfig = field(default_factory=ObstacleConfig)
 
     @property
     def cam_offset_3d(self):
@@ -52,6 +67,7 @@ GO2_CONFIG = RobotConfig(
     camera_x=0.2, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.2,
+    obstacle=ObstacleConfig(robot_z_bottom=-0.4, robot_z_top=0.4),
 )
 
 GO2W_CONFIG = RobotConfig(
@@ -60,6 +76,7 @@ GO2W_CONFIG = RobotConfig(
     camera_x=0.2, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.2,
+    obstacle=ObstacleConfig(robot_z_bottom=-0.4, robot_z_top=0.4),
 )
 
 B2_CONFIG = RobotConfig(
@@ -68,6 +85,7 @@ B2_CONFIG = RobotConfig(
     camera_x=0.3, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.1,
+    obstacle=ObstacleConfig(robot_z_bottom=-0.6, robot_z_top=0.6),
 )
 
 B2W_CONFIG = RobotConfig(
@@ -76,6 +94,7 @@ B2W_CONFIG = RobotConfig(
     camera_x=0.3, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.1,
+    obstacle=ObstacleConfig(robot_z_bottom=-0.6, robot_z_top=0.6),
 )
 
 G1_CONFIG = RobotConfig(
@@ -84,7 +103,8 @@ G1_CONFIG = RobotConfig(
     camera_x=0.1, camera_y=0.0,
     control_x=0.0, control_y=0.0,
     safety_radius=0.15,
-    min_linear_vel=0.2,min_angular_vel=0.3
+    min_linear_vel=0.2, min_angular_vel=0.3,
+    obstacle=ObstacleConfig(robot_z_bottom=-0.8, robot_z_top=0.6),
 )
 
 ROBOT_TYPE = os.environ.get("ROBOT_TYPE", "go2").strip().lower()

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -34,7 +34,6 @@ from scipy.spatial.transform import Rotation as R
 from sensor_msgs.msg import CameraInfo, Image, PointCloud
 from std_msgs.msg import Bool
 
-from tinynav.core.planning_node import ObstacleConfig
 from tinynav.core.robot_specs import GO2_CONFIG
 from tool.simulator.planning_scene import (
     SimObject,
@@ -47,8 +46,8 @@ from tool.simulator.planning_scene import (
 
 ROOT = Path(__file__).resolve().parent
 STATIC_DIR = ROOT / "offline_planning_web"
-PLANNING_ROBOT_DEFAULT = asdict(GO2_CONFIG)
-PLANNING_OBSTACLE_DEFAULT = asdict(ObstacleConfig())
+PLANNING_ROBOT_DEFAULT = {k: v for k, v in asdict(GO2_CONFIG).items() if k != "obstacle"}
+PLANNING_OBSTACLE_DEFAULT = asdict(GO2_CONFIG.obstacle)
 
 
 def default_config() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Move `ObstacleConfig` from `planning_node` into `robot_specs` so each `ROBOT_TYPE` owns its collision height band.
- Keep Go2/Go2W at `[-0.4, 0.4]`; widen B2/B2W to `[-0.6, 0.6]` and G1 to `[-0.8, 0.6]`.
- Planning node now reads `ROBOT_CONFIG.obstacle`; the ROS planning web sim still exposes robot and obstacle as separate config blobs.

## Test plan
- [ ] `ROBOT_TYPE=go2` planning node still starts and logs `z_band=[-0.4, 0.4]`
- [ ] `ROBOT_TYPE=b2` planning node logs the wider z-band and still builds obstacle maps
- [ ] ROS planning web sim still loads default robot/obstacle config without nested `obstacle` inside `robot`
