### PR TITLE
Add active map endpoint

### DIFF
--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -56,6 +56,7 @@ The interactive API docs are available at `http://<host>:8000/docs`.
 | Method | Path | Description |
 |---|---|---|
 | `POST` | `/map/build` | Trigger map build from the recorded bag |
+| `GET` | `/map/active` | Current active map name, resolved path, and localization state |
 | `GET` | `/map/current` | Map metadata (image URL, resolution, origin, size) |
 | `GET` | `/map/image` | Occupancy grid rendered as a PNG image |
 

--- a/app/backend/routers/map.py
+++ b/app/backend/routers/map.py
@@ -22,6 +22,16 @@ def _require_node():
     return runner.node
 
 
+def _active_map_payload(node):
+    """Return the active map identity without changing any runtime state."""
+    map_path = os.path.realpath(node.map_path)
+    return {
+        'active_map': os.path.basename(map_path.rstrip(os.sep)),
+        'map_path': map_path,
+        'localized': bool(getattr(node, '_localized', False)),
+    }
+
+
 class MapBuildRequest(BaseModel):
     bag_name: Optional[str] = None
 
@@ -55,8 +65,15 @@ def map_current():
         raise HTTPException(500, str(e))
     return {
         'imageUrl': '/map/image',
+        'name': _active_map_payload(node)['active_map'],
         **meta,
     }
+
+
+@router.get('/active')
+def map_active():
+    """Returns the map currently selected by tinynav_db/map."""
+    return _active_map_payload(_require_node())
 
 
 @router.get('/image', response_class=Response)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -221,6 +221,7 @@ def _run_router_tests():
             self._stopped = False
             self._nav_target = None
             self.pose_callbacks: list = []
+            self._localized = False
 
         def get_status(self):
             grid = os.path.join(self.map_path, 'occupancy_grid.npy')
@@ -279,6 +280,7 @@ def _run_router_suite(client, node, map_path, bag_path):
         node._started.clear()
         node._stopped = False
         node._nav_target = None
+        node._localized = False
         # clear pois
         pois_file = os.path.join(map_path, 'pois.json')
         if os.path.exists(pois_file):
@@ -348,10 +350,22 @@ def _run_router_suite(client, node, map_path, bag_path):
         r = client.get('/map/current')
         assert r.status_code == 200
         assert r.json()['imageUrl'] == '/map/image'
+        assert r.json()['name'] == 'map'
         r2 = client.get('/map/image')
         assert r2.status_code == 200
         assert r2.headers['content-type'] == 'image/png'
         assert r2.content[:4] == b'\x89PNG'
+
+    def test_map_active():
+        reset()
+        node._localized = True
+        r = client.get('/map/active')
+        assert r.status_code == 200
+        assert r.json() == {
+            'active_map': 'map',
+            'map_path': map_path,
+            'localized': True,
+        }
 
     # -- POI --
     def test_poi_list_empty():
@@ -424,7 +438,7 @@ def _run_router_suite(client, node, map_path, bag_path):
         test_bag_start_from_idle, test_bag_start_already_recording,
         test_bag_stop, test_bag_stop_when_idle, test_bag_status_recording,
         test_map_build_no_bag, test_map_build_with_bag,
-        test_map_current_no_map, test_map_current_and_image,
+        test_map_current_no_map, test_map_current_and_image, test_map_active,
         test_poi_list_empty, test_poi_create_and_list, test_poi_delete,
         test_poi_delete_nonexistent, test_poi_invalid_position, test_poi_unique_ids,
         test_nav_go_to_poi, test_nav_go_already_navigating,


### PR DESCRIPTION
## Summary
- add GET /map/active for the active map name, resolved path, and localization state
- include the active map name in GET /map/current
- cover the new route in backend router tests

## Testing
- python3 -m py_compile app/backend/routers/map.py tests/test_backend.py