### PR TITLE
feat(sim): load TinyNav maps in ROS planning lab

### DIFF
--- a/scripts/run_ros_planning_web.sh
+++ b/scripts/run_ros_planning_web.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
+export TINYNAV_DB_PATH="${TINYNAV_DB_PATH:-$ROOT/tinynav_db}"
 set +u
 source /opt/ros/humble/setup.bash
 set -u

--- a/tool/simulator/map_volume.py
+++ b/tool/simulator/map_volume.py
@@ -1,0 +1,215 @@
+"""Load TinyNav map occupancy volumes for the planning web simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from numba import njit
+
+
+OCCUPIED = 2
+
+
+@dataclass(frozen=True)
+class MapInfo:
+    map_path: str
+    origin_x: float
+    origin_y: float
+    origin_z: float
+    resolution: float
+    width: int   # Nx (world X)
+    height: int  # Ny (world Y)
+    depth: int   # Nz (world Z)
+
+    @property
+    def x_min(self) -> float:
+        return self.origin_x
+
+    @property
+    def x_max(self) -> float:
+        return self.origin_x + self.width * self.resolution
+
+    @property
+    def y_min(self) -> float:
+        return self.origin_y
+
+    @property
+    def y_max(self) -> float:
+        return self.origin_y + self.height * self.resolution
+
+    def as_dict(self) -> dict:
+        return {
+            "map_path": self.map_path,
+            "origin": [self.origin_x, self.origin_y, self.origin_z],
+            "resolution": self.resolution,
+            "width": self.width,
+            "height": self.height,
+            "depth": self.depth,
+            "bounds": {
+                "x_min": self.x_min,
+                "x_max": self.x_max,
+                "y_min": self.y_min,
+                "y_max": self.y_max,
+            },
+        }
+
+
+@dataclass
+class MapVolume:
+    grid: np.ndarray
+    origin: np.ndarray
+    resolution: float
+    map_path: str
+
+    @classmethod
+    def load(cls, map_path: str | Path) -> MapVolume:
+        root = Path(map_path).expanduser().resolve()
+        grid_file = root / "occupancy_grid.npy"
+        meta_file = root / "occupancy_meta.npy"
+        if not grid_file.is_file() or not meta_file.is_file():
+            raise FileNotFoundError(
+                f"Map needs occupancy_grid.npy and occupancy_meta.npy under {root}"
+            )
+        grid = np.load(grid_file)
+        meta = np.load(meta_file).astype(np.float64)
+        if grid.ndim != 3:
+            raise ValueError(f"occupancy_grid must be 3D, got shape {grid.shape}")
+        if meta.shape[0] < 4:
+            raise ValueError(f"occupancy_meta must have 4 values, got {meta.shape}")
+        return cls(
+            grid=np.ascontiguousarray(grid, dtype=np.uint8),
+            origin=np.array(meta[:3], dtype=np.float64),
+            resolution=float(meta[3]),
+            map_path=str(root),
+        )
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        return tuple(int(v) for v in self.grid.shape)
+
+    def info(self) -> MapInfo:
+        nx, ny, nz = self.shape
+        return MapInfo(
+            map_path=self.map_path,
+            origin_x=float(self.origin[0]),
+            origin_y=float(self.origin[1]),
+            origin_z=float(self.origin[2]),
+            resolution=float(self.resolution),
+            width=nx,
+            height=ny,
+            depth=nz,
+        )
+
+    def default_start_xy(self) -> tuple[float, float]:
+        info = self.info()
+        return (
+            (info.x_min + info.x_max) * 0.5,
+            (info.y_min + info.y_max) * 0.5,
+        )
+
+    def background_rgb(self) -> np.ndarray:
+        """Top-down RGB preview for the planning web UI.
+
+        Canvas convention (must match ``worldToCanvas`` in app.js):
+        - image width  = world Y  (screen horizontal)
+        - image height = world X  (screen vertical, +X points up)
+        """
+        occupied = np.any(self.grid == OCCUPIED, axis=2)
+        free = np.any(self.grid == 1, axis=2)
+        nx, ny = occupied.shape
+        img = np.full((nx, ny, 3), 128, dtype=np.uint8)
+        img[free] = (210, 210, 210)
+        img[occupied] = (35, 35, 35)
+        # Row 0 → max world X so +X is up on screen after worldToCanvas.
+        return np.flipud(img)
+
+
+@njit(cache=True)
+def _raycast_map(origin, rays, z_cam, max_range, grid, origin_xyz, resolution):
+    n_rays = rays.shape[0]
+    nx, ny, nz = grid.shape[0], grid.shape[1], grid.shape[2]
+    ox, oy, oz = origin_xyz[0], origin_xyz[1], origin_xyz[2]
+    inv_res = 1.0 / resolution
+    best = np.empty(n_rays, dtype=np.float64)
+    for i in range(n_rays):
+        best[i] = np.inf
+        dx, dy, dz = rays[i, 0], rays[i, 1], rays[i, 2]
+        zc = z_cam[i]
+        if zc <= 1e-9:
+            continue
+        ix = int(np.floor((origin[0] - ox) * inv_res))
+        iy = int(np.floor((origin[1] - oy) * inv_res))
+        iz = int(np.floor((origin[2] - oz) * inv_res))
+        if ix < 0 or iy < 0 or iz < 0 or ix >= nx or iy >= ny or iz >= nz:
+            continue
+        step_x = 1 if dx >= 0.0 else -1
+        step_y = 1 if dy >= 0.0 else -1
+        step_z = 1 if dz >= 0.0 else -1
+        if abs(dx) < 1e-12:
+            t_delta_x = np.inf
+            t_max_x = np.inf
+        else:
+            next_x = ix + (1 if dx >= 0.0 else 0)
+            t_delta_x = abs(resolution / dx)
+            t_max_x = ((ox + next_x * resolution) - origin[0]) / dx
+        if abs(dy) < 1e-12:
+            t_delta_y = np.inf
+            t_max_y = np.inf
+        else:
+            next_y = iy + (1 if dy >= 0.0 else 0)
+            t_delta_y = abs(resolution / dy)
+            t_max_y = ((oy + next_y * resolution) - origin[1]) / dy
+        if abs(dz) < 1e-12:
+            t_delta_z = np.inf
+            t_max_z = np.inf
+        else:
+            next_z = iz + (1 if dz >= 0.0 else 0)
+            t_delta_z = abs(resolution / dz)
+            t_max_z = ((oz + next_z * resolution) - origin[2]) / dz
+        dist = 0.0
+        while dist <= max_range:
+            if 0 <= ix < nx and 0 <= iy < ny and 0 <= iz < nz:
+                if grid[ix, iy, iz] == OCCUPIED:
+                    if dist > 1e-4:
+                        best[i] = dist
+                    break
+            else:
+                break
+            if t_max_x < t_max_y:
+                if t_max_x < t_max_z:
+                    dist = t_max_x
+                    t_max_x += t_delta_x
+                    ix += step_x
+                else:
+                    dist = t_max_z
+                    t_max_z += t_delta_z
+                    iz += step_z
+            elif t_max_y < t_max_z:
+                dist = t_max_y
+                t_max_y += t_delta_y
+                iy += step_y
+            else:
+                dist = t_max_z
+                t_max_z += t_delta_z
+                iz += step_z
+    return best
+
+
+def raycast_map(
+    origin: np.ndarray,
+    rays: np.ndarray,
+    z_cam: np.ndarray,
+    max_range: float,
+    volume: MapVolume,
+) -> np.ndarray:
+    return _raycast_map(
+        origin.astype(np.float64),
+        np.ascontiguousarray(rays, dtype=np.float64),
+        np.ascontiguousarray(z_cam, dtype=np.float64),
+        float(max_range),
+        volume.grid,
+        volume.origin.astype(np.float64),
+        float(volume.resolution),
+    )

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -1,7 +1,8 @@
 const REALTIME_TICK_DELAY_MS = 33;
 const GRID_STEP_M = 1.0;
-const SCENE = { xMin: -0.8, xMax: 9.8, yMin: -5.4, yMax: 5.4 };
-const CAM_DEFAULTS = { width: 160, image_height: 100, fx: 80, fy: 25, max_range: 15, mount_height: 0.45 };
+const DEFAULT_SCENE = { xMin: -0.8, xMax: 9.8, yMin: -5.4, yMax: 5.4 };
+const LAB_VIEW_HALF_M = 5.0;
+let sceneBounds = { ...DEFAULT_SCENE };
 const DEPTH_STOPS = [
   [0.0, [255, 230, 80]],
   [0.18, [255, 120, 40]],
@@ -20,10 +21,15 @@ let realtimeTimer = null;
 let realtimePending = false;
 let realtimePath = [];
 let currentFrame = null;
-let realtimeNeedsReset = true;
+let mapCatalog = [];
+let robotPresets = {};
+let mapBackgroundImage = null;
+let mapBackgroundSrc = null;
 
 const canvas = document.getElementById("sceneCanvas");
 const ctx = canvas.getContext("2d");
+const mapCanvas = document.getElementById("mapCanvas");
+const mapCtx = mapCanvas.getContext("2d");
 const depthCanvas = document.getElementById("depthCanvas");
 const depthCtx = depthCanvas.getContext("2d");
 const statusEl = document.getElementById("status");
@@ -33,14 +39,13 @@ const realtimeButton = document.getElementById("realtimeButton");
 const $ = (id) => document.getElementById(id);
 
 const fields = {
+  mapSelect: $("mapSelect"),
+  mapSummary: $("mapSummary"),
+  startX: $("startX"),
+  startY: $("startY"),
+  startYaw: $("startYaw"),
   targetX: $("targetX"),
   targetY: $("targetY"),
-  camWidth: $("camWidth"),
-  camHeight: $("camHeight"),
-  camFx: $("camFx"),
-  camFy: $("camFy"),
-  camMaxRange: $("camMaxRange"),
-  camMountHeight: $("camMountHeight"),
   objectName: $("objectName"),
   objectX: $("objectX"),
   objectY: $("objectY"),
@@ -48,25 +53,49 @@ const fields = {
   objectSY: $("objectSY"),
   objectSZ: $("objectSZ"),
   configText: $("configText"),
+  robotPreset: $("robotPreset"),
   robotSummary: $("robotSummary"),
   cameraSummary: $("cameraSummary"),
 };
 
-const editableFields = [
-  fields.targetX, fields.targetY,
-  fields.camWidth, fields.camHeight, fields.camFx, fields.camFy, fields.camMaxRange, fields.camMountHeight,
-  fields.objectName, fields.objectX, fields.objectY, fields.objectSX, fields.objectSY, fields.objectSZ,
-];
+const boundInputs = () => [...document.querySelectorAll("[data-bind]")];
 
 function clamp(v, lo, hi) {
   return Math.max(lo, Math.min(hi, v));
 }
 
-function num(el, fallback, min = null, round = false) {
-  let v = Number(el.value);
-  if (!Number.isFinite(v)) v = fallback;
-  if (round) v = Math.round(v);
-  return min == null ? v : Math.max(min, v);
+function pathGet(obj, path) {
+  return path.split(".").reduce((cur, key) => (cur == null ? cur : cur[key]), obj);
+}
+
+function pathSet(obj, path, value) {
+  const keys = path.split(".");
+  const last = keys.pop();
+  let cur = obj;
+  keys.forEach((key) => {
+    if (cur[key] == null || typeof cur[key] !== "object") cur[key] = {};
+    cur = cur[key];
+  });
+  cur[last] = value;
+}
+
+function readBoundFields() {
+  boundInputs().forEach((el) => {
+    const path = el.dataset.bind;
+    if (el.type === "number") {
+      const v = Number(el.value);
+      if (Number.isFinite(v)) pathSet(config, path, v);
+    } else {
+      pathSet(config, path, el.value);
+    }
+  });
+}
+
+function writeBoundFields() {
+  boundInputs().forEach((el) => {
+    const v = pathGet(config, el.dataset.bind);
+    if (v != null) el.value = v;
+  });
 }
 
 function lerpRGB(a, b, t) {
@@ -84,8 +113,8 @@ function logicalSize(target = canvas) {
   };
 }
 
-function sceneView(target = canvas) {
-  const b = SCENE;
+function sceneView(target = canvas, bounds = sceneBounds) {
+  const b = bounds;
   const { width, height } = logicalSize(target);
   const pad = 12;
   const availW = Math.max(1, width - pad * 2);
@@ -99,18 +128,18 @@ function sceneView(target = canvas) {
   };
 }
 
-function worldToCanvas(x, y, target = canvas) {
-  const v = sceneView(target);
+function worldToCanvas(x, y, target = canvas, bounds = sceneBounds) {
+  const v = sceneView(target, bounds);
   return [v.offsetX + (y - v.b.yMin) * v.scale, v.offsetY + (v.b.xMax - x) * v.scale];
 }
 
-function canvasToWorld(px, py) {
-  const v = sceneView();
+function canvasToWorld(px, py, target = canvas, bounds = sceneBounds) {
+  const v = sceneView(target, bounds);
   return [v.b.xMax - (py - v.offsetY) / v.scale, v.b.yMin + (px - v.offsetX) / v.scale];
 }
 
-function pointerPos(event) {
-  const rect = canvas.getBoundingClientRect();
+function pointerPosOn(event, targetCanvas = canvas) {
+  const rect = targetCanvas.getBoundingClientRect();
   return [event.clientX - rect.left, event.clientY - rect.top];
 }
 
@@ -163,14 +192,15 @@ function summaryLines(lines) {
 
 function robotSummaryHtml() {
   const r = config.robot || {};
-  const o = config.obstacle || {};
-  return summaryLines([
-    ["preset", r.preset || "go2"],
-    ["size", `${Number(r.length || 0).toFixed(2)} x ${Number(r.width || 0).toFixed(2)} m`],
-    ["camera/control", `${Number(r.camera_x || 0).toFixed(2)} / ${Number(r.control_x || 0).toFixed(2)} m`],
-    ["safety radius", `${Number(r.safety_radius || 0).toFixed(2)} m`],
-    ["obstacle dilation", `${Number(o.dilation_cells || 0)}`],
-  ]);
+  const [fl, rl, hw] = footprintFromControl(r);
+  return summaryLines([["footprint F/R/W", `${fl.toFixed(2)} / ${rl.toFixed(2)} / ${hw.toFixed(2)} m`]]);
+}
+
+function footprintFromControl(r) {
+  const hl = r.shape === "circle" ? Number(r.radius || 0) : Number(r.length || 0) / 2;
+  const hw = r.shape === "circle" ? Number(r.radius || 0) : Number(r.width || 0) / 2;
+  const cx = Number(r.control_x || 0);
+  return [hl - cx, hl + cx, hw];
 }
 
 function cameraSummaryHtml() {
@@ -186,13 +216,83 @@ function cameraSummaryHtml() {
   ]);
 }
 
+function updateLabViewBounds(focusXY = null) {
+  const xy = focusXY || currentFrame?.robot_xy || config?.start?.xy;
+  if (!xy) return;
+  sceneBounds = {
+    xMin: xy[0] - LAB_VIEW_HALF_M,
+    xMax: xy[0] + LAB_VIEW_HALF_M,
+    yMin: xy[1] - LAB_VIEW_HALF_M,
+    yMax: xy[1] + LAB_VIEW_HALF_M,
+  };
+}
+
+function perceptionBounds() {
+  const info = currentFrame?.map_info || config?.map_info;
+  if (info?.bounds) {
+    const b = info.bounds;
+    const pad = 0.3;
+    return {
+      xMin: b.x_min - pad,
+      xMax: b.x_max + pad,
+      yMin: b.y_min - pad,
+      yMax: b.y_max + pad,
+    };
+  }
+  return { ...DEFAULT_SCENE };
+}
+
+function mapSummaryHtml() {
+  const info = config?.map_info || currentFrame?.map_info;
+  if (!info) return "No map loaded. Using synthetic demo scene.";
+  const b = info.bounds;
+  return summaryLines([
+    ["name", config?.map_name || info.map_path?.split("/").pop() || "—"],
+    ["size", `${info.width} x ${info.height} x ${info.depth} @ ${Number(info.resolution).toFixed(2)} m`],
+    ["origin", `[${info.origin.map((v) => Number(v).toFixed(2)).join(", ")}]`],
+    ["world XY", `${Number(b.x_min).toFixed(1)}..${Number(b.x_max).toFixed(1)}, ${Number(b.y_min).toFixed(1)}..${Number(b.y_max).toFixed(1)}`],
+  ]);
+}
+
+function setMapBackground(bg) {
+  const src = bg?.data_url || null;
+  if (src === mapBackgroundSrc) return;
+  mapBackgroundSrc = src;
+  mapBackgroundImage = null;
+  if (!src) return;
+  const img = new Image();
+  img.onload = () => {
+    if (mapBackgroundSrc !== src) return;
+    mapBackgroundImage = img;
+    drawPerceptionMap();
+  };
+  img.src = src;
+}
+
+function drawMapBackgroundOn(targetCtx, targetCanvas, bounds) {
+  const bg = currentFrame?.map_background || config?.map_background;
+  const info = currentFrame?.map_info || config?.map_info;
+  if (!bg?.data_url || !info?.bounds) return;
+  setMapBackground(bg);
+  if (!mapBackgroundImage) return;
+  const b = info.bounds;
+  // Image width = world-Y span, height = world-X span (see map_volume.background_rgb).
+  const [topLeftX, topLeftY] = worldToCanvas(b.x_max, b.y_min, targetCanvas, bounds);
+  const [botRightX, botRightY] = worldToCanvas(b.x_min, b.y_max, targetCanvas, bounds);
+  const x = Math.min(topLeftX, botRightX);
+  const y = Math.min(topLeftY, botRightY);
+  const w = Math.abs(botRightX - topLeftX);
+  const h = Math.abs(botRightY - topLeftY);
+  targetCtx.drawImage(mapBackgroundImage, x, y, w, h);
+}
+
 function drawGrid() {
   const { width, height } = logicalSize();
   ctx.fillStyle = "#fbfcfd";
   ctx.fillRect(0, 0, width, height);
   ctx.strokeStyle = "#e0e7ee";
   ctx.lineWidth = 1;
-  const b = SCENE;
+  const b = sceneBounds;
   for (let x = Math.ceil(b.xMin / GRID_STEP_M) * GRID_STEP_M; x <= b.xMax + 1e-9; x += GRID_STEP_M) {
     const [px0, py] = worldToCanvas(x, b.yMin);
     const [px1] = worldToCanvas(x, b.yMax);
@@ -212,7 +312,8 @@ function drawGrid() {
 }
 
 function drawGround() {
-  const b = SCENE;
+  if (config?.map_path || currentFrame?.map_info) return;
+  const b = sceneBounds;
   const [px0, py0] = worldToCanvas(b.xMin + 0.3, b.yMin + 0.3);
   const [px1, py1] = worldToCanvas(b.xMax - 0.3, b.yMax - 0.3);
   ctx.fillStyle = "rgba(226, 232, 220, 0.85)";
@@ -238,34 +339,34 @@ function drawObjects() {
   });
 }
 
-function drawMarker(xy, label, color, radius = 7) {
-  const [px, py] = worldToCanvas(xy[0], xy[1]);
-  ctx.fillStyle = color;
-  ctx.beginPath();
-  ctx.arc(px, py, radius, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.fillText(label, px, py - 12);
+function drawMarker(xy, label, color, radius = 7, targetCtx = ctx, targetCanvas = canvas, bounds = sceneBounds) {
+  const [px, py] = worldToCanvas(xy[0], xy[1], targetCanvas, bounds);
+  targetCtx.fillStyle = color;
+  targetCtx.beginPath();
+  targetCtx.arc(px, py, radius, 0, Math.PI * 2);
+  targetCtx.fill();
+  if (label) targetCtx.fillText(label, px, py - 12);
 }
 
-function drawHeadingArrow(xy, yawDeg, color, length = 0.45) {
+function drawHeadingArrow(xy, yawDeg, color, length = 0.45, targetCtx = ctx, targetCanvas = canvas, bounds = sceneBounds) {
   if (!xy || yawDeg == null) return;
   const yaw = (Number(yawDeg) * Math.PI) / 180;
   const tip = [xy[0] + Math.cos(yaw) * length, xy[1] + Math.sin(yaw) * length];
-  const [x0, y0] = worldToCanvas(xy[0], xy[1]);
-  const [x1, y1] = worldToCanvas(tip[0], tip[1]);
-  ctx.strokeStyle = ctx.fillStyle = color;
-  ctx.lineWidth = 3;
-  ctx.beginPath();
-  ctx.moveTo(x0, y0);
-  ctx.lineTo(x1, y1);
-  ctx.stroke();
+  const [x0, y0] = worldToCanvas(xy[0], xy[1], targetCanvas, bounds);
+  const [x1, y1] = worldToCanvas(tip[0], tip[1], targetCanvas, bounds);
+  targetCtx.strokeStyle = targetCtx.fillStyle = color;
+  targetCtx.lineWidth = 3;
+  targetCtx.beginPath();
+  targetCtx.moveTo(x0, y0);
+  targetCtx.lineTo(x1, y1);
+  targetCtx.stroke();
   const angle = Math.atan2(y1 - y0, x1 - x0);
-  ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x1 - Math.cos(angle - 0.55) * 12, y1 - Math.sin(angle - 0.55) * 12);
-  ctx.lineTo(x1 - Math.cos(angle + 0.55) * 12, y1 - Math.sin(angle + 0.55) * 12);
-  ctx.closePath();
-  ctx.fill();
+  targetCtx.beginPath();
+  targetCtx.moveTo(x1, y1);
+  targetCtx.lineTo(x1 - Math.cos(angle - 0.55) * 12, y1 - Math.sin(angle - 0.55) * 12);
+  targetCtx.lineTo(x1 - Math.cos(angle + 0.55) * 12, y1 - Math.sin(angle + 0.55) * 12);
+  targetCtx.closePath();
+  targetCtx.fill();
 }
 
 function drawStartTarget() {
@@ -276,7 +377,7 @@ function drawStartTarget() {
   const camera = cameraPose();
   drawMarker(camera.xy, "camera", "#6d28d9", 6);
   drawHeadingArrow(camera.xy, config.start.yaw_deg, "#6d28d9", 0.32);
-  drawMarker(config.target, "target", "#da1e28");
+  drawMarker(config.target, "target", "#da1e28", realtimeRunning ? 5 : 7);
   ctx.restore();
 }
 
@@ -345,20 +446,20 @@ function drawEsdfSceneOverlay() {
   ctx.restore();
 }
 
-function drawPath(points, color, width, alpha = 1) {
+function drawPath(points, color, width, alpha = 1, targetCtx = ctx, targetCanvas = canvas, bounds = sceneBounds) {
   if (!points || points.length < 2) return;
-  ctx.save();
-  ctx.globalAlpha = alpha;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = width;
-  ctx.beginPath();
+  targetCtx.save();
+  targetCtx.globalAlpha = alpha;
+  targetCtx.strokeStyle = color;
+  targetCtx.lineWidth = width;
+  targetCtx.beginPath();
   points.forEach(([x, y], i) => {
-    const [px, py] = worldToCanvas(x, y);
-    if (i === 0) ctx.moveTo(px, py);
-    else ctx.lineTo(px, py);
+    const [px, py] = worldToCanvas(x, y, targetCanvas, bounds);
+    if (i === 0) targetCtx.moveTo(px, py);
+    else targetCtx.lineTo(px, py);
   });
-  ctx.stroke();
-  ctx.restore();
+  targetCtx.stroke();
+  targetCtx.restore();
 }
 
 function drawFootprint(footprint) {
@@ -432,6 +533,72 @@ function drawScene() {
   drawRealtimeOverlay();
 }
 
+function syncMapCanvasSize() {
+  const { width: cssW, height: cssH } = logicalSize(mapCanvas);
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const nextW = Math.max(1, Math.round(cssW * dpr));
+  const nextH = Math.max(1, Math.round(cssH * dpr));
+  if (mapCanvas.width !== nextW || mapCanvas.height !== nextH) {
+    mapCanvas.width = nextW;
+    mapCanvas.height = nextH;
+  }
+  mapCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { width: cssW, height: cssH };
+}
+
+function drawPerceptionMap() {
+  if (!config) return;
+  const bounds = perceptionBounds();
+  const size = syncMapCanvasSize();
+  mapCtx.clearRect(0, 0, size.width, size.height);
+  mapCtx.fillStyle = "#fbfcfd";
+  mapCtx.fillRect(0, 0, size.width, size.height);
+
+  const hasMap = config?.map_info || currentFrame?.map_info;
+  if (!hasMap) {
+    mapCtx.fillStyle = "#5c6975";
+    mapCtx.font = "13px system-ui";
+    mapCtx.textAlign = "center";
+    mapCtx.textBaseline = "middle";
+    mapCtx.fillText("Load a map to see overview", size.width / 2, size.height / 2);
+    return;
+  }
+
+  drawMapBackgroundOn(mapCtx, mapCanvas, bounds);
+
+  config.objects.forEach((obj) => {
+    const [x, y] = obj.center;
+    const [sx, sy] = obj.size;
+    const [px0, py0] = worldToCanvas(x - sx / 2, y - sy / 2, mapCanvas, bounds);
+    const [px1, py1] = worldToCanvas(x + sx / 2, y + sy / 2, mapCanvas, bounds);
+    const rx = Math.min(px0, px1);
+    const ry = Math.min(py0, py1);
+    mapCtx.fillStyle = "rgba(95, 108, 120, 0.55)";
+    mapCtx.strokeStyle = "#56616c";
+    mapCtx.lineWidth = 1.5;
+    mapCtx.beginPath();
+    mapCtx.rect(rx, ry, Math.abs(px1 - px0), Math.abs(py1 - py0));
+    mapCtx.fill();
+    mapCtx.stroke();
+  });
+
+  mapCtx.save();
+  mapCtx.textAlign = "center";
+  mapCtx.textBaseline = "alphabetic";
+  drawPath(realtimePath, "#0f766e", 3, 1, mapCtx, mapCanvas, bounds);
+  const robotXY = robotDragXY();
+  const showStart = !realtimeRunning
+    || Math.hypot(config.start.xy[0] - robotXY[0], config.start.xy[1] - robotXY[1]) > 0.15;
+  if (showStart) drawMarker(config.start.xy, "", "#24a148", 5, mapCtx, mapCanvas, bounds);
+  drawMarker(config.target, "", "#da1e28", 5, mapCtx, mapCanvas, bounds);
+  drawMarker(robotXY, "", "#003f4a", 6, mapCtx, mapCanvas, bounds);
+  const robotYaw = realtimeRunning && currentFrame?.robot_yaw_deg != null
+    ? currentFrame.robot_yaw_deg
+    : config.start.yaw_deg;
+  drawHeadingArrow(robotXY, robotYaw, "#003f4a", 0.35, mapCtx, mapCanvas, bounds);
+  mapCtx.restore();
+}
+
 function depthColor(value) {
   if (value <= 0) return [10, 12, 20];
   const t = clamp(value / 255, 0, 1);
@@ -485,20 +652,23 @@ function syncControlsLayout() {
 function drawRealtimeFrame(frame) {
   currentFrame = frame;
   drawU8Canvas(depthCanvas, depthCtx, frame.depth_u8);
+  if (config?.map_info) updateLabViewBounds(frame.robot_xy);
   drawScene();
+  drawPerceptionMap();
 }
 
 function refreshFields() {
   const obj = selectedObject();
-  const cam = config.camera || (config.camera = {});
-  fields.targetX.value = config.target[0];
-  fields.targetY.value = config.target[1];
-  fields.camWidth.value = cam.width ?? CAM_DEFAULTS.width;
-  fields.camHeight.value = cam.image_height ?? cam.height ?? CAM_DEFAULTS.image_height;
-  fields.camFx.value = cam.fx ?? CAM_DEFAULTS.fx;
-  fields.camFy.value = cam.fy ?? CAM_DEFAULTS.fy;
-  fields.camMaxRange.value = cam.max_range ?? CAM_DEFAULTS.max_range;
-  fields.camMountHeight.value = cam.mount_height ?? CAM_DEFAULTS.mount_height;
+  config.start = config.start || { xy: [0, 0], yaw_deg: 0 };
+  if (config.robot?.name) fields.robotPreset.value = config.robot.name;
+  if (config.map_name) fields.mapSelect.value = config.map_name;
+  else if (config.map_path) {
+    const match = mapCatalog.find((entry) => entry.path === config.map_path);
+    fields.mapSelect.value = match?.name || "";
+  } else {
+    fields.mapSelect.value = "";
+  }
+  writeBoundFields();
   if (obj) {
     fields.objectName.value = obj.name;
     fields.objectX.value = obj.center[0];
@@ -510,20 +680,22 @@ function refreshFields() {
   fields.configText.value = JSON.stringify(config, null, 2);
   fields.robotSummary.innerHTML = robotSummaryHtml();
   fields.cameraSummary.innerHTML = cameraSummaryHtml();
+  fields.mapSummary.innerHTML = mapSummaryHtml();
+  if (config.map_info && !realtimeRunning) updateLabViewBounds(config.start?.xy);
   drawScene();
+  drawPerceptionMap();
 }
 
-function applyFieldChanges() {
+function syncConfigFromFields() {
   const obj = selectedObject();
-  const cam = config.camera || (config.camera = {});
-  config.target[0] = Number(fields.targetX.value);
-  config.target[1] = Number(fields.targetY.value);
-  cam.width = num(fields.camWidth, CAM_DEFAULTS.width, 16, true);
-  cam.image_height = num(fields.camHeight, CAM_DEFAULTS.image_height, 16, true);
-  cam.fx = num(fields.camFx, CAM_DEFAULTS.fx, 1);
-  cam.fy = num(fields.camFy, CAM_DEFAULTS.fy, 1);
-  cam.max_range = num(fields.camMaxRange, CAM_DEFAULTS.max_range, 0.5);
-  cam.mount_height = num(fields.camMountHeight, CAM_DEFAULTS.mount_height, 0.05);
+  config.start = config.start || { xy: [0, 0], yaw_deg: 0 };
+  config.map_name = fields.mapSelect.value.trim() || null;
+  config.map_path = mapCatalog.find((entry) => entry.name === config.map_name)?.path || config.map_path || null;
+  readBoundFields();
+  if (config.robot) {
+    config.robot.name = fields.robotPreset.value || config.robot.name || "go2";
+    config.obstacle = structuredClone(config.robot.obstacle || {});
+  }
   if (obj) {
     obj.name = fields.objectName.value || obj.name;
     obj.center[0] = Number(fields.objectX.value);
@@ -532,12 +704,70 @@ function applyFieldChanges() {
     obj.size[1] = Number(fields.objectSY.value);
     obj.size[2] = Number(fields.objectSZ.value);
   }
+}
+
+function applyFieldChanges() {
+  syncConfigFromFields();
   refreshFields();
 }
 
-function hitTestTarget(px, py) {
-  const [tpx, tpy] = worldToCanvas(config.target[0], config.target[1]);
+function syncStartFieldsFromFrame(frame) {
+  config.start.xy = frame.next_start.xy;
+  config.start.yaw_deg = frame.next_start.yaw_deg;
+  fields.startX.value = config.start.xy[0];
+  fields.startY.value = config.start.xy[1];
+  fields.startYaw.value = config.start.yaw_deg;
+}
+
+async function pushConfigToServer(reset = false) {
+  syncConfigFromFields();
+  const response = await fetch("/api/update-config", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ config, reset }),
+  });
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.detail || "Config update failed");
+  return data;
+}
+
+function robotDragXY() {
+  if (realtimeRunning && currentFrame?.robot_xy) return currentFrame.robot_xy;
+  return config.start.xy;
+}
+
+function labBottomRightAddXY() {
+  const pad = 0.5;
+  const b = sceneBounds;
+  // Lab view: screen right = +Y, screen bottom = low X.
+  return [Number((b.xMin + pad).toFixed(2)), Number((b.yMax - pad).toFixed(2))];
+}
+
+function stopRealtimeForEdit(message = "Realtime stopped (editing)") {
+  if (!realtimeRunning) return;
+  stopRealtime();
+  statusEl.textContent = message;
+}
+
+function editScene() {
+  stopRealtimeForEdit();
+  applyFieldChanges();
+}
+
+function hitTestTarget(px, py, targetCanvas = canvas, bounds = sceneBounds) {
+  const [tpx, tpy] = worldToCanvas(config.target[0], config.target[1], targetCanvas, bounds);
   return Math.hypot(px - tpx, py - tpy) <= 14;
+}
+
+function hitTestStart(px, py, targetCanvas = canvas, bounds = sceneBounds) {
+  const [sx, sy] = worldToCanvas(config.start.xy[0], config.start.xy[1], targetCanvas, bounds);
+  return Math.hypot(px - sx, py - sy) <= 14;
+}
+
+function hitTestRobot(px, py, targetCanvas = canvas, bounds = sceneBounds) {
+  const xy = robotDragXY();
+  const [rx, ry] = worldToCanvas(xy[0], xy[1], targetCanvas, bounds);
+  return Math.hypot(px - rx, py - ry) <= 14;
 }
 
 function hitTestObject(px, py) {
@@ -572,11 +802,6 @@ function scheduleRealtimeTick(delay = REALTIME_TICK_DELAY_MS) {
   }, delay);
 }
 
-function noteSceneEdited(resetOccupancy = false, immediate = true) {
-  if (resetOccupancy) realtimeNeedsReset = true;
-  if (realtimeRunning && immediate) scheduleRealtimeTick(0);
-}
-
 async function realtimeTick() {
   if (!realtimeRunning) return;
   if (realtimeBusy) {
@@ -585,23 +810,15 @@ async function realtimeTick() {
   }
   realtimeBusy = true;
   realtimePending = false;
-  applyFieldChanges();
   try {
-    const response = await fetch("/api/realtime-step", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ config, reset: realtimeNeedsReset }),
-    });
-    realtimeNeedsReset = false;
+    const response = await fetch("/api/sim-state");
     const data = await response.json();
-    if (!response.ok) throw new Error(data.detail || "Realtime step failed");
+    if (!response.ok) throw new Error(data.detail || "Sim state failed");
     const frame = data.frame;
-    config.start.xy = frame.next_start.xy;
-    config.start.yaw_deg = frame.next_start.yaw_deg;
+    syncStartFieldsFromFrame(frame);
     realtimePath.push(frame.robot_xy);
     if (realtimePath.length > 300) realtimePath = realtimePath.slice(-300);
     drawRealtimeFrame(frame);
-    refreshFields();
     statusEl.textContent = "Realtime running";
   } catch (error) {
     statusEl.textContent = "Realtime error";
@@ -623,6 +840,7 @@ async function toggleRealtime() {
   try {
     const response = await fetch("/api/start-ros-loop", { method: "POST" });
     if (!response.ok) throw new Error((await response.json()).detail || "Failed to start ROS loop");
+    await pushConfigToServer(true);
   } catch (error) {
     statusEl.textContent = "ROS start error";
     return;
@@ -630,7 +848,6 @@ async function toggleRealtime() {
   realtimeRunning = true;
   realtimeBusy = false;
   realtimePending = false;
-  realtimeNeedsReset = true;
   realtimePath = [config.start.xy.slice()];
   currentFrame = null;
   realtimeButton.textContent = "Stop";
@@ -639,49 +856,174 @@ async function toggleRealtime() {
   realtimeTick();
 }
 
+async function fetchRobotPresets() {
+  try {
+    const data = await (await fetch("/api/robot-presets")).json();
+    robotPresets = Object.fromEntries((data.presets || []).map((entry) => [entry.name, entry.robot]));
+    const select = fields.robotPreset;
+    select.innerHTML = "";
+    (data.presets || []).forEach((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.name;
+      option.textContent = entry.name.toUpperCase();
+      select.appendChild(option);
+    });
+    if (config?.robot?.name && robotPresets[config.robot.name]) {
+      select.value = config.robot.name;
+    }
+  } catch (error) {
+    statusEl.textContent = "Robot preset load error";
+  }
+}
+
+async function fetchMapCatalog() {
+  if (!fields.mapSelect) {
+    fields.mapSummary.innerHTML = "Map selector missing — hard refresh the page (Ctrl+Shift+R).";
+    return;
+  }
+  try {
+    const response = await fetch("/api/map-catalog");
+    let data = null;
+    try {
+      data = await response.json();
+    } catch {
+      throw new Error(`Invalid response (HTTP ${response.status})`);
+    }
+    if (!response.ok) {
+      throw new Error(data?.detail || `HTTP ${response.status}`);
+    }
+    mapCatalog = data.maps || [];
+    const select = fields.mapSelect;
+    const current = select.value;
+    select.innerHTML = '<option value="">— select a map —</option>';
+    mapCatalog.forEach((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.name;
+      option.textContent = entry.name;
+      select.appendChild(option);
+    });
+    if (current && mapCatalog.some((entry) => entry.name === current)) {
+      select.value = current;
+    } else if (config?.map_name && mapCatalog.some((entry) => entry.name === config.map_name)) {
+      select.value = config.map_name;
+    }
+    if (!data.maps_root_exists) {
+      fields.mapSummary.innerHTML = `Maps folder missing: <code>${data.maps_root}</code>`;
+    } else if (!mapCatalog.length) {
+      fields.mapSummary.innerHTML = `No loadable maps under <code>${data.maps_root}</code> (need <code>occupancy_grid.npy</code> in each subfolder).`;
+    } else if (!config?.map_info) {
+      fields.mapSummary.innerHTML = `${mapCatalog.length} map(s) available under <code>${data.maps_root}</code>.`;
+    }
+  } catch (error) {
+    fields.mapSummary.innerHTML = `Map catalog failed: ${error.message}. Restart <code>./scripts/run_ros_planning_web.sh</code> and hard-refresh.`;
+    statusEl.textContent = "Map catalog error";
+  }
+}
+
 async function loadDefault() {
   stopRealtime();
   config = await (await fetch("/api/default-config")).json();
+  sceneBounds = { ...DEFAULT_SCENE };
+  config.map_info = null;
+  config.map_background = null;
+  setMapBackground(null);
   selectedIndex = 0;
   currentFrame = null;
   realtimePath = [];
+  fields.mapSelect.value = "";
   refreshFields();
   statusEl.textContent = "Ready";
+}
+
+async function loadMapFromSelection() {
+  const mapName = fields.mapSelect.value.trim();
+  if (!mapName) {
+    statusEl.textContent = "Select a map first";
+    return;
+  }
+  stopRealtime();
+  applyFieldChanges();
+  statusEl.textContent = "Loading map...";
+  try {
+    const response = await fetch("/api/load-map", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        map_name: mapName,
+        start_xy: null,
+        yaw_deg: Number(fields.startYaw.value) || 0,
+      }),
+    });
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.detail || "Map load failed");
+    config = data.config;
+    config.map_info = data.map_info;
+    config.map_background = data.map_background;
+    setMapBackground(data.map_background);
+    updateLabViewBounds(config.start.xy);
+    selectedIndex = config.objects?.length ? Math.min(selectedIndex, config.objects.length - 1) : 0;
+    currentFrame = null;
+    realtimePath = [config.start.xy.slice()];
+    refreshFields();
+    statusEl.textContent = `Map loaded: ${mapName}`;
+  } catch (error) {
+    statusEl.textContent = `Map error: ${error.message}`;
+  }
 }
 
 function selectObject(index) {
   selectedIndex = index;
   refreshFields();
-  noteSceneEdited(true, true);
 }
 
-editableFields.forEach((field) => {
-  field.addEventListener("change", () => {
-    applyFieldChanges();
-    noteSceneEdited(true, true);
-  });
+boundInputs().forEach((el) => {
+  el.addEventListener("change", editScene);
+});
+[fields.objectName, fields.objectX, fields.objectY, fields.objectSX, fields.objectSY, fields.objectSZ].forEach((el) => {
+  el.addEventListener("change", editScene);
+});
+
+fields.robotPreset.addEventListener("change", () => {
+  const preset = robotPresets[fields.robotPreset.value];
+  if (preset) {
+    config.robot = structuredClone(preset);
+    config.obstacle = structuredClone(preset.obstacle || {});
+  }
+  stopRealtimeForEdit();
+  refreshFields();
 });
 
 realtimeButton.addEventListener("click", toggleRealtime);
 controlsToggle.addEventListener("click", () => setControlsVisible(controlsPanel.classList.contains("is-hidden")));
 $("resetScene").addEventListener("click", loadDefault);
+$("loadMap").addEventListener("click", loadMapFromSelection);
 $("applyJson").addEventListener("click", () => {
   const next = JSON.parse(fields.configText.value);
-  next.robot = config.robot;
-  next.obstacle = config.obstacle;
+  if (!next.obstacle) next.obstacle = config.obstacle;
   config = next;
-  selectedIndex = Math.min(selectedIndex, config.objects.length - 1);
+  if (!config.robot) config.robot = structuredClone(robotPresets.go2 || {});
+  if (config.map_info) updateLabViewBounds(config.start?.xy);
+  else sceneBounds = { ...DEFAULT_SCENE };
+  selectedIndex = config.objects?.length ? Math.min(selectedIndex, config.objects.length - 1) : 0;
   currentFrame = null;
   refreshFields();
-  noteSceneEdited(true, true);
 });
 $("addBox").addEventListener("click", () => {
-  config.objects.push({ name: `box_${config.objects.length + 1}`, kind: "box", center: [2.0, 0.0, 0.35], size: [0.5, 0.5, 0.8] });
+  const [x, y] = labBottomRightAddXY();
+  const z = Number(config.camera?.mount_height ?? 0.45) * 0.75;
+  stopRealtimeForEdit();
+  config.objects.push({
+    name: `box_${config.objects.length + 1}`,
+    kind: "box",
+    center: [x, y, z],
+    size: [0.5, 0.5, 0.8],
+  });
   selectObject(config.objects.length - 1);
 });
 $("duplicateObject").addEventListener("click", () => {
   const obj = selectedObject();
   if (!obj) return;
+  stopRealtimeForEdit();
   const copy = structuredClone(obj);
   copy.name = `${copy.name}_copy`;
   copy.center[1] += 0.4;
@@ -690,55 +1032,118 @@ $("duplicateObject").addEventListener("click", () => {
 });
 $("deleteObject").addEventListener("click", () => {
   if (!config.objects.length) return;
+  stopRealtimeForEdit();
   config.objects.splice(selectedIndex, 1);
   selectObject(Math.max(0, selectedIndex - 1));
 });
 
-canvas.addEventListener("pointerdown", (event) => {
-  const [px, py] = pointerPos(event);
-  if (hitTestTarget(px, py)) {
-    const [wx, wy] = canvasToWorld(px, py);
-    dragState = { type: "target", dx: config.target[0] - wx, dy: config.target[1] - wy };
-    canvas.setPointerCapture(event.pointerId);
-    return;
+function beginDrag(type, wx, wy, event, sourceCanvas) {
+  let ox;
+  let oy;
+  if (type === "target") {
+    ox = config.target[0];
+    oy = config.target[1];
+  } else if (realtimeRunning && currentFrame?.robot_xy) {
+    [ox, oy] = currentFrame.robot_xy;
+  } else {
+    [ox, oy] = config.start.xy;
   }
-  const hit = hitTestObject(px, py);
-  if (hit < 0) return;
-  selectedIndex = hit;
-  const [wx, wy] = canvasToWorld(px, py);
-  const obj = selectedObject();
-  dragState = { type: "object", dx: obj.center[0] - wx, dy: obj.center[1] - wy };
-  canvas.setPointerCapture(event.pointerId);
-  refreshFields();
-});
+  dragState = { type, dx: ox - wx, dy: oy - wy, sourceCanvas };
+  sourceCanvas.setPointerCapture(event.pointerId);
+}
 
-canvas.addEventListener("pointermove", (event) => {
+function applyDragMove(wx, wy) {
   if (!dragState) return;
-  const [px, py] = pointerPos(event);
-  const [wx, wy] = canvasToWorld(px, py);
   if (dragState.type === "target") {
     config.target[0] = Number((wx + dragState.dx).toFixed(2));
     config.target[1] = Number((wy + dragState.dy).toFixed(2));
-    noteSceneEdited(false, true);
   } else {
+    config.start.xy[0] = Number((wx + dragState.dx).toFixed(2));
+    config.start.xy[1] = Number((wy + dragState.dy).toFixed(2));
+    if (currentFrame?.robot_xy) currentFrame.robot_xy = config.start.xy.slice();
+    if (config.map_info) updateLabViewBounds(config.start.xy);
+  }
+  refreshFields();
+}
+
+function handleCanvasPointerDown(event, targetCanvas, bounds) {
+  if (!config) return;
+  const [px, py] = pointerPosOn(event, targetCanvas);
+  if (hitTestTarget(px, py, targetCanvas, bounds)) {
+    stopRealtimeForEdit();
+    const [wx, wy] = canvasToWorld(px, py, targetCanvas, bounds);
+    beginDrag("target", wx, wy, event, targetCanvas);
+    return;
+  }
+  if (hitTestRobot(px, py, targetCanvas, bounds)) {
+    stopRealtimeForEdit();
+    const [wx, wy] = canvasToWorld(px, py, targetCanvas, bounds);
+    beginDrag("start", wx, wy, event, targetCanvas);
+    return;
+  }
+  if (targetCanvas === canvas && hitTestStart(px, py, targetCanvas, bounds)) {
+    stopRealtimeForEdit();
+    const [wx, wy] = canvasToWorld(px, py, targetCanvas, bounds);
+    beginDrag("start", wx, wy, event, targetCanvas);
+    return;
+  }
+  if (targetCanvas === canvas) {
+    const hit = hitTestObject(px, py);
+    if (hit < 0) return;
+    stopRealtimeForEdit();
+    selectedIndex = hit;
+    const [wx, wy] = canvasToWorld(px, py, targetCanvas, bounds);
+    const obj = selectedObject();
+    dragState = { type: "object", dx: obj.center[0] - wx, dy: obj.center[1] - wy, sourceCanvas: targetCanvas };
+    targetCanvas.setPointerCapture(event.pointerId);
+    refreshFields();
+  }
+}
+
+function handleCanvasPointerMove(event, targetCanvas, bounds) {
+  if (!dragState || dragState.sourceCanvas !== targetCanvas) return;
+  const [px, py] = pointerPosOn(event, targetCanvas);
+  const [wx, wy] = canvasToWorld(px, py, targetCanvas, bounds);
+  if (dragState.type === "object") {
     const obj = selectedObject();
     obj.center[0] = Number((wx + dragState.dx).toFixed(2));
     obj.center[1] = Number((wy + dragState.dy).toFixed(2));
-    noteSceneEdited(true, true);
+  } else {
+    applyDragMove(wx, wy);
   }
   refreshFields();
-});
+}
 
-canvas.addEventListener("pointerup", () => {
-  dragState = null;
-});
+function handleCanvasPointerUp(event, targetCanvas) {
+  if (dragState?.sourceCanvas === targetCanvas) dragState = null;
+}
 
-loadDefault();
+canvas.addEventListener("pointerdown", (event) => handleCanvasPointerDown(event, canvas, sceneBounds));
+canvas.addEventListener("pointermove", (event) => handleCanvasPointerMove(event, canvas, sceneBounds));
+canvas.addEventListener("pointerup", (event) => handleCanvasPointerUp(event, canvas));
+canvas.addEventListener("pointercancel", (event) => handleCanvasPointerUp(event, canvas));
+
+mapCanvas.addEventListener("pointerdown", (event) => {
+  if (!config?.map_info && !currentFrame?.map_info) return;
+  handleCanvasPointerDown(event, mapCanvas, perceptionBounds());
+});
+mapCanvas.addEventListener("pointermove", (event) => handleCanvasPointerMove(event, mapCanvas, perceptionBounds()));
+mapCanvas.addEventListener("pointerup", (event) => handleCanvasPointerUp(event, mapCanvas));
+mapCanvas.addEventListener("pointercancel", (event) => handleCanvasPointerUp(event, mapCanvas));
+
+loadDefault().then(async () => {
+  await Promise.all([fetchMapCatalog(), fetchRobotPresets()]);
+});
 syncControlsLayout();
 window.addEventListener("resize", () => {
   syncControlsLayout();
   drawScene();
+  drawPerceptionMap();
 });
 if (typeof ResizeObserver !== "undefined") {
-  new ResizeObserver(() => drawScene()).observe(canvas);
+  new ResizeObserver(() => {
+    drawScene();
+    drawPerceptionMap();
+  }).observe(canvas);
+  new ResizeObserver(() => drawPerceptionMap()).observe(mapCanvas);
 }

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -30,22 +30,60 @@
 
       <section class="panel controls" id="controlsPanel">
         <h2>Robot</h2>
-        <p class="robot-note">Robot geometry and planner safety settings are read from <code>planning_node.py</code>.</p>
+        <p class="robot-note">Presets from <code>robot_specs.py</code>. Switching type restarts planning.</p>
+        <label class="map-select-label">Preset
+          <select id="robotPreset"></select>
+        </label>
+        <label>Shape
+          <select data-bind="robot.shape">
+            <option value="square">square</option>
+            <option value="circle">circle</option>
+          </select>
+        </label>
+        <label>Length (m) <input data-bind="robot.length" type="number" step="0.05" min="0.05" /></label>
+        <label>Width (m) <input data-bind="robot.width" type="number" step="0.05" min="0.05" /></label>
+        <label>Radius (m) <input data-bind="robot.radius" type="number" step="0.05" min="0.05" /></label>
+        <label>Camera X (m) <input data-bind="robot.camera_x" type="number" step="0.01" /></label>
+        <label>Camera Y (m) <input data-bind="robot.camera_y" type="number" step="0.01" /></label>
+        <label>Control X (m) <input data-bind="robot.control_x" type="number" step="0.01" /></label>
+        <label>Control Y (m) <input data-bind="robot.control_y" type="number" step="0.01" /></label>
+        <label>Safety radius (m) <input data-bind="robot.safety_radius" type="number" step="0.01" min="0" /></label>
+        <label>Max linear (m/s) <input data-bind="robot.max_linear_vel" type="number" step="0.05" min="0.05" /></label>
+        <label>Max angular (rad/s) <input data-bind="robot.max_angular_vel" type="number" step="0.05" min="0.05" /></label>
+        <label>Z-band bottom (m) <input data-bind="robot.obstacle.robot_z_bottom" type="number" step="0.05" /></label>
+        <label>Z-band top (m) <input data-bind="robot.obstacle.robot_z_top" type="number" step="0.05" /></label>
+        <label>Dilation (cells) <input data-bind="robot.obstacle.dilation_cells" type="number" step="1" min="0" /></label>
         <div class="robot-summary" id="robotSummary"></div>
 
         <h2>Camera</h2>
-        <p class="robot-note">Pinhole intrinsics used for synthetic depth and <code>CameraInfo</code>. FOV is derived from width/height and fx/fy.</p>
-        <label>Width <input id="camWidth" type="number" step="1" min="16" /></label>
-        <label>Height <input id="camHeight" type="number" step="1" min="16" /></label>
-        <label>fx <input id="camFx" type="number" step="1" min="1" /></label>
-        <label>fy <input id="camFy" type="number" step="1" min="1" /></label>
-        <label>Max range (m) <input id="camMaxRange" type="number" step="0.1" min="0.5" /></label>
-        <label>Mount height (m) <input id="camMountHeight" type="number" step="0.01" min="0.05" /></label>
+        <p class="robot-note">Pinhole intrinsics for synthetic depth. FOV is derived from width/height and fx/fy.</p>
+        <label>Width <input data-bind="camera.width" type="number" step="1" min="16" /></label>
+        <label>Height <input data-bind="camera.image_height" type="number" step="1" min="16" /></label>
+        <label>fx <input data-bind="camera.fx" type="number" step="1" min="1" /></label>
+        <label>fy <input data-bind="camera.fy" type="number" step="1" min="1" /></label>
+        <label>Max range (m) <input data-bind="camera.max_range" type="number" step="0.1" min="0.5" /></label>
+        <label>Mount height (m) <input data-bind="camera.mount_height" type="number" step="0.01" min="0.05" /></label>
         <div class="robot-summary" id="cameraSummary"></div>
 
+        <h2>Map</h2>
+        <p class="robot-note">Choose a map from <code>/tinynav/tinynav_db/maps</code>. Coordinates use the map world frame.</p>
+        <label class="map-select-label">Map
+          <select id="mapSelect">
+            <option value="">— select a map —</option>
+          </select>
+        </label>
+        <button id="loadMap" class="primary">Load Map</button>
+        <div class="robot-summary" id="mapSummary"></div>
+
+        <h2>Start Pose</h2>
+        <p class="robot-note">Fixed initial pose in map world frame (replaces relocalization). Drag the green control marker on the scene.</p>
+        <label>Start X <input id="startX" data-bind="start.xy.0" type="number" step="0.1" /></label>
+        <label>Start Y <input id="startY" data-bind="start.xy.1" type="number" step="0.1" /></label>
+        <label>Start yaw (deg) <input id="startYaw" data-bind="start.yaw_deg" type="number" step="1" /></label>
+
         <h2>Target</h2>
-        <label>Target X <input id="targetX" type="number" step="0.1" /></label>
-        <label>Target Y <input id="targetY" type="number" step="0.1" /></label>
+        <label>Target X <input id="targetX" data-bind="target.0" type="number" step="0.1" /></label>
+        <label>Target Y <input id="targetY" data-bind="target.1" type="number" step="0.1" /></label>
 
         <h2>Selected Object</h2>
         <label>Name <input id="objectName" type="text" /></label>
@@ -71,6 +109,10 @@
           <summary>Perception / Planning Diagnostics</summary>
           <div class="image-grid">
             <div>
+              <h3>Map Overview</h3>
+              <canvas id="mapCanvas" width="320" height="240" aria-label="Map overview"></canvas>
+            </div>
+            <div>
               <h3>Depth</h3>
               <canvas id="depthCanvas" width="320" height="200" aria-label="Depth image"></canvas>
               <div class="depth-legend" aria-hidden="true">
@@ -83,6 +125,6 @@
         </details>
       </section>
     </main>
-    <script src="/static/app.js"></script>
+    <script src="/static/app.js?v=20260820m"></script>
   </body>
 </html>

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -169,7 +169,12 @@ label {
   color: #43505c;
 }
 
+label.map-select-label {
+  grid-template-columns: 1fr;
+}
+
 input,
+select,
 textarea {
   width: 100%;
   border: 1px solid #c7d1da;
@@ -206,7 +211,7 @@ textarea {
 
 .image-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 10px;
   margin-bottom: 10px;
 }
@@ -223,9 +228,22 @@ textarea {
   display: block;
   border: 1px solid #d8e0e7;
   border-radius: 6px;
-  background: #0b1020;
+  background: #fbfcfd;
   image-rendering: pixelated;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+#mapCanvas {
+  aspect-ratio: 4 / 3;
+  cursor: grab;
+}
+
+#mapCanvas:active {
+  cursor: grabbing;
+}
+
+#depthCanvas {
+  background: #0b1020;
 }
 
 .depth-legend {

--- a/tool/simulator/planning_scene.py
+++ b/tool/simulator/planning_scene.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import numpy as np
 
+from tool.simulator.map_volume import MapVolume, raycast_map
+
 
 @dataclass
 class SimObject:
@@ -70,8 +72,13 @@ def make_camera_pose_from_config(
     )
 
 
-def render_depth(objects: list[SimObject], T_cam_to_world: np.ndarray, cam: dict[str, Any]) -> np.ndarray:
-    """Pinhole depth with optional ground plane (default z=0)."""
+def render_depth(
+    objects: list[SimObject],
+    T_cam_to_world: np.ndarray,
+    cam: dict[str, Any],
+    map_volume: MapVolume | None = None,
+) -> np.ndarray:
+    """Pinhole depth with optional ground plane (default z=0) and map voxels."""
     width, height = cam_size(cam)
     fx, fy = float(cam["fx"]), float(cam["fy"])
     max_range = float(cam["max_range"])
@@ -92,6 +99,10 @@ def render_depth(objects: list[SimObject], T_cam_to_world: np.ndarray, cam: dict
     t_ground[down] = (ground_z - origin[2]) / dz[down]
     hit_ground = down & (t_ground > 1e-4) & (t_ground <= max_range)
     best = np.where(hit_ground, t_ground, best)
+
+    if map_volume is not None:
+        t_map = raycast_map(origin, rays, z_cam, max_range, map_volume)
+        best = np.where(np.isfinite(t_map) & (t_map < best), t_map, best)
 
     for obj in objects:
         box_min, box_max = obj.bounds

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -8,6 +8,7 @@ real planning_node + cmd_vel_control loop.
 
 from __future__ import annotations
 
+import base64
 import copy
 import math
 import os
@@ -18,6 +19,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+import cv2
 import numpy as np
 import rclpy
 from cv_bridge import CvBridge
@@ -35,9 +37,10 @@ from sensor_msgs.msg import CameraInfo, Image, PointCloud
 from std_msgs.msg import Bool
 
 from tinynav.core.robot_specs import GO2_CONFIG
+from tinynav.core import robot_specs as robot_specs_mod
+from tool.simulator.map_volume import MapVolume
 from tool.simulator.planning_scene import (
     SimObject,
-    box,
     cam_size,
     image_u8_payload,
     make_camera_pose_from_config,
@@ -46,36 +49,52 @@ from tool.simulator.planning_scene import (
 
 ROOT = Path(__file__).resolve().parent
 STATIC_DIR = ROOT / "offline_planning_web"
-PLANNING_ROBOT_DEFAULT = {k: v for k, v in asdict(GO2_CONFIG).items() if k != "obstacle"}
-PLANNING_OBSTACLE_DEFAULT = asdict(GO2_CONFIG.obstacle)
+REPO_ROOT = ROOT.parents[1]
 
 
-def default_config() -> dict[str, Any]:
-    # Fences + ground plane give valid depth so free-space carving works when
-    # boxes move (planning core stays unchanged).
+def _default_tinynav_db_path() -> Path:
+    env = os.environ.get("TINYNAV_DB_PATH")
+    if env:
+        return Path(env).expanduser()
+    repo_db = REPO_ROOT / "tinynav_db"
+    if (repo_db / "maps").is_dir():
+        return repo_db
+    return Path("/tinynav/tinynav_db")
+
+
+MAPS_ROOT = _default_tinynav_db_path() / "maps"
+CAMERA_DEFAULTS = {
+    "width": 160,
+    "image_height": 100,
+    "fx": 80.0,
+    "fy": 50.0,
+    "max_range": 15.0,
+    "mount_height": 0.45,
+}
+ROBOT_PRESETS = {
+    name.removesuffix("_CONFIG").lower(): asdict(getattr(robot_specs_mod, name))
+    for name in dir(robot_specs_mod)
+    if name.endswith("_CONFIG") and name != "ROBOT_CONFIG"
+}
+
+
+def _robot_dict(name: str | None = None) -> dict[str, Any]:
+    key = (name or GO2_CONFIG.name).strip().lower()
+    return copy.deepcopy(ROBOT_PRESETS.get(key, asdict(GO2_CONFIG)))
+
+
+def default_config(robot_name: str | None = None) -> dict[str, Any]:
+    robot = _robot_dict(robot_name)
     return {
         "name": "ros_planning_sim",
-        "robot": copy.deepcopy(PLANNING_ROBOT_DEFAULT),
-        "camera": {
-            "width": 160,
-            "image_height": 100,
-            "fx": 80.0,
-            "fy": 25.0,
-            "max_range": 15.0,
-            "mount_height": 0.45,
-        },
+        "robot": robot,
+        "obstacle": copy.deepcopy(robot.get("obstacle") or {}),
+        "camera": copy.deepcopy(CAMERA_DEFAULTS),
         "start": {"xy": [0.0, 0.0], "yaw_deg": 0.0},
         "target": [4.0, 0.0, 0.0],
-        "obstacle": copy.deepcopy(PLANNING_OBSTACLE_DEFAULT),
-        "objects": [
-            box("fence_back", [-0.35, 0.0, 0.6], [0.2, 10.2, 1.2]),
-            box("fence_front", [9.35, 0.0, 0.6], [0.2, 10.2, 1.2]),
-            box("fence_left", [4.5, 5.05, 0.6], [10.0, 0.2, 1.2]),
-            box("fence_right", [4.5, -5.05, 0.6], [10.0, 0.2, 1.2]),
-            box("left_wall", [2.0, 1.0, 0.35], [3.2, 0.25, 1.3]),
-            box("right_wall", [2.0, -1.0, 0.35], [3.2, 0.25, 1.3]),
-            box("center_box", [1.65, 0.0, 0.25], [0.45, 0.55, 0.5]),
-        ],
+        "map_path": None,
+        "map_name": None,
+        "objects": [],
     }
 
 
@@ -100,12 +119,95 @@ def grid_payload(msg: OccupancyGrid, data_u8: np.ndarray) -> dict[str, Any]:
     }
 
 
+def rgb_payload(image: np.ndarray) -> dict[str, Any]:
+    rgb = np.ascontiguousarray(image, dtype=np.uint8)
+    h, w = rgb.shape[:2]
+    bgr = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+    ok, buf = cv2.imencode(".png", bgr)
+    if not ok:
+        raise RuntimeError("failed to encode map background PNG")
+    data_url = "data:image/png;base64," + base64.b64encode(buf.tobytes()).decode("ascii")
+    return {"width": int(w), "height": int(h), "mime": "image/png", "data_url": data_url}
+
+
+_MAP_CACHE: dict[str, MapVolume] = {}
+
+
+def load_map_volume(map_path: str | None) -> MapVolume | None:
+    if not map_path:
+        return None
+    path = str(Path(map_path).expanduser().resolve())
+    cached = _MAP_CACHE.get(path)
+    if cached is not None:
+        return cached
+    volume = MapVolume.load(path)
+    _MAP_CACHE[path] = volume
+    return volume
+
+
+def resolve_map_path(map_name: str | None = None, map_path: str | None = None) -> str:
+    if map_name:
+        candidate = (MAPS_ROOT / map_name).resolve()
+        if MAPS_ROOT.resolve() not in candidate.parents and candidate != MAPS_ROOT.resolve():
+            raise ValueError(f"Invalid map name: {map_name!r}")
+        if not candidate.is_dir():
+            raise FileNotFoundError(f"Map folder not found: {candidate}")
+        return str(candidate)
+    if map_path:
+        return str(Path(map_path).expanduser().resolve())
+    raise ValueError("map_name or map_path is required")
+
+
+def list_map_catalog() -> list[dict[str, Any]]:
+    root = MAPS_ROOT
+    if not root.is_dir():
+        return []
+    entries: list[dict[str, Any]] = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name.lower()):
+        if not child.is_dir():
+            continue
+        if not (child / "occupancy_grid.npy").is_file():
+            continue
+        entries.append({"name": child.name, "path": str(child.resolve())})
+    return entries
+
+
+def map_config_for_path(map_path: str, start_xy: list[float] | None = None, yaw_deg: float = 0.0) -> dict[str, Any]:
+    volume = load_map_volume(map_path)
+    if volume is None:
+        raise FileNotFoundError(f"Could not load map at {map_path}")
+    robot_name = None
+    camera = copy.deepcopy(CAMERA_DEFAULTS)
+    if SIM_NODE is not None:
+        robot_name = SIM_NODE.config.get("robot", {}).get("name")
+        camera = copy.deepcopy(SIM_NODE.config.get("camera") or camera)
+    config = default_config(robot_name)
+    config["camera"] = camera
+    if start_xy is None:
+        start_xy = list(volume.default_start_xy())
+    z = float(volume.origin[2])
+    config.update({
+        "name": Path(map_path).name,
+        "map_path": volume.map_path,
+        "map_name": Path(map_path).name,
+        "start": {"xy": [float(start_xy[0]), float(start_xy[1])], "yaw_deg": float(yaw_deg)},
+        "target": [float(start_xy[0]) + 2.0, float(start_xy[1]), z],
+        "objects": [],
+    })
+    config["camera"]["ground_z"] = z
+    return config
+
+
 class RosPlanningSimNode(Node):
     def __init__(self):
         super().__init__("tinynav_ros_planning_sim")
         self.bridge = CvBridge()
         self.lock = threading.RLock()
         self.config = default_config()
+        self.map_volume: MapVolume | None = None
+        self.map_info: dict[str, Any] | None = None
+        self.map_background: dict[str, Any] | None = None
+        self._apply_map_from_config(self.config)
         self.control_xy = list(self.config["start"]["xy"])
         self.yaw_deg = float(self.config["start"]["yaw_deg"])
         self.last_update = time.monotonic()
@@ -133,11 +235,39 @@ class RosPlanningSimNode(Node):
         self.create_subscription(OccupancyGrid, "/planning/occupancy_grid", self.esdf_callback, 10)
         self.create_timer(1.0 / 8.0, self.tick)
 
+    def _apply_map_from_config(self, config: dict[str, Any]) -> None:
+        map_path = config.get("map_path")
+        if not map_path:
+            self.map_volume = None
+            self.map_info = None
+            self.map_background = None
+            return
+        try:
+            volume = load_map_volume(str(map_path))
+        except (FileNotFoundError, ValueError, OSError) as exc:
+            self.get_logger().error(f"Map load failed: {exc}")
+            self.map_volume = None
+            self.map_info = None
+            self.map_background = None
+            return
+        self.map_volume = volume
+        self.map_info = volume.info().as_dict()
+        self.map_background = rgb_payload(volume.background_rgb())
+        config["map_path"] = volume.map_path
+        cam = config.setdefault("camera", {})
+        cam["ground_z"] = float(volume.origin[2])
+
     def set_config(self, config: dict[str, Any], reset: bool = False) -> None:
         with self.lock:
+            prev_map = self.config.get("map_path")
             self.config = copy.deepcopy(config)
-            self.config["robot"] = copy.deepcopy(PLANNING_ROBOT_DEFAULT)
-            self.config["obstacle"] = copy.deepcopy(PLANNING_OBSTACLE_DEFAULT)
+            robot = self.config.get("robot")
+            if not isinstance(robot, dict):
+                robot = _robot_dict()
+                self.config["robot"] = robot
+            self.config["obstacle"] = copy.deepcopy(robot.get("obstacle") or {})
+            if self.config.get("map_path") != prev_map:
+                self._apply_map_from_config(self.config)
             if reset:
                 self.control_xy = list(self.config.get("start", {}).get("xy", [0.0, 0.0]))
                 self.yaw_deg = float(self.config.get("start", {}).get("yaw_deg", 0.0))
@@ -216,10 +346,11 @@ class RosPlanningSimNode(Node):
             config.setdefault("start", {})["xy"] = [float(self.control_xy[0]), float(self.control_xy[1])]
             config["start"]["yaw_deg"] = float(self.yaw_deg)
             yaw_deg = float(self.yaw_deg)
+            map_volume = self.map_volume
 
         objects = [SimObject(**obj) for obj in config.get("objects", [])]
         T_cam = make_camera_pose_from_config(config["start"]["xy"], yaw_deg, config["robot"], config["camera"])
-        depth = render_depth(objects, T_cam, config["camera"])
+        depth = render_depth(objects, T_cam, config["camera"], map_volume=map_volume)
         with self.lock:
             self.last_depth = depth
 
@@ -257,18 +388,30 @@ class RunRequest(BaseModel):
     reset: bool | None = None
 
 
+class LoadMapRequest(BaseModel):
+    map_name: str | None = None
+    map_path: str | None = None
+    start_xy: list[float] | None = None
+    yaw_deg: float = 0.0
+
+
 app = FastAPI(title="TinyNav ROS Planning Simulator")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 SIM_NODE: RosPlanningSimNode | None = None
 EXECUTOR: MultiThreadedExecutor | None = None
 PROCS: list[subprocess.Popen] = []
-REPO_ROOT = ROOT.parents[1]
 CHILD_SCRIPTS = (
     "tinynav/core/planning_node.py",
     "tinynav/platforms/cmd_vel_control.py",
 )
 _LAST_PLANNING_RESET = 0.0
 _PLANNING_RESET_COOLDOWN_S = 1.0
+
+
+def _require_sim() -> RosPlanningSimNode:
+    if SIM_NODE is None:
+        raise HTTPException(status_code=503, detail="ROS simulator is not ready")
+    return SIM_NODE
 
 
 def start_ros() -> None:
@@ -282,10 +425,17 @@ def start_ros() -> None:
     threading.Thread(target=EXECUTOR.spin, daemon=True).start()
 
 
+def _active_robot_type() -> str:
+    if SIM_NODE is None:
+        return "go2"
+    return str(SIM_NODE.config.get("robot", {}).get("name", "go2")).strip().lower()
+
+
 def _child_env() -> dict[str, str]:
     env = os.environ.copy()
     for key in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
         env.setdefault(key, "1")
+    env["ROBOT_TYPE"] = _active_robot_type()
     return env
 
 
@@ -372,18 +522,67 @@ def get_default_config() -> dict[str, Any]:
     return default_config()
 
 
-@app.post("/api/realtime-step")
-def realtime_step(request: RunRequest) -> dict[str, Any]:
-    if SIM_NODE is None:
-        raise HTTPException(status_code=503, detail="ROS simulator is not ready")
+@app.get("/api/map-catalog")
+def map_catalog() -> dict[str, Any]:
+    root = MAPS_ROOT
+    maps = list_map_catalog()
+    return {
+        "maps_root": str(root.resolve() if root.exists() else root),
+        "maps_root_exists": root.is_dir(),
+        "maps": maps,
+    }
+
+
+@app.post("/api/load-map")
+def load_map(request: LoadMapRequest) -> dict[str, Any]:
+    try:
+        resolved = resolve_map_path(request.map_name, request.map_path)
+        config = map_config_for_path(resolved, request.start_xy, request.yaw_deg)
+    except (FileNotFoundError, ValueError, OSError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if SIM_NODE is not None:
+        SIM_NODE.set_config(config, reset=True)
+    volume = load_map_volume(config["map_path"])
+    return {
+        "config": config,
+        "map_info": volume.info().as_dict() if volume else None,
+        "map_background": rgb_payload(volume.background_rgb()) if volume else None,
+    }
+
+
+@app.get("/api/map-info")
+def map_info(map_path: str) -> dict[str, Any]:
+    try:
+        volume = load_map_volume(map_path)
+    except (FileNotFoundError, ValueError, OSError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if volume is None:
+        raise HTTPException(status_code=400, detail="map_path is required")
+    return {
+        "map_info": volume.info().as_dict(),
+        "map_background": rgb_payload(volume.background_rgb()),
+    }
+
+
+@app.get("/api/robot-presets")
+def get_robot_presets() -> dict[str, Any]:
+    return {"presets": [{"name": name, "robot": copy.deepcopy(robot)} for name, robot in ROBOT_PRESETS.items()]}
+
+
+@app.post("/api/update-config")
+def update_config(request: RunRequest) -> dict[str, Any]:
+    node = _require_sim()
     if not isinstance(request.config, dict):
         raise HTTPException(status_code=400, detail="config must be an object")
     reset = bool(request.reset)
-    SIM_NODE.set_config(copy.deepcopy(request.config), reset=reset)
-    # Scene edits set reset=true; restart planning so occupancy/ESDF is not sticky.
-    if reset:
-        ensure_ros_loop(reset_planning=True, force=False)
-    return {"frame": SIM_NODE.frame()}
+    prev_robot = node.config.get("robot", {}).get("name")
+    node.set_config(copy.deepcopy(request.config), reset=reset)
+    robot_changed = prev_robot != node.config.get("robot", {}).get("name")
+    if robot_changed:
+        _stop_script("tinynav/platforms/cmd_vel_control.py")
+    if reset or robot_changed:
+        ensure_ros_loop(reset_planning=True, force=robot_changed)
+    return {"ok": True, "robot_changed": robot_changed}
 
 
 @app.post("/api/start-ros-loop")
@@ -393,9 +592,7 @@ def start_ros_loop() -> dict[str, Any]:
 
 @app.get("/api/sim-state")
 def sim_state() -> dict[str, Any]:
-    if SIM_NODE is None:
-        raise HTTPException(status_code=503, detail="ROS simulator is not ready")
-    return {"frame": SIM_NODE.frame()}
+    return {"frame": _require_sim().frame()}
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Load occupancy maps from `tinynav_db/maps` via a dropdown, raycast voxels for synthetic depth, and keep Planning Lab as a robot-centered 10m window (full map lives in Perception overview).
- Align sim robot presets with main `robot_specs` (per-type obstacle z-band + dilation), and stop realtime on scene edits instead of pushing config every tick.
- Cut realtime payload by sending map background/info only on Load Map; poll `GET /api/sim-state` while running.

## Test plan
- [x] `./scripts/run_ros_planning_web.sh` in tinynav-dev, open the lab, confirm map dropdown lists folders under `tinynav_db/maps`
- [x] Load a map, drag start/target in overview + lab, add a box in the current lab corner, then Realtime
- [x] Switch robot preset (go2 / b2 / g1) and confirm planning restarts with matching `ROBOT_TYPE`
- [x] Confirm Lab follows the robot and depth still sees map geometry


https://github.com/user-attachments/assets/3b906884-a39e-404c-8817-88ecc9e3713c


