### PR TITLE
fix(tool): read RGB from VideoDB, not the shelve that lost its writer

### DIFF
--- a/tool/bundle_adjustment_refiner.py
+++ b/tool/bundle_adjustment_refiner.py
@@ -11,6 +11,7 @@ from tinynav.tinynav_cpp_bind import ba_solve
 from typing import Dict, List, Tuple
 from dataclasses import dataclass
 from convert_to_colmap_format import convert_nerf_format
+from video_db import VideoDB
 
 
 extractor = SuperPoint(max_num_keypoints=2048).eval().cuda()  # load the extractor
@@ -350,7 +351,8 @@ def draw_image(image_left, image_right, keypoints0, keypoints1, matches):
 
 def main(tinynav_db_path: str):
     infra1_poses = np.load(os.path.join(tinynav_db_path, "poses.npy"), allow_pickle=True).item()
-    rgb_images = shelve.open(os.path.join(tinynav_db_path, "rgb_images"), flag='r')
+    # Same move to VideoDB as in convert_to_colmap_format (#126).
+    rgb_images = VideoDB(dir_path=os.path.join(tinynav_db_path, "rgb_images_db"), mode="read")
     T_rgb_to_infra1 = np.load(os.path.join(tinynav_db_path, "T_rgb_to_infra1.npy"), allow_pickle=True)
     rgb_intrinsics = np.load(os.path.join(tinynav_db_path, "rgb_camera_intrinsics.npy"), allow_pickle=True)
     edges = np.load(os.path.join(tinynav_db_path, "edges.npy"), allow_pickle=True)
@@ -362,8 +364,10 @@ def main(tinynav_db_path: str):
     landmark_tracker = LandmarkTracker()
     rgb_image_size = None
     for prev_timestamp, curr_timestamp in edges:
-        prev_rgb_image = rgb_images[str(prev_timestamp)]
-        curr_rgb_image = rgb_images[str(curr_timestamp)]
+        prev_rgb_image = rgb_images.read(prev_timestamp)
+        curr_rgb_image = rgb_images.read(curr_timestamp)
+        if prev_rgb_image is None or curr_rgb_image is None:
+            continue
         if rgb_image_size is None:
             rgb_image_size = prev_rgb_image.shape[:2]
         keypoints0, keypoints1, matches, descriptors0, descriptors1 = match_images(prev_rgb_image, curr_rgb_image)

--- a/tool/convert_to_colmap_format.py
+++ b/tool/convert_to_colmap_format.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Tuple
 import shelve
 from tqdm import tqdm
 from convert_to_nerf_format import convert_nerf_format
+from video_db import VideoDB
 
 
 
@@ -46,8 +47,18 @@ class TinynavToColmapConverter:
         self.depths = shelve.open(f"{self.input_dir}/depths")
 
         self.rgb_camera_K = np.load(self.input_dir / "rgb_camera_intrinsics.npy", allow_pickle=True)
-        self.rgb_images = shelve.open(f"{self.input_dir}/rgb_images")
+        # RGB moved to VideoDB in #126 and the old shelve has had no writer since.
+        # shelve.open defaults to flag='c', so reading it created an empty db and
+        # extracted zero images, leaving rgb_image_size None.
+        self.rgb_images = VideoDB(dir_path=f"{self.input_dir}/rgb_images_db", mode="read")
         self.T_rgb_to_infra1 = np.load(self.input_dir / "T_rgb_to_infra1.npy", allow_pickle=True)
+        if self.T_rgb_to_infra1.ndim == 0:
+            # build_map_node saves None when the rig publishes no rgb->infra1
+            # extrinsic. Say so here rather than dying inside a matmul after
+            # having already extracted every frame.
+            raise SystemExit(
+                f"{self.input_dir}/T_rgb_to_infra1.npy is None: this map was built "
+                "without an rgb->infra1 extrinsic, so RGB poses cannot be computed")
         self.rgb_image_size = None
    
     def _get_image_list(self) -> List[Tuple[int, str, np.ndarray]]:
@@ -108,7 +119,7 @@ class TinynavToColmapConverter:
         # Generate PLY file from 3D points
         self._write_ply_file(points3d_data)
         
-        print(f"Created COLMAP text files with {len(self.rgb_images)} images and {len(points3d_data)} 3D points")
+        print(f"Created COLMAP text files with {len(self.rgb_images.ts_to_idx)} images and {len(points3d_data)} 3D points")
     
     def _write_cameras_txt(self, camera_data, sparse_dir):
         """Write cameras.txt file for COLMAP"""
@@ -281,16 +292,16 @@ class TinynavToColmapConverter:
         return color
     
     def _extract_images_from_db(self):
-        """Extract images from tinynav database using shelve"""
-        
+        """Extract every RGB frame to images/. Returns the (h, w) of the last one."""
+
         images_dir = self.output_dir / "images"
         images_dir.mkdir(exist_ok=True)
-        # Extract images from shelve database
         image_size = None
-        for timestamp, image in tqdm(self.rgb_images.items(), desc="Extracting images"):
-            # Convert key to string if needed
-            key_str = str(timestamp)
-            image_path = images_dir / f"image_{key_str}.png"
+        for timestamp in tqdm(sorted(self.rgb_images.ts_to_idx), desc="Extracting images"):
+            image = self.rgb_images.read(timestamp)
+            if image is None:
+                continue
+            image_path = images_dir / f"image_{timestamp}.png"
             cv2.imwrite(str(image_path), image)
             image_size = image.shape[:2]
         print("Image extraction completed")


### PR DESCRIPTION
## The bug

`#126` moved image storage to `VideoDB` but left both of the old shelve's readers behind. There has been no writer for `rgb_images` since, so:

- `tool/convert_to_colmap_format.py:49` opens it with `shelve.open`'s default `flag='c'`, which **silently creates an empty db**. `_extract_images_from_db` then iterates nothing, `rgb_image_size` stays `None`, and the run dies much later on `int(self.rgb_image_size[1])`:

  ```
  Extracting images: 0it [00:00, ?it/s]
  TypeError: 'NoneType' object is not subscriptable
    convert_to_colmap_format.py:73  int(self.rgb_image_size[1])
  ```

- `tool/bundle_adjustment_refiner.py:353` opens it with `flag='r'`, so it raises on the missing file instead.

`_on_build_map_done` does not check that subprocess's exit code, so on a normal build this traceback is printed and ignored — the map is archived and reported as a success while the COLMAP/NeRF export has silently produced nothing. Measured on a 2961-keyframe map: `rgb_images_db/video.mp4` is 272 MB, the legacy `rgb_images.db` is a 12 KB empty shelve.

`tool/convert_to_nerf_format.py` was migrated to `VideoDB`; only the COLMAP half was missed.

## The fix

Both readers go through `VideoDB(dir_path=.../rgb_images_db, mode="read")`, iterating `ts_to_idx` and calling `read(timestamp)`. The timestamp keys are ints and match `poses.npy`'s keys exactly, so the `image_{timestamp}.png` filenames `_get_image_list` builds still line up with what is extracted.

Plus one fail-fast: `T_rgb_to_infra1.npy` is saved as `None` when the rig publishes no rgb→infra1 extrinsic, and the converter then dies in

```
ValueError: matmul: Input operand 1 does not have enough dimensions (has 0 ...)
  rgb_pose = infra1_pose @ self.T_rgb_to_infra1
```

**after** having extracted every frame. It now says so at load time and exits.

## Verification

Run against a real 2961-keyframe map:

- before: `Extracting images: 0it`, then the `TypeError`
- after: all 2961 frames extracted, `(1920, 1088, 3)`, `Image extraction completed`
- with `T_rgb_to_infra1` `None`: exits in ~1s with the message above and writes nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
