### PR TITLE
perf(nav): plan on the latest depth frame, and publish visual odometry from the pose

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -8,6 +8,7 @@ from scipy.ndimage import distance_transform_edt, binary_dilation
 from scipy.spatial.transform import Rotation as R
 from numba import njit
 import message_filters
+from rclpy.qos import QoSProfile, HistoryPolicy, ReliabilityPolicy
 from rclpy.time import Time
 from sensor_msgs.msg import PointCloud2, PointCloud
 from geometry_msgs.msg import PoseStamped, Point32
@@ -318,8 +319,16 @@ class PlanningNode(Node):
         self.occupancy_cloud_pub = self.create_publisher(PointCloud2, '/planning/occupied_voxels', 10)
         self.occupancy_cloud_esdf_pub = self.create_publisher(PointCloud2, '/planning/occupied_voxels_with_esdf', 10)
         self.occupancy_grid_pub = self.create_publisher(OccupancyGrid, '/planning/occupancy_grid', 10)
-        self.depth_sub = message_filters.Subscriber(self, Image, '/slam/depth')
-        self.pose_sub = message_filters.Subscriber(self, Odometry, '/slam/odometry_visual')
+        latest_depth_only = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST, depth=1, reliability=ReliabilityPolicy.RELIABLE
+        )
+        poses_covering_one_depth_frame = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST, depth=10, reliability=ReliabilityPolicy.RELIABLE
+        )
+        self.depth_sub = message_filters.Subscriber(self, Image, '/slam/depth',
+                                                    qos_profile=latest_depth_only)
+        self.pose_sub = message_filters.Subscriber(self, Odometry, '/slam/odometry_visual',
+                                                   qos_profile=poses_covering_one_depth_frame)
 
         self.ts = message_filters.TimeSynchronizer([self.depth_sub, self.pose_sub], queue_size=10)
         self.ts.registerCallback(self.sync_callback)

--- a/tool/looper_bridge_node.py
+++ b/tool/looper_bridge_node.py
@@ -52,6 +52,7 @@ class LooperBridgeNode(Node):
         self.depth_sub = message_filters.Subscriber(self, Image, "/camera/camera/depth/image_rect_raw", qos_profile=self.sensor_qos)
         self.pose_sub = message_filters.Subscriber(self, PoseStamped, "/camera/camera/vio_image")
         self.image_sub = message_filters.Subscriber(self, Image, "/camera/camera/infra1/image_rect_raw", qos_profile=self.sensor_qos)
+        self.pose_sub.registerCallback(self.publish_visual_odom)
         self.sync = message_filters.TimeSynchronizer(
             [self.depth_sub, self.pose_sub, self.image_sub], queue_size=20
         )
@@ -189,6 +190,10 @@ class LooperBridgeNode(Node):
         disp_color_msg.header.frame_id = "camera"
         return disp_color_msg
 
+    def publish_visual_odom(self, pose_msg: PoseStamped):
+        odom_msg = self.build_odom(pose_msg2np(pose_msg), pose_msg.header.stamp)
+        self.odom_visual_pub.publish(odom_msg)
+
     def sync_callback(self, depth_msg: Image, pose_msg: PoseStamped, image_msg: Image):
         if self.cached_camera_info is None:
             self.log_missing_inputs()
@@ -198,7 +203,6 @@ class LooperBridgeNode(Node):
         stamp = pose_msg.header.stamp
 
         odom_msg = self.build_odom(T_world_camera, stamp)
-        self.odom_visual_pub.publish(odom_msg)
         depth_m = self.decode_depth_meters(depth_msg)
         depth_out = self.build_depth_msg(depth_m, stamp)
         disparity_vis_msg = self.build_disparity_vis(depth_m, stamp)


### PR DESCRIPTION
## What this changes

Two places where the pose the planner works from was older than it had to be.

**`looper_bridge_node`** published `/slam/odometry_visual` from the three-way
exact-time sync, so the pose waited for the depth frame carrying the same stamp.
The odometry is built from the pose alone, so it is published from the pose
subscription instead.

**`planning_node`** subscribed to `/slam/depth` and `/slam/odometry_visual` with
the same default queue of ten. Depth sets the pace of the planning loop, so only
the newest depth frame is worth keeping; the pose queue stays deep enough to still
hold the pose whose stamp matches it.

## How it was measured

A node subscribing to each stage and recording `receipt - header.stamp`. Rate alone
does not show this: a stage can publish at a steady 10 Hz while every frame it
publishes is hundreds of milliseconds old.

`planning_node` puts the depth frame's stamp on the trajectory poses
(`pose.header = depth_msg.header`), so a trajectory pose's age is the whole
camera-to-plan latency. `/cmd_vel` carries no header, so it is measured against the
newest trajectory stamp held: "how old is the sensing behind the command going out
now".

Rig: Jetson Orin, 6 cores, stereo + VIO camera over a USB network gadget, ROS 2
Humble. Navigation live with a goal held. 15-second samples, same map, same goal,
before and after. The camera stamps its own messages and its clock runs ahead of
the compute box, so the absolute ages below include a constant offset; the third
column nets it out using the offset visible on `/camera/camera/vio_100hz` in the
same sample.

## Result

| stage | before (ms) | after (ms) | net of clock offset |
|---|---|---|---|
| `/slam/odometry_visual` | 598.7 | **78.4** | 495.6 -> 16.8 |
| `/slam/depth` | 611.2 | 241.7 | 508.1 -> 180.1 |
| `/planning/trajectory_path` | 1039.0 | **288.8** | 935.9 -> 227.2 |
| `/cmd_vel` | 1066.5 | **349.4** | 963.4 -> 287.8 |

Inter-arrival on the pose stream, which is what a planner actually feels:

| | before | after |
|---|---|---|
| median | 73.7 ms | 50.5 ms |
| p95 | 531.7 ms | **70.6 ms** |
| max | 782.6 ms | **93.9 ms** |

The command now acts on sensing ~0.29 m old at 1 m/s where it was ~0.96 m, and the
half-second stalls on the pose stream are gone.

## What it does not fix

`/slam/depth` still arrives ~180 ms old with a p95 of 836 ms, and in the same
sample the depth frame is the last of the three synced inputs to arrive, every time:

| input | age at arrival (median) | p95 |
|---|---|---|
| `/camera/camera/vio_image` | 113.9 | 119.3 |
| `/camera/camera/infra1/image_rect_raw` | 125.0 | 132.4 |
| `/camera/camera/depth/image_rect_raw` | **267.1** | 296.9 |

Depth is last on 253 of 253 matched stamps, about 142 ms behind its siblings. That
is upstream of this repo.

## Trade-offs, and what the old shape was buying

Publishing the odometry only from the three-way sync guaranteed that every
`/slam/odometry_visual` had a `/slam/depth` with the same stamp. `planning_node`'s
exact-time sync relied on that guarantee without stating it. Publishing the pose on
its own removes it, and the pose queue depth in `planning_node` is now what keeps
the match alive: it has to be deep enough to still hold the pose matching the newest
depth frame. That is an assumption about their relative rates, and nothing enforces
it — if depth ever slows far enough that more than ten poses arrive between frames,
the exact match starves. Measured here, the ratio is about 2.5 poses per depth frame.

An earlier revision of this branch used depth 1 on both subscriptions and dropped
the planner from 189 trajectories per 15 s to 2, for exactly that reason.

The planner also publishes less often: 12.6 Hz before, 9.1 Hz after. Every plan is
~700 ms fresher, and `/cmd_vel` is unchanged at 12 Hz, but it is a real trade rather
than a free win. `self.last_param` (the smoothness penalty's reference) is now the
previous *plan* across a slightly longer interval.

`publish_visual_odom` is registered on `pose_sub` before the synchronizer so the
pose goes out first; that relies on `signalMessage` calling callbacks in
registration order.

If keeping the stamp-pairing guarantee is preferred, the alternative is to leave the
bridge alone and make `planning_node` tolerant instead (approximate-time sync, or
taking the latest pose outside the sync). That trades this patch's simplicity for
keeping the invariant where it was.

Draft: opened for review of the approach before it is squared away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

