### PR TITLE
fix(app): keep one preview reader per image topic

### DIFF
--- a/app/backend/node_manager.py
+++ b/app/backend/node_manager.py
@@ -203,6 +203,7 @@ class BackendNode(Ros2NodeManager):
         # Sensor mode detection and image subscriptions
         self._sensor_mode: str = 'unknown'  # 'looper' | 'realsense' | 'unknown'
         self._image_subs: dict = {}
+        self._image_sub_lock = threading.Lock()
         self._last_frame: dict[str, bytes] = {}   # topic -> latest JPEG bytes
         self._last_frame_time: dict[str, float] = {}
         self._looper_bridge_proc: subprocess.Popen | None = None
@@ -498,9 +499,7 @@ class BackendNode(Ros2NodeManager):
             return False
         with self._lock:
             self.preview_callbacks[topic].append((cb, max_edge_px, jpeg_quality))
-            first = len(self.preview_callbacks[topic]) == 1
-        if first:
-            self._create_image_sub(topic)
+        self._sync_image_sub(topic)
         return True
 
     def remove_preview_callback(self, topic: str, cb):
@@ -513,30 +512,40 @@ class BackendNode(Ros2NodeManager):
                 for registration in self.preview_callbacks[topic]
                 if registration[0] is not cb
             ]
-            empty = len(self.preview_callbacks[topic]) == 0
-        if empty:
-            self._destroy_image_sub(topic)
+        self._sync_image_sub(topic)
 
-    def _create_image_sub(self, topic: str):
-        if topic in self._image_subs:
-            return
+    def _sync_image_sub(self, topic: str):
+        """Bring the subscription in line with whether anyone is still watching.
+
+        Viewers come and go concurrently, so whether to subscribe is read here
+        rather than carried in from the caller: a decision made before this lock
+        was taken can already be stale, and acting on it leaves a second reader
+        on the topic that _image_subs no longer names and no later removal frees.
+
+        This runs under its own lock, not self._lock: destroy_subscription waits
+        for the executor to leave the callback, and the executor takes self._lock
+        to fan a frame out to viewers.
+        """
+        with self._image_sub_lock:
+            with self._lock:
+                watched = bool(self.preview_callbacks.get(topic))
+            if watched and topic not in self._image_subs:
+                self._image_subs[topic] = self._make_image_sub(topic)
+            elif not watched and topic in self._image_subs:
+                self.destroy_subscription(self._image_subs.pop(topic))
+
+    def _make_image_sub(self, topic: str):
         if topic == _COLOR_TOPIC_LOOPER:
-            self._image_subs[topic] = self.create_subscription(
+            return self.create_subscription(
                 CompressedImage, topic,
                 lambda msg, t=topic: self._on_compressed_image(msg, t),
                 1,
             )
-        else:
-            self._image_subs[topic] = self.create_subscription(
-                Image, topic,
-                lambda msg, t=topic: self._on_image(msg, t),
-                1,
-            )
-
-    def _destroy_image_sub(self, topic: str):
-        sub = self._image_subs.pop(topic, None)
-        if sub is not None:
-            self.destroy_subscription(sub)
+        return self.create_subscription(
+            Image, topic,
+            lambda msg, t=topic: self._on_image(msg, t),
+            1,
+        )
 
     def _publish_preview_frame(self, topic: str, arr: np.ndarray):
         with self._lock:

--- a/tests/test_preview_subscription.py
+++ b/tests/test_preview_subscription.py
@@ -1,0 +1,121 @@
+"""Preview subscription lifecycle under concurrent viewers.
+
+add_preview_callback / remove_preview_callback decide whether to create or
+destroy the ROS subscription while holding the lock, but act on that decision
+after releasing it. Two viewers churning on the same topic can therefore both
+decide "I am the first" and both create, leaving a subscription that nothing
+holds a reference to and that no later remove can destroy -- a duplicate reader
+on an image topic, for the life of the process.
+
+Usage:
+    cd /tinynav
+    python tests/test_preview_subscription.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import traceback
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from app.backend.node_manager import BackendNode
+
+TOPIC = '/camera/camera/infra1/image_rect_raw'
+
+
+class _Recorder:
+    """Stands in for the rclpy subscription factory and records lifetimes."""
+
+    def __init__(self):
+        self.created = []
+        self.destroyed = []
+        self.block_next = None
+        self.entered = threading.Event()
+
+    def create_subscription(self, msg_type, topic, callback, qos):
+        gate = self.block_next
+        if gate is not None:
+            self.block_next = None
+            self.entered.set()
+            gate.wait(5.0)
+        sub = object()
+        self.created.append(sub)
+        return sub
+
+    def destroy_subscription(self, sub):
+        self.destroyed.append(sub)
+
+    def live(self):
+        return [s for s in self.created if s not in self.destroyed]
+
+
+def _bare_node(rec):
+    node = BackendNode.__new__(BackendNode)
+    node._lock = threading.Lock()
+    node._image_sub_lock = threading.Lock()
+    node.preview_callbacks = {TOPIC: []}
+    node._image_subs = {}
+    node.create_subscription = rec.create_subscription
+    node.destroy_subscription = rec.destroy_subscription
+    return node
+
+
+def test_churn_leaves_at_most_one_reader():
+    rec = _Recorder()
+    node = _bare_node(rec)
+
+    # Hold the first viewer inside create_subscription so the second viewer's
+    # add/remove/add cycle interleaves with it, the way two browser tabs do.
+    gate = threading.Event()
+    rec.block_next = gate
+    first = threading.Thread(target=node.add_preview_callback, args=(TOPIC, 'cb1'))
+    first.start()
+    assert rec.entered.wait(5.0), 'the first viewer never reached create_subscription'
+
+    node.remove_preview_callback(TOPIC, 'cb1')
+    node.add_preview_callback(TOPIC, 'cb2')
+    gate.set()
+    first.join(5.0)
+    assert not first.is_alive(), 'the first viewer never returned'
+
+    live = rec.live()
+    assert len(live) <= 1, (
+        f'{len(live)} readers left on {TOPIC}; a duplicate subscription keeps '
+        f'consuming the stream and no remove_preview_callback can reach it')
+    for sub in live:
+        assert sub is node._image_subs.get(TOPIC), (
+            'a live subscription is not the one _image_subs holds, so nothing '
+            'can ever destroy it')
+
+
+def test_last_viewer_leaves_no_reader():
+    rec = _Recorder()
+    node = _bare_node(rec)
+    node.add_preview_callback(TOPIC, 'cb1')
+    node.add_preview_callback(TOPIC, 'cb2')
+    node.remove_preview_callback(TOPIC, 'cb1')
+    assert len(rec.live()) == 1, 'the stream must survive while a viewer remains'
+    node.remove_preview_callback(TOPIC, 'cb2')
+    assert rec.live() == [], 'the last viewer leaving must release the stream'
+
+
+def main():
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith('test_'):
+            continue
+        try:
+            fn()
+            print(f'  PASS  {name}')
+        except Exception:
+            failures += 1
+            print(f'  FAIL  {name}')
+            traceback.print_exc()
+    print('FAILED' if failures else 'OK')
+    return 1 if failures else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## The bug

`add_preview_callback` and `remove_preview_callback` decide whether the topic
needs a subscription while holding `self._lock`, then act on that decision after
releasing it:

```python
with self._lock:
    self.preview_callbacks[topic].append(...)
    first = len(self.preview_callbacks[topic]) == 1
if first:
    self._create_image_sub(topic)
```

By the time `_create_image_sub` runs, `first` can be stale. Two viewers churning
on the same topic -- a browser tab closing while another opens, which is the
normal preview workload -- can both come away believing they are the first:

1. viewer A appends, sees `first`, enters `_create_image_sub`, passes the
   `topic in self._image_subs` guard, and is preempted inside
   `create_subscription` (a C call that releases the GIL)
2. viewer A goes away; `_destroy_image_sub` pops nothing and does nothing
3. viewer B appends, also sees `first`, and creates a subscription
4. A resumes and creates a second one, overwriting `_image_subs[topic]`

The subscription from step 3 is now unreachable. No later
`remove_preview_callback` can free it, and it keeps pulling frames for the life
of the process.

Found on a running rig: `ros2 topic info -v` showed the backend node holding two
readers on `/camera/camera/infra1/image_rect_raw` while `ros2 node list` showed
only one such node. On a setup where the camera is on the far side of a link, a
duplicate reader is a duplicated stream.

## The fix

Whether to subscribe is now read where it is acted on, so a decision cannot go
stale between the two:

```python
with self._image_sub_lock:
    with self._lock:
        watched = bool(self.preview_callbacks.get(topic))
    if watched and topic not in self._image_subs:
        self._image_subs[topic] = self._make_image_sub(topic)
    elif not watched and topic in self._image_subs:
        self.destroy_subscription(self._image_subs.pop(topic))
```

This also collapses the create and destroy paths into one, so the two callers
say the same thing.

### Why a second lock rather than widening `self._lock`

`destroy_subscription` waits for the executor thread to leave the subscription
callback, and that thread takes `self._lock` in `_publish_preview_frame` to fan
a frame out to viewers. Holding `self._lock` across the destroy would deadlock
the two against each other. `_image_sub_lock` is only ever taken before
`self._lock`, never after, so no cycle exists.

## Test

`tests/test_preview_subscription.py` drives the interleaving above by holding the
first viewer inside a stubbed `create_subscription` while a second viewer's
add/remove/add cycle runs, then asserts the property rather than a call count:
at most one live reader per topic, and every live reader reachable from
`_image_subs`.

```
$ python tests/test_preview_subscription.py     # before
  FAIL  test_churn_leaves_at_most_one_reader
AssertionError: 2 readers left on /camera/camera/infra1/image_rect_raw
  PASS  test_last_viewer_leaves_no_reader

$ python tests/test_preview_subscription.py     # after
  PASS  test_churn_leaves_at_most_one_reader
  PASS  test_last_viewer_leaves_no_reader
```

The second test covers the ordinary path, so the fix cannot pass by simply never
subscribing.

`tests/test_backend.py` is unchanged by this: 12/14 before and after, the same
two failures (`test_render_metadata_origin`, `test_odom_yaw_90`) present on
`main` already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)