### PR TITLE
fix(unitree): stop on stale cmd_vel stream

### DIFF
--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -56,10 +56,12 @@ def test_nonzero_attempt_stays_armed_until_confirmed_stop():
     assert watchdog.consume_expiration(10.5001)
 
 
-def test_clear_disarms_watchdog():
+def test_confirmed_stop_disarms_watchdog():
     watchdog = VelocityCommandWatchdog(0.5)
-    watchdog.observe_nonzero(10.0)
-    watchdog.clear()
+    generation = watchdog.observe_nonzero(10.0)
+    stop_generation = watchdog.request_stop()
+    assert stop_generation == generation
+    watchdog.confirm_stop(stop_generation)
     assert not watchdog.consume_expiration(20.0)
 
 
@@ -79,18 +81,27 @@ def test_normal_completion_does_not_require_stop():
 def test_explicit_stop_covers_inflight_generation():
     watchdog = VelocityCommandWatchdog(0.5)
     generation = watchdog.observe_nonzero(10.0)
-    watchdog.clear()
+    watchdog.request_stop()
     assert watchdog.completed_after_stop(generation)
+    assert watchdog.consume_expiration(10.5001)
 
 
-def test_stop_failure_retries_same_generation():
+def test_unconfirmed_stop_keeps_watchdog_armed():
     watchdog = VelocityCommandWatchdog(0.5)
     generation = watchdog.observe_nonzero(10.0)
-    watchdog.clear()
-    watchdog.retry_after_stop_failure(10.1)
-    assert not watchdog.consume_expiration(10.6)
-    assert watchdog.consume_expiration(10.6001)
+    watchdog.request_stop()
+    assert watchdog.consume_expiration(10.5001)
     assert watchdog.completed_after_stop(generation)
+
+
+def test_confirming_old_stop_does_not_disarm_new_generation():
+    watchdog = VelocityCommandWatchdog(0.5)
+    first_generation = watchdog.observe_nonzero(10.0)
+    stop_generation = watchdog.request_stop()
+    second_generation = watchdog.observe_nonzero(10.1)
+    assert second_generation > first_generation
+    watchdog.confirm_stop(stop_generation)
+    assert watchdog.consume_expiration(10.6001)
 
 
 def test_stop_uses_status_returning_g1_api():
@@ -112,11 +123,12 @@ if __name__ == '__main__':
         test_nonzero_expires_once,
         test_refresh_extends_deadline,
         test_nonzero_attempt_stays_armed_until_confirmed_stop,
-        test_clear_disarms_watchdog,
+        test_confirmed_stop_disarms_watchdog,
         test_late_completion_requires_compensating_stop,
         test_normal_completion_does_not_require_stop,
         test_explicit_stop_covers_inflight_generation,
-        test_stop_failure_retries_same_generation,
+        test_unconfirmed_stop_keeps_watchdog_armed,
+        test_confirming_old_stop_does_not_disarm_new_generation,
         test_stop_uses_status_returning_g1_api,
         test_stop_uses_sport_api_for_quadruped,
     ]

--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -36,6 +36,12 @@ def test_refresh_extends_deadline():
     assert watchdog.consume_expiration(10.9001)
 
 
+def test_nonzero_attempt_stays_armed_until_confirmed_stop():
+    watchdog = VelocityCommandWatchdog(0.5)
+    watchdog.observe_nonzero(10.0)
+    assert watchdog.consume_expiration(10.5001)
+
+
 def test_clear_disarms_watchdog():
     watchdog = VelocityCommandWatchdog(0.5)
     watchdog.observe_nonzero(10.0)
@@ -49,6 +55,7 @@ if __name__ == '__main__':
         test_idle_does_not_expire,
         test_nonzero_expires_once,
         test_refresh_extends_deadline,
+        test_nonzero_attempt_stays_armed_until_confirmed_stop,
         test_clear_disarms_watchdog,
     ]
     for test in tests:

--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -35,7 +35,8 @@ def test_idle_does_not_expire():
 
 def test_nonzero_expires_once():
     watchdog = VelocityCommandWatchdog(0.5)
-    watchdog.observe_nonzero(10.0)
+    generation = watchdog.observe_nonzero(10.0)
+    assert generation == 1
     assert not watchdog.consume_expiration(10.5)
     assert watchdog.consume_expiration(10.5001)
     assert not watchdog.consume_expiration(20.0)
@@ -43,8 +44,8 @@ def test_nonzero_expires_once():
 
 def test_refresh_extends_deadline():
     watchdog = VelocityCommandWatchdog(0.5)
-    watchdog.observe_nonzero(10.0)
-    watchdog.observe_nonzero(10.4)
+    assert watchdog.observe_nonzero(10.0) == 1
+    assert watchdog.observe_nonzero(10.4) == 2
     assert not watchdog.consume_expiration(10.8)
     assert watchdog.consume_expiration(10.9001)
 
@@ -60,6 +61,36 @@ def test_clear_disarms_watchdog():
     watchdog.observe_nonzero(10.0)
     watchdog.clear()
     assert not watchdog.consume_expiration(20.0)
+
+
+def test_late_completion_requires_compensating_stop():
+    watchdog = VelocityCommandWatchdog(0.5)
+    generation = watchdog.observe_nonzero(10.0)
+    assert watchdog.consume_expiration(10.5001)
+    assert watchdog.completed_after_stop(generation)
+
+
+def test_normal_completion_does_not_require_stop():
+    watchdog = VelocityCommandWatchdog(0.5)
+    generation = watchdog.observe_nonzero(10.0)
+    assert not watchdog.completed_after_stop(generation)
+
+
+def test_explicit_stop_covers_inflight_generation():
+    watchdog = VelocityCommandWatchdog(0.5)
+    generation = watchdog.observe_nonzero(10.0)
+    watchdog.clear()
+    assert watchdog.completed_after_stop(generation)
+
+
+def test_stop_failure_retries_same_generation():
+    watchdog = VelocityCommandWatchdog(0.5)
+    generation = watchdog.observe_nonzero(10.0)
+    watchdog.clear()
+    watchdog.retry_after_stop_failure(10.1)
+    assert not watchdog.consume_expiration(10.6)
+    assert watchdog.consume_expiration(10.6001)
+    assert watchdog.completed_after_stop(generation)
 
 
 def test_stop_uses_status_returning_g1_api():
@@ -82,6 +113,10 @@ if __name__ == '__main__':
         test_refresh_extends_deadline,
         test_nonzero_attempt_stays_armed_until_confirmed_stop,
         test_clear_disarms_watchdog,
+        test_late_completion_requires_compensating_stop,
+        test_normal_completion_does_not_require_stop,
+        test_explicit_stop_covers_inflight_generation,
+        test_stop_failure_retries_same_generation,
         test_stop_uses_status_returning_g1_api,
         test_stop_uses_sport_api_for_quadruped,
     ]

--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -6,8 +6,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from tinynav.platforms.command_watchdog import VelocityCommandWatchdog
 
 
-def test_rejects_non_positive_timeout():
-    for timeout_s in (0.0, -0.1):
+def test_rejects_invalid_timeout():
+    for timeout_s in (0.0, -0.1, float('inf'), float('nan')):
         try:
             VelocityCommandWatchdog(timeout_s)
         except ValueError:
@@ -51,7 +51,7 @@ def test_clear_disarms_watchdog():
 
 if __name__ == '__main__':
     tests = [
-        test_rejects_non_positive_timeout,
+        test_rejects_invalid_timeout,
         test_idle_does_not_expire,
         test_nonzero_expires_once,
         test_refresh_extends_deadline,

--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -3,7 +3,20 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from tinynav.platforms.command_watchdog import VelocityCommandWatchdog
+from tinynav.platforms.command_watchdog import VelocityCommandWatchdog, stop_unitree_motion
+
+
+class FakeMotionClient:
+    def __init__(self):
+        self.calls = []
+
+    def SetVelocity(self, vx, vy, vyaw):
+        self.calls.append(('SetVelocity', vx, vy, vyaw))
+        return 0
+
+    def StopMove(self):
+        self.calls.append(('StopMove',))
+        return 0
 
 
 def test_rejects_invalid_timeout():
@@ -49,6 +62,18 @@ def test_clear_disarms_watchdog():
     assert not watchdog.consume_expiration(20.0)
 
 
+def test_stop_uses_status_returning_g1_api():
+    client = FakeMotionClient()
+    assert stop_unitree_motion(client, 'g1') == 0
+    assert client.calls == [('SetVelocity', 0.0, 0.0, 0.0)]
+
+
+def test_stop_uses_sport_api_for_quadruped():
+    client = FakeMotionClient()
+    assert stop_unitree_motion(client, 'go2w') == 0
+    assert client.calls == [('StopMove',)]
+
+
 if __name__ == '__main__':
     tests = [
         test_rejects_invalid_timeout,
@@ -57,6 +82,8 @@ if __name__ == '__main__':
         test_refresh_extends_deadline,
         test_nonzero_attempt_stays_armed_until_confirmed_stop,
         test_clear_disarms_watchdog,
+        test_stop_uses_status_returning_g1_api,
+        test_stop_uses_sport_api_for_quadruped,
     ]
     for test in tests:
         test()

--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -104,6 +104,32 @@ def test_confirming_old_stop_does_not_disarm_new_generation():
     assert watchdog.consume_expiration(10.6001)
 
 
+def test_current_unconfirmed_stop_failure_retries():
+    watchdog = VelocityCommandWatchdog(0.5)
+    generation = watchdog.observe_nonzero(10.0)
+    assert watchdog.consume_expiration(10.5001) == generation
+    assert watchdog.retry_after_stop_failure(generation, 10.6)
+    assert watchdog.consume_expiration(11.1001) == generation
+
+
+def test_old_stop_failure_does_not_delay_new_generation():
+    watchdog = VelocityCommandWatchdog(0.5)
+    first_generation = watchdog.observe_nonzero(10.0)
+    assert watchdog.consume_expiration(10.5001) == first_generation
+    second_generation = watchdog.observe_nonzero(10.6)
+    assert not watchdog.retry_after_stop_failure(first_generation, 20.0)
+    assert watchdog.consume_expiration(11.1001) == second_generation
+
+
+def test_confirmed_stop_failure_does_not_rearm_idle_watchdog():
+    watchdog = VelocityCommandWatchdog(0.5)
+    generation = watchdog.observe_nonzero(10.0)
+    stop_generation = watchdog.request_stop()
+    watchdog.confirm_stop(stop_generation)
+    assert not watchdog.retry_after_stop_failure(generation, 20.0)
+    assert watchdog.consume_expiration(30.0) is None
+
+
 def test_stop_uses_status_returning_g1_api():
     client = FakeMotionClient()
     assert stop_unitree_motion(client, 'g1') == 0
@@ -129,6 +155,9 @@ if __name__ == '__main__':
         test_explicit_stop_covers_inflight_generation,
         test_unconfirmed_stop_keeps_watchdog_armed,
         test_confirming_old_stop_does_not_disarm_new_generation,
+        test_current_unconfirmed_stop_failure_retries,
+        test_old_stop_failure_does_not_delay_new_generation,
+        test_confirmed_stop_failure_does_not_rearm_idle_watchdog,
         test_stop_uses_status_returning_g1_api,
         test_stop_uses_sport_api_for_quadruped,
     ]

--- a/tests/test_command_watchdog.py
+++ b/tests/test_command_watchdog.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tinynav.platforms.command_watchdog import VelocityCommandWatchdog
+
+
+def test_rejects_non_positive_timeout():
+    for timeout_s in (0.0, -0.1):
+        try:
+            VelocityCommandWatchdog(timeout_s)
+        except ValueError:
+            continue
+        raise AssertionError(f'timeout {timeout_s} should fail')
+
+
+def test_idle_does_not_expire():
+    watchdog = VelocityCommandWatchdog(0.5)
+    assert not watchdog.consume_expiration(10.0)
+
+
+def test_nonzero_expires_once():
+    watchdog = VelocityCommandWatchdog(0.5)
+    watchdog.observe_nonzero(10.0)
+    assert not watchdog.consume_expiration(10.5)
+    assert watchdog.consume_expiration(10.5001)
+    assert not watchdog.consume_expiration(20.0)
+
+
+def test_refresh_extends_deadline():
+    watchdog = VelocityCommandWatchdog(0.5)
+    watchdog.observe_nonzero(10.0)
+    watchdog.observe_nonzero(10.4)
+    assert not watchdog.consume_expiration(10.8)
+    assert watchdog.consume_expiration(10.9001)
+
+
+def test_clear_disarms_watchdog():
+    watchdog = VelocityCommandWatchdog(0.5)
+    watchdog.observe_nonzero(10.0)
+    watchdog.clear()
+    assert not watchdog.consume_expiration(20.0)
+
+
+if __name__ == '__main__':
+    tests = [
+        test_rejects_non_positive_timeout,
+        test_idle_does_not_expire,
+        test_nonzero_expires_once,
+        test_refresh_extends_deadline,
+        test_clear_disarms_watchdog,
+    ]
+    for test in tests:
+        test()
+        print(f'PASS {test.__name__}')

--- a/tinynav/platforms/command_watchdog.py
+++ b/tinynav/platforms/command_watchdog.py
@@ -26,9 +26,16 @@ class VelocityCommandWatchdog:
             self._armed = True
             return self._generation
 
-    def clear(self):
+    def request_stop(self) -> int:
         with self._lock:
             self._stopped_through = self._generation
+            return self._generation
+
+    def confirm_stop(self, generation: int):
+        with self._lock:
+            self._stopped_through = max(self._stopped_through, generation)
+            if self._generation > generation:
+                return
             self._last_nonzero_at = None
             self._armed = False
 

--- a/tinynav/platforms/command_watchdog.py
+++ b/tinynav/platforms/command_watchdog.py
@@ -1,10 +1,11 @@
+import math
 import threading
 
 
 class VelocityCommandWatchdog:
     def __init__(self, timeout_s: float):
-        if timeout_s <= 0:
-            raise ValueError('timeout_s must be positive')
+        if not math.isfinite(timeout_s) or timeout_s <= 0:
+            raise ValueError('timeout_s must be finite and positive')
         self.timeout_s = float(timeout_s)
         self._last_nonzero_at = None
         self._armed = False

--- a/tinynav/platforms/command_watchdog.py
+++ b/tinynav/platforms/command_watchdog.py
@@ -15,17 +15,31 @@ class VelocityCommandWatchdog:
         self.timeout_s = float(timeout_s)
         self._last_nonzero_at = None
         self._armed = False
+        self._generation = 0
+        self._stopped_through = 0
         self._lock = threading.Lock()
 
     def observe_nonzero(self, now: float):
         with self._lock:
+            self._generation += 1
             self._last_nonzero_at = float(now)
             self._armed = True
+            return self._generation
 
     def clear(self):
         with self._lock:
+            self._stopped_through = self._generation
             self._last_nonzero_at = None
             self._armed = False
+
+    def retry_after_stop_failure(self, now: float):
+        with self._lock:
+            self._last_nonzero_at = float(now)
+            self._armed = True
+
+    def completed_after_stop(self, generation: int) -> bool:
+        with self._lock:
+            return generation <= self._stopped_through
 
     def consume_expiration(self, now: float) -> bool:
         with self._lock:
@@ -33,6 +47,7 @@ class VelocityCommandWatchdog:
                 return False
             if float(now) - self._last_nonzero_at <= self.timeout_s:
                 return False
+            self._stopped_through = self._generation
             self._last_nonzero_at = None
             self._armed = False
             return True

--- a/tinynav/platforms/command_watchdog.py
+++ b/tinynav/platforms/command_watchdog.py
@@ -2,6 +2,12 @@ import math
 import threading
 
 
+def stop_unitree_motion(client, robot_model: str):
+    if robot_model == 'g1':
+        return client.SetVelocity(0.0, 0.0, 0.0)
+    return client.StopMove()
+
+
 class VelocityCommandWatchdog:
     def __init__(self, timeout_s: float):
         if not math.isfinite(timeout_s) or timeout_s <= 0:

--- a/tinynav/platforms/command_watchdog.py
+++ b/tinynav/platforms/command_watchdog.py
@@ -17,6 +17,7 @@ class VelocityCommandWatchdog:
         self._armed = False
         self._generation = 0
         self._stopped_through = 0
+        self._confirmed_through = 0
         self._lock = threading.Lock()
 
     def observe_nonzero(self, now: float):
@@ -34,27 +35,31 @@ class VelocityCommandWatchdog:
     def confirm_stop(self, generation: int):
         with self._lock:
             self._stopped_through = max(self._stopped_through, generation)
+            self._confirmed_through = max(self._confirmed_through, generation)
             if self._generation > generation:
                 return
             self._last_nonzero_at = None
             self._armed = False
 
-    def retry_after_stop_failure(self, now: float):
+    def retry_after_stop_failure(self, generation: int, now: float) -> bool:
         with self._lock:
+            if generation != self._generation or generation <= self._confirmed_through:
+                return False
             self._last_nonzero_at = float(now)
             self._armed = True
+            return True
 
     def completed_after_stop(self, generation: int) -> bool:
         with self._lock:
             return generation <= self._stopped_through
 
-    def consume_expiration(self, now: float) -> bool:
+    def consume_expiration(self, now: float) -> int | None:
         with self._lock:
             if not self._armed or self._last_nonzero_at is None:
-                return False
+                return None
             if float(now) - self._last_nonzero_at <= self.timeout_s:
-                return False
+                return None
             self._stopped_through = self._generation
             self._last_nonzero_at = None
             self._armed = False
-            return True
+            return self._generation

--- a/tinynav/platforms/command_watchdog.py
+++ b/tinynav/platforms/command_watchdog.py
@@ -1,0 +1,31 @@
+import threading
+
+
+class VelocityCommandWatchdog:
+    def __init__(self, timeout_s: float):
+        if timeout_s <= 0:
+            raise ValueError('timeout_s must be positive')
+        self.timeout_s = float(timeout_s)
+        self._last_nonzero_at = None
+        self._armed = False
+        self._lock = threading.Lock()
+
+    def observe_nonzero(self, now: float):
+        with self._lock:
+            self._last_nonzero_at = float(now)
+            self._armed = True
+
+    def clear(self):
+        with self._lock:
+            self._last_nonzero_at = None
+            self._armed = False
+
+    def consume_expiration(self, now: float) -> bool:
+        with self._lock:
+            if not self._armed or self._last_nonzero_at is None:
+                return False
+            if float(now) - self._last_nonzero_at <= self.timeout_s:
+                return False
+            self._last_nonzero_at = None
+            self._armed = False
+            return True

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -5,6 +5,7 @@ import time
 from enum import Enum
 
 import rclpy
+from rclpy.clock import Clock, ClockType
 from rclpy.node import Node
 from std_msgs.msg import Float32, String
 from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
@@ -73,6 +74,7 @@ class Ros2UnitreeManagerNode(Node):
         self.logger = self.get_logger()
         self.cmd_vel_watchdog = VelocityCommandWatchdog(cmd_vel_timeout_s)
         self._motion_lock = threading.Lock()
+        self._watchdog_clock = Clock(clock_type=ClockType.STEADY_TIME)
 
         self.twist_subscriber = ChannelSubscriber("rt/cmd_vel", Twist_)
         self.twist_subscriber.Init(self.TwistMessageHandler, 10)
@@ -89,7 +91,8 @@ class Ros2UnitreeManagerNode(Node):
 
         self._status_timer = self.create_timer(1.0, self._publish_robot_status)
         watchdog_period_s = min(0.05, cmd_vel_timeout_s / 2.0)
-        self._cmd_vel_watchdog_timer = self.create_timer(watchdog_period_s, self._cmd_vel_watchdog_tick)
+        self._cmd_vel_watchdog_timer = self.create_timer(
+            watchdog_period_s, self._cmd_vel_watchdog_tick, clock=self._watchdog_clock)
 
     # twist message handler
     def TwistMessageHandler(self, msg: Twist_):
@@ -102,10 +105,9 @@ class Ros2UnitreeManagerNode(Node):
         with self._motion_lock:
             if (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
                 self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
+                self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
                 code = self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
-                if code == 0:
-                    self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
-                else:
+                if code != 0:
                     self.logger.error(f"Move failed: code={code}")
             else:
                 code = self.sport_client.StopMove()

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -118,11 +118,12 @@ class Ros2UnitreeManagerNode(Node):
             if self.cmd_vel_watchdog.completed_after_stop(generation):
                 self._send_safety_stop("late Move completion")
         else:
-            self.cmd_vel_watchdog.clear()
+            stop_generation = self.cmd_vel_watchdog.request_stop()
             code = stop_unitree_motion(self.sport_client, self.robot_model)
-            if code != 0:
+            if code == 0:
+                self.cmd_vel_watchdog.confirm_stop(stop_generation)
+            else:
                 self.logger.error(f"StopMove failed: code={code}")
-                self.cmd_vel_watchdog.retry_after_stop_failure(time.monotonic())
         time.sleep(0.02)
 
     def _cmd_vel_watchdog_tick(self):

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import threading
 import time
 from enum import Enum
 
@@ -64,6 +65,7 @@ class Ros2UnitreeManagerNode(Node):
         self.robot_model = robot_model
         self.is_quadruped = robot_model in _QUADRUPED_ROBOT_MODELS
         self.cmd_vel_watchdog = VelocityCommandWatchdog(cmd_vel_timeout_s)
+        self._safety_stop_lock = threading.Lock()
 
         self.channel = ChannelFactoryInitialize(0, networkInterface)
         self.sport_client = _build_sport_client(robot_model)
@@ -109,27 +111,33 @@ class Ros2UnitreeManagerNode(Node):
 
         if (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
             self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
-            self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
+            generation = self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
             code = self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
             if code not in (0, None):
                 self.logger.error(f"Move failed: code={code}")
+            if self.cmd_vel_watchdog.completed_after_stop(generation):
+                self._send_safety_stop("late Move completion")
         else:
+            self.cmd_vel_watchdog.clear()
             code = stop_unitree_motion(self.sport_client, self.robot_model)
-            if code == 0:
-                self.cmd_vel_watchdog.clear()
-            else:
+            if code != 0:
                 self.logger.error(f"StopMove failed: code={code}")
+                self.cmd_vel_watchdog.retry_after_stop_failure(time.monotonic())
         time.sleep(0.02)
 
     def _cmd_vel_watchdog_tick(self):
         if not self.cmd_vel_watchdog.consume_expiration(time.monotonic()):
             return
-        code = stop_unitree_motion(self.safety_client, self.robot_model)
+        self._send_safety_stop("cmd_vel stream stale")
+
+    def _send_safety_stop(self, reason: str):
+        with self._safety_stop_lock:
+            code = stop_unitree_motion(self.safety_client, self.robot_model)
         if code == 0:
-            self.logger.warning("cmd_vel stream stale; StopMove sent")
+            self.logger.warning(f"{reason}; StopMove sent")
         else:
-            self.logger.error(f"cmd_vel stream stale; StopMove failed: code={code}")
-            self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
+            self.logger.error(f"{reason}; StopMove failed: code={code}")
+            self.cmd_vel_watchdog.retry_after_stop_failure(time.monotonic())
 
     def ActionMessageHandler(self, msg: String_):
         self.logger.info(f"ActionMessageHandler received: {msg.data!r}")

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import threading
 import time
 from enum import Enum
 
@@ -12,7 +11,10 @@ from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscri
 from unitree_sdk2py.idl.geometry_msgs.msg.dds_ import Twist_
 from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
 
-from tinynav.platforms.command_watchdog import VelocityCommandWatchdog
+from tinynav.platforms.command_watchdog import (
+    VelocityCommandWatchdog,
+    stop_unitree_motion,
+)
 
 # go2/b2 are quadrupeds sharing the same SportClient gait API (Move/StandUp/
 # StandDown/BalanceStand/ClassicWalk). go2w/b2w are the wheeled variants of the
@@ -61,19 +63,22 @@ class Ros2UnitreeManagerNode(Node):
             raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {_SUPPORTED_ROBOT_MODELS}")
         self.robot_model = robot_model
         self.is_quadruped = robot_model in _QUADRUPED_ROBOT_MODELS
+        self.cmd_vel_watchdog = VelocityCommandWatchdog(cmd_vel_timeout_s)
 
         self.channel = ChannelFactoryInitialize(0, networkInterface)
         self.sport_client = _build_sport_client(robot_model)
         self.sport_client.SetTimeout(10.0)
         self.sport_client.Init()
+        # A blocked primary RPC must not prevent the watchdog from sending StopMove.
+        self.safety_client = _build_sport_client(robot_model)
+        self.safety_client.SetTimeout(min(0.1, cmd_vel_timeout_s / 4.0))
+        self.safety_client.Init()
         if self.is_quadruped:
             self.sport_client.ClassicWalk(True)
         self._robot_status = RobotStatus.SITTING
         self.battery = 0.0
         self.last_twist_time = None
         self.logger = self.get_logger()
-        self.cmd_vel_watchdog = VelocityCommandWatchdog(cmd_vel_timeout_s)
-        self._motion_lock = threading.Lock()
         self._watchdog_clock = Clock(clock_type=ClockType.STEADY_TIME)
 
         self.twist_subscriber = ChannelSubscriber("rt/cmd_vel", Twist_)
@@ -102,31 +107,29 @@ class Ros2UnitreeManagerNode(Node):
             self.logger.debug(f"cmd_vel callback time interval: {time_interval*1000:.2f} ms")
         self.last_twist_time = current_time
 
-        with self._motion_lock:
-            if (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
-                self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
-                self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
-                code = self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
-                if code != 0:
-                    self.logger.error(f"Move failed: code={code}")
+        if (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
+            self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
+            self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
+            code = self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
+            if code not in (0, None):
+                self.logger.error(f"Move failed: code={code}")
+        else:
+            code = stop_unitree_motion(self.sport_client, self.robot_model)
+            if code == 0:
+                self.cmd_vel_watchdog.clear()
             else:
-                code = self.sport_client.StopMove()
-                if code == 0:
-                    self.cmd_vel_watchdog.clear()
-                else:
-                    self.logger.error(f"StopMove failed: code={code}")
+                self.logger.error(f"StopMove failed: code={code}")
         time.sleep(0.02)
 
     def _cmd_vel_watchdog_tick(self):
-        with self._motion_lock:
-            if not self.cmd_vel_watchdog.consume_expiration(time.monotonic()):
-                return
-            code = self.sport_client.StopMove()
-            if code == 0:
-                self.logger.warning("cmd_vel stream stale; StopMove sent")
-            else:
-                self.logger.error(f"cmd_vel stream stale; StopMove failed: code={code}")
-                self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
+        if not self.cmd_vel_watchdog.consume_expiration(time.monotonic()):
+            return
+        code = stop_unitree_motion(self.safety_client, self.robot_model)
+        if code == 0:
+            self.logger.warning("cmd_vel stream stale; StopMove sent")
+        else:
+            self.logger.error(f"cmd_vel stream stale; StopMove failed: code={code}")
+            self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
 
     def ActionMessageHandler(self, msg: String_):
         self.logger.info(f"ActionMessageHandler received: {msg.data!r}")

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -116,7 +116,7 @@ class Ros2UnitreeManagerNode(Node):
             if code not in (0, None):
                 self.logger.error(f"Move failed: code={code}")
             if self.cmd_vel_watchdog.completed_after_stop(generation):
-                self._send_safety_stop("late Move completion")
+                self._send_safety_stop("late Move completion", generation)
         else:
             stop_generation = self.cmd_vel_watchdog.request_stop()
             code = stop_unitree_motion(self.sport_client, self.robot_model)
@@ -127,18 +127,20 @@ class Ros2UnitreeManagerNode(Node):
         time.sleep(0.02)
 
     def _cmd_vel_watchdog_tick(self):
-        if not self.cmd_vel_watchdog.consume_expiration(time.monotonic()):
+        generation = self.cmd_vel_watchdog.consume_expiration(time.monotonic())
+        if generation is None:
             return
-        self._send_safety_stop("cmd_vel stream stale")
+        self._send_safety_stop("cmd_vel stream stale", generation)
 
-    def _send_safety_stop(self, reason: str):
+    def _send_safety_stop(self, reason: str, generation: int):
         with self._safety_stop_lock:
             code = stop_unitree_motion(self.safety_client, self.robot_model)
         if code == 0:
+            self.cmd_vel_watchdog.confirm_stop(generation)
             self.logger.warning(f"{reason}; StopMove sent")
         else:
             self.logger.error(f"{reason}; StopMove failed: code={code}")
-            self.cmd_vel_watchdog.retry_after_stop_failure(time.monotonic())
+            self.cmd_vel_watchdog.retry_after_stop_failure(generation, time.monotonic())
 
     def ActionMessageHandler(self, msg: String_):
         self.logger.info(f"ActionMessageHandler received: {msg.data!r}")

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -1,13 +1,17 @@
 import argparse
 import os
+import threading
+import time
+from enum import Enum
+
 import rclpy
 from rclpy.node import Node
+from std_msgs.msg import Float32, String
 from unitree_sdk2py.core.channel import ChannelFactoryInitialize, ChannelSubscriber
 from unitree_sdk2py.idl.geometry_msgs.msg.dds_ import Twist_
 from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
-from std_msgs.msg import Float32, String
-from enum import Enum
-import time
+
+from tinynav.platforms.command_watchdog import VelocityCommandWatchdog
 
 # go2/b2 are quadrupeds sharing the same SportClient gait API (Move/StandUp/
 # StandDown/BalanceStand/ClassicWalk). go2w/b2w are the wheeled variants of the
@@ -49,7 +53,8 @@ class RobotStatus(Enum):
 
 
 class Ros2UnitreeManagerNode(Node):
-    def __init__(self, networkInterface: str = "enP8p1s0", robot_model: str = ROBOT_TYPE):
+    def __init__(self, networkInterface: str = "enP8p1s0", robot_model: str = ROBOT_TYPE,
+                 cmd_vel_timeout_s: float = 0.5):
         super().__init__('ros2_unitree_manager')
         if robot_model not in _SUPPORTED_ROBOT_MODELS:
             raise ValueError(f"Unsupported robot model: {robot_model!r}, expected one of {_SUPPORTED_ROBOT_MODELS}")
@@ -66,6 +71,8 @@ class Ros2UnitreeManagerNode(Node):
         self.battery = 0.0
         self.last_twist_time = None
         self.logger = self.get_logger()
+        self.cmd_vel_watchdog = VelocityCommandWatchdog(cmd_vel_timeout_s)
+        self._motion_lock = threading.Lock()
 
         self.twist_subscriber = ChannelSubscriber("rt/cmd_vel", Twist_)
         self.twist_subscriber.Init(self.TwistMessageHandler, 10)
@@ -81,6 +88,8 @@ class Ros2UnitreeManagerNode(Node):
         self.publisher_robot_status = self.create_publisher(String, '/robot_status', 10)
 
         self._status_timer = self.create_timer(1.0, self._publish_robot_status)
+        watchdog_period_s = min(0.05, cmd_vel_timeout_s / 2.0)
+        self._cmd_vel_watchdog_timer = self.create_timer(watchdog_period_s, self._cmd_vel_watchdog_tick)
 
     # twist message handler
     def TwistMessageHandler(self, msg: Twist_):
@@ -90,12 +99,32 @@ class Ros2UnitreeManagerNode(Node):
             self.logger.debug(f"cmd_vel callback time interval: {time_interval*1000:.2f} ms")
         self.last_twist_time = current_time
 
-        if  (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
-            self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
-            self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
-        else:
-            self.sport_client.StopMove()
+        with self._motion_lock:
+            if (msg.linear.x != 0 or msg.linear.y != 0 or msg.angular.z != 0):
+                self.logger.debug(f"Moving with velocity: {msg.linear.x}, {msg.linear.y}, {msg.angular.z}")
+                code = self.sport_client.Move(msg.linear.x, msg.linear.y, msg.angular.z)
+                if code == 0:
+                    self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
+                else:
+                    self.logger.error(f"Move failed: code={code}")
+            else:
+                code = self.sport_client.StopMove()
+                if code == 0:
+                    self.cmd_vel_watchdog.clear()
+                else:
+                    self.logger.error(f"StopMove failed: code={code}")
         time.sleep(0.02)
+
+    def _cmd_vel_watchdog_tick(self):
+        with self._motion_lock:
+            if not self.cmd_vel_watchdog.consume_expiration(time.monotonic()):
+                return
+            code = self.sport_client.StopMove()
+            if code == 0:
+                self.logger.warning("cmd_vel stream stale; StopMove sent")
+            else:
+                self.logger.error(f"cmd_vel stream stale; StopMove failed: code={code}")
+                self.cmd_vel_watchdog.observe_nonzero(time.monotonic())
 
     def ActionMessageHandler(self, msg: String_):
         self.logger.info(f"ActionMessageHandler received: {msg.data!r}")
@@ -135,7 +164,7 @@ class Ros2UnitreeManagerNode(Node):
             battery_msg = Float32()
             battery_msg.data = float(self.battery)
             self.publisher_battery.publish(battery_msg)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             self.logger.error(f"Error in LowStateMessageHandler: {e}")
             import traceback
             traceback.print_exc()
@@ -145,10 +174,13 @@ def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--network-interface", default="enP8p1s0",
                         help="Network interface connected to the robot")
+    parser.add_argument("--cmd-vel-timeout", type=float, default=0.5,
+                        help="Stop after this many seconds without a fresh non-zero cmd_vel")
     parsed_args, ros_args = parser.parse_known_args(args=args)
 
     rclpy.init(args=ros_args)
-    node = Ros2UnitreeManagerNode(parsed_args.network_interface)
+    node = Ros2UnitreeManagerNode(parsed_args.network_interface,
+                                  cmd_vel_timeout_s=parsed_args.cmd_vel_timeout)
     rclpy.spin(node)
     node.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
## Summary

Add a bridge-level `cmd_vel` freshness watchdog so a silent publisher, stalled RPC, failed safety stop or cross-client reordering cannot leave an old non-zero Unitree motion active indefinitely.

## Current behavior

- Arm before every non-zero `Move()` attempt.
- Schedule on `ClockType.STEADY_TIME`, independent of ROS time.
- Reject zero, negative, infinite and NaN timeout values.
- Use a dedicated safety client with a response timeout of at most 100 ms and one quarter of the stale budget, so blocked primary G1 `SetVelocity()` cannot starve the watchdog.
- Dispatch G1 stop through status-returning `SetVelocity(0,0,0)`; use `StopMove()` for quadrupeds.
- Assign an increasing generation to each non-zero command. Expiry or explicit zero records which generations require stopping; late completion of a covered `Move()` triggers a compensating safety stop.
- Keep explicit zero in stop-pending state until its RPC succeeds; an old confirmation cannot disarm a newer generation.
- Record `confirmed_through`. A failed safety stop may retry only when it still targets the current, unconfirmed generation, so it cannot delay a newer deadline or re-arm an already stopped idle bridge.

The configurable 0.5 s default is an initial fail-closed value, not a measured Go2-W performance claim.

## Tests

```text
uv run --python 3.10 --no-project python tests/test_command_watchdog.py
PASS test_rejects_invalid_timeout
PASS test_idle_does_not_expire
PASS test_nonzero_expires_once
PASS test_refresh_extends_deadline
PASS test_nonzero_attempt_stays_armed_until_confirmed_stop
PASS test_confirmed_stop_disarms_watchdog
PASS test_late_completion_requires_compensating_stop
PASS test_normal_completion_does_not_require_stop
PASS test_explicit_stop_covers_inflight_generation
PASS test_unconfirmed_stop_keeps_watchdog_armed
PASS test_confirming_old_stop_does_not_disarm_new_generation
PASS test_current_unconfirmed_stop_failure_retries
PASS test_old_stop_failure_does_not_delay_new_generation
PASS test_confirmed_stop_failure_does_not_rearm_idle_watchdog
PASS test_stop_uses_status_returning_g1_api
PASS test_stop_uses_sport_api_for_quadruped
```

```text
uvx ruff check --isolated \
  tinynav/platforms/command_watchdog.py \
  tinynav/platforms/unitree_control.py
# All checks passed

python3 -m compileall -q \
  tinynav/platforms/command_watchdog.py \
  tinynav/platforms/unitree_control.py
```

## Hardware validation boundary

This patch has **not** been actuated on a robot. It was developed from a source-only Go2-W bounty preflight in #234 and checked against TinyNav's pinned Unitree SDK revision. Before merge or non-zero hardware motion, maintainers should confirm the default timeout and run a bounded HIL test with the area clear and remote/e-stop available:

1. stream non-zero velocity at the normal rate;
2. stop only the publisher while leaving the bridge alive;
3. delay the primary motion and stop responses;
4. verify safety stop occurs within the configured budget;
5. verify late old motion completion is followed by a compensating stop;
6. verify an old stop failure cannot extend a newer command deadline;
7. verify an old stop confirmation cannot disarm a newer generation.

Related: #234
