### PR TITLE
fix(sim): improve mobile touch UX in planning web lab

### DIFF
--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -1,5 +1,6 @@
 const REALTIME_TICK_DELAY_MS = 33;
 const GRID_STEP_M = 1.0;
+const MARKER_HIT_RADIUS = window.matchMedia?.("(pointer: coarse)").matches ? 22 : 14;
 const DEFAULT_SCENE = { xMin: -0.8, xMax: 9.8, yMin: -5.4, yMax: 5.4 };
 const LAB_VIEW_HALF_M = 5.0;
 let sceneBounds = { ...DEFAULT_SCENE };
@@ -645,8 +646,12 @@ function setControlsVisible(visible) {
   controlsToggle.textContent = visible ? "Hide Controls" : "Show Controls";
 }
 
+let lastControlsWide = null;
 function syncControlsLayout() {
-  setControlsVisible(window.innerWidth > 1180);
+  const wide = window.innerWidth > 1180;
+  if (wide === lastControlsWide) return;
+  lastControlsWide = wide;
+  setControlsVisible(wide);
 }
 
 function drawRealtimeFrame(frame) {
@@ -756,18 +761,18 @@ function editScene() {
 
 function hitTestTarget(px, py, targetCanvas = canvas, bounds = sceneBounds) {
   const [tpx, tpy] = worldToCanvas(config.target[0], config.target[1], targetCanvas, bounds);
-  return Math.hypot(px - tpx, py - tpy) <= 14;
+  return Math.hypot(px - tpx, py - tpy) <= MARKER_HIT_RADIUS;
 }
 
 function hitTestStart(px, py, targetCanvas = canvas, bounds = sceneBounds) {
   const [sx, sy] = worldToCanvas(config.start.xy[0], config.start.xy[1], targetCanvas, bounds);
-  return Math.hypot(px - sx, py - sy) <= 14;
+  return Math.hypot(px - sx, py - sy) <= MARKER_HIT_RADIUS;
 }
 
 function hitTestRobot(px, py, targetCanvas = canvas, bounds = sceneBounds) {
   const xy = robotDragXY();
   const [rx, ry] = worldToCanvas(xy[0], xy[1], targetCanvas, bounds);
-  return Math.hypot(px - rx, py - ry) <= 14;
+  return Math.hypot(px - rx, py - ry) <= MARKER_HIT_RADIUS;
 }
 
 function hitTestObject(px, py) {

--- a/tool/simulator/offline_planning_web/index.html
+++ b/tool/simulator/offline_planning_web/index.html
@@ -125,6 +125,6 @@
         </details>
       </section>
     </main>
-    <script src="/static/app.js?v=20260820m"></script>
+    <script src="/static/app.js?v=20260821"></script>
   </body>
 </html>

--- a/tool/simulator/offline_planning_web/styles.css
+++ b/tool/simulator/offline_planning_web/styles.css
@@ -33,7 +33,8 @@ body {
 .scene-panel {
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 32px);
+  max-height: calc(100vh - 32px); /* dvh fallback below overrides where supported, avoids mobile toolbar jump */
+  max-height: calc(100dvh - 32px);
   overflow: hidden;
 }
 
@@ -113,15 +114,18 @@ button.danger {
 }
 
 #sceneCanvas {
-  width: min(100%, calc(100vh - 190px));
+  width: min(100%, calc(100vh - 190px)); /* dvh fallback below overrides where supported, avoids mobile toolbar jump */
+  width: min(100%, calc(100dvh - 190px));
   max-width: 100%;
   aspect-ratio: 1 / 1;
   height: auto;
   max-height: calc(100vh - 190px);
+  max-height: calc(100dvh - 190px);
   display: block;
   border: 1px solid #ccd6df;
   border-radius: 6px;
   background: #fbfcfd;
+  touch-action: none;
 }
 
 .controls {
@@ -236,6 +240,7 @@ textarea {
 #mapCanvas {
   aspect-ratio: 4 / 3;
   cursor: grab;
+  touch-action: none;
 }
 
 #mapCanvas:active {
@@ -287,5 +292,40 @@ textarea {
 
   .controls.is-visible {
     display: block;
+  }
+}
+
+@media (max-width: 640px) {
+  .app {
+    padding: 10px;
+    gap: 10px;
+  }
+
+  .panel {
+    padding: 12px;
+  }
+
+  button {
+    padding: 10px 12px;
+    min-height: 40px;
+  }
+
+  .toolbar button,
+  .header-actions button {
+    flex: 1 1 auto;
+  }
+
+  label {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  label input,
+  label select {
+    min-height: 40px;
+  }
+
+  .image-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Add `touch-action: none` on the scene/map canvases so dragging the robot/target markers no longer fights the browser's scroll/pan gesture on touch devices
- Widen the marker drag hit radius on touch pointers (14px → 22px via `(pointer: coarse)`) so grabbing markers with a finger is easier
- Swap `100vh` for a `100dvh`-with-fallback pattern on the scene panel/canvas sizing to stop layout jumps as the mobile browser's address bar shows/hides
- Fix controls panel re-hiding itself: `syncControlsLayout()` was forcing visibility on every `resize` event, including the ones fired by address-bar collapse while scrolling — it now only reacts when the width actually crosses the desktop breakpoint
- Add a `≤640px` media query for single-column labels and larger (40px) touch targets on buttons/inputs

## Test plan
- [x] `node --check` on `app.js`
- [x] Ran `scripts/run_ros_planning_web.sh` inside the `tinynav-dev` container and verified over Tailscale from a real phone: dragging markers no longer scrolls the page, "Show Controls" stays open while scrolling, layout doesn't jump
- [ ] Reviewer sanity check on desktop (should be a no-op there)

https://github.com/user-attachments/assets/06d55fef-ddd5-4c1a-a1d5-ba3950e65e2f