### PR TITLE
feat(poi): per-POI arrival actions, g1 arm gesture, tuned g1 footprint

### DIFF
--- a/app/backend/routers/device.py
+++ b/app/backend/routers/device.py
@@ -4,6 +4,7 @@ import psutil
 from fastapi import APIRouter
 
 from ..state import runner
+from tinynav.core.robot_specs import ROBOT_CONFIG
 
 router = APIRouter(tags=['device'])
 
@@ -14,6 +15,8 @@ def device_info():
         'deviceId': socket.gethostname(),
         'firmwareVersion': '0.1.0',
         'capabilities': ['bag_record', 'map_build', 'navigation'],
+        'robotType': ROBOT_CONFIG.name,
+        'arrivalActions': ROBOT_CONFIG.available_actions,
     }
 
 

--- a/app/backend/routers/map.py
+++ b/app/backend/routers/map.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from ..map_renderer import render_map
 from ..state import runner
+from tinynav.core.robot_specs import ROBOT_CONFIG
 
 router = APIRouter(tags=['map'])
 
@@ -194,6 +195,7 @@ def _snap_to_sdf(map_path: str, x: float, y: float, search_radius: int = 8, sdf_
 class MapPoiCreateRequest(BaseModel):
     name: str
     position: list[float]  # [x, y, z]  — z will be snapped from SDF
+    action: Optional[str] = None  # gesture to play on arrival; must be in ROBOT_CONFIG.available_actions
 
 
 @router.post('/preview/{map_name}/pois')
@@ -201,6 +203,8 @@ def map_preview_create_poi(map_name: str, req: MapPoiCreateRequest):
     path = _resolve_map_path(map_name)
     if len(req.position) != 3:
         raise HTTPException(400, 'position must be [x, y, z]')
+    if req.action is not None and req.action not in ROBOT_CONFIG.available_actions:
+        raise HTTPException(400, f'action must be one of {ROBOT_CONFIG.available_actions}')
 
     # Snap (x, y) to the nearest prior-path point using the SDF map.
     # The incoming z is ignored — the snapped z comes from the SDF volume.
@@ -214,7 +218,7 @@ def map_preview_create_poi(map_name: str, req: MapPoiCreateRequest):
             pois = json.load(f)
     existing_ids = [int(k) for k in pois.keys()] if pois else []
     new_id = max(existing_ids) + 1 if existing_ids else 0
-    pois[str(new_id)] = {'id': new_id, 'name': req.name, 'position': snapped_position}
+    pois[str(new_id)] = {'id': new_id, 'name': req.name, 'position': snapped_position, 'action': req.action}
     with open(pois_file, 'w') as f:
         json.dump(pois, f, indent=2)
     return pois[str(new_id)]

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -268,6 +268,7 @@ class MapNode(Node):
         self.T_from_map_to_odom = None
 
         self.pois = {}
+        self.poi_actions = {}
         self.poi_index = -1
         self._nav_completed = False
         self._leg_initial_length: float | None = None
@@ -299,13 +300,17 @@ class MapNode(Node):
             self.pois = json.loads(msg.data)
 
             pois_dict = {}
+            poi_actions = {}
             keys = sorted([int (key) for key in self.pois.keys()])
             for index, key in enumerate(keys):
                 pois_dict[index] = np.array(self.pois[str(key)]["position"])
+                poi_actions[index] = self.pois[str(key)].get("action")
             self.pois = pois_dict
+            self.poi_actions = poi_actions
 
             if not self.pois:
                 self.poi_index = -1
+                self.poi_actions = {}
                 self.cached_nav_path_in_map = None
                 # Signal planning_node to clear target_pose so it stops publishing paths
                 dummy_pose = np.eye(4)
@@ -326,6 +331,7 @@ class MapNode(Node):
         except json.JSONDecodeError as e:
             self.get_logger().error(f"Failed to parse POIs JSON: {e}")
             self.pois = {}
+            self.poi_actions = {}
 
     def info_callback(self, msg:CameraInfo):
         if self.K is None:
@@ -649,16 +655,27 @@ class MapNode(Node):
         pos = pose_in_map[:3, 3]
 
         if np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0:
-            if ROBOT_CONFIG.arrival_action and not self._poi_action_pending:
+            action = self.poi_actions.get(self.poi_index)
+            if action and action not in ROBOT_CONFIG.available_actions:
+                self.get_logger().warning(
+                    f"POI {self.poi_index} wants action {action!r}, not available for "
+                    f"robot {ROBOT_CONFIG.name!r} ({ROBOT_CONFIG.available_actions}); skipping"
+                )
+                action = None
+            if action and not self._poi_action_pending:
                 self._poi_action_pending = True
                 self._poi_action_until = time.time() + ROBOT_CONFIG.arrival_action_hold_s
-                self.action_pub.publish(String(data=f"play {ROBOT_CONFIG.arrival_action}"))
-                self.get_logger().info(f"Arrived at POI {self.poi_index}, playing {ROBOT_CONFIG.arrival_action!r}")
+                self.action_pub.publish(String(data=f"play {action}"))
+                self.get_logger().info(f"Arrived at POI {self.poi_index}, playing {action!r}")
                 return
             if self._poi_action_pending:
                 if time.time() < self._poi_action_until:
                     return
                 self._poi_action_pending = False
+                if ROBOT_CONFIG.name == 'g1':
+                    # g1 arm gestures don't self-release; some (e.g. "hug") leave the
+                    # arm extended until explicitly told to reset.
+                    self.action_pub.publish(String(data="play release arm"))
 
             if self._leg_initial_length is not None:
                 self.nav_progress_pub.publish(String(data=json.dumps({

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -673,8 +673,6 @@ class MapNode(Node):
                     return
                 self._poi_action_pending = False
                 if ROBOT_CONFIG.name == 'g1':
-                    # g1 arm gestures don't self-release; some (e.g. "hug") leave the
-                    # arm extended until explicitly told to reset.
                     self.action_pub.publish(String(data="play release arm"))
 
             if self._leg_initial_length is not None:

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -28,6 +28,7 @@ from tinynav.core.build_map_node import find_loop, solve_pose_graph
 from tinynav.core.vlad import compute_vlad
 import einops
 from tinynav.core.build_map_node import OdomPoseRecorder
+from tinynav.core.robot_specs import ROBOT_CONFIG
 logger = logging.getLogger(__name__)
 
 
@@ -274,11 +275,14 @@ class MapNode(Node):
         self._speed_estimate: float | None = None
         self.cached_nav_path_in_map = None
         self.cached_nav_path_poi_index = -1
+        self._poi_action_pending = False
+        self._poi_action_until: float | None = None
 
         self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
         self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
         self.nav_done_pub = self.create_publisher(Bool, '/mapping/nav_done', 10)
         self.nav_progress_pub = self.create_publisher(String, '/mapping/nav_progress', 10)
+        self.action_pub = self.create_publisher(String, '/service/command', 10)
 
         self.current_pose_pub = self.create_publisher(Odometry, "/mapping/current_pose", 10)
         self.global_plan_pub = self.create_publisher(Path, '/mapping/global_plan', 10)
@@ -314,6 +318,8 @@ class MapNode(Node):
             self._leg_initial_length = None
             self._leg_start_time = None
             self._speed_estimate = None
+            self._poi_action_pending = False
+            self._poi_action_until = None
             self.cached_nav_path_in_map = None
             self.cached_nav_path_poi_index = -1
             self.get_logger().info(f"Parsed POIs: {self.pois}")
@@ -643,6 +649,17 @@ class MapNode(Node):
         pos = pose_in_map[:3, 3]
 
         if np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0:
+            if ROBOT_CONFIG.arrival_action and not self._poi_action_pending:
+                self._poi_action_pending = True
+                self._poi_action_until = time.time() + ROBOT_CONFIG.arrival_action_hold_s
+                self.action_pub.publish(String(data=f"play {ROBOT_CONFIG.arrival_action}"))
+                self.get_logger().info(f"Arrived at POI {self.poi_index}, playing {ROBOT_CONFIG.arrival_action!r}")
+                return
+            if self._poi_action_pending:
+                if time.time() < self._poi_action_until:
+                    return
+                self._poi_action_pending = False
+
             if self._leg_initial_length is not None:
                 self.nav_progress_pub.publish(String(data=json.dumps({
                     "poi_index": self.poi_index,

--- a/tinynav/core/robot_specs.py
+++ b/tinynav/core/robot_specs.py
@@ -43,6 +43,11 @@ class RobotConfig:
     min_angular_vel: float = 0.1
     max_angular_vel: float = 0.75
     obstacle: ObstacleConfig = field(default_factory=ObstacleConfig)
+    # Arm gesture map_node plays on POI arrival before advancing to the next POI
+    # (see unitree_sdk2py's g1_arm_action_client action_map for valid names).
+    # None means no arrival action for this robot.
+    arrival_action: str | None = None
+    arrival_action_hold_s: float = 5.0
 
     @property
     def cam_offset_3d(self):
@@ -105,6 +110,7 @@ G1_CONFIG = RobotConfig(
     safety_radius=0.15,
     min_linear_vel=0.2, min_angular_vel=0.3,
     obstacle=ObstacleConfig(robot_z_bottom=-0.8, robot_z_top=0.6),
+    arrival_action='high wave',
 )
 
 ROBOT_TYPE = os.environ.get("ROBOT_TYPE", "go2").strip().lower()

--- a/tinynav/core/robot_specs.py
+++ b/tinynav/core/robot_specs.py
@@ -119,10 +119,10 @@ _G1_ACTIONS = [
 
 G1_CONFIG = RobotConfig(
     name='g1', shape='square',
-    length=0.3, width=0.5,
+    length=0.3, width=0.4,
     camera_x=0.1, camera_y=0.0,
     control_x=0.0, control_y=0.0,
-    safety_radius=0.15,
+    safety_radius=0.1,
     min_linear_vel=0.2, min_angular_vel=0.3,
     obstacle=ObstacleConfig(robot_z_bottom=-0.8, robot_z_top=0.6),
     available_actions=_G1_ACTIONS,

--- a/tinynav/core/robot_specs.py
+++ b/tinynav/core/robot_specs.py
@@ -119,10 +119,10 @@ _G1_ACTIONS = [
 
 G1_CONFIG = RobotConfig(
     name='g1', shape='square',
-    length=0.3, width=0.4,
+    length=0.2, width=0.3,
     camera_x=0.1, camera_y=0.0,
     control_x=0.0, control_y=0.0,
-    safety_radius=0.1,
+    safety_radius=0.15,
     min_linear_vel=0.2, min_angular_vel=0.3,
     obstacle=ObstacleConfig(robot_z_bottom=-0.8, robot_z_top=0.6),
     available_actions=_G1_ACTIONS,

--- a/tinynav/core/robot_specs.py
+++ b/tinynav/core/robot_specs.py
@@ -43,10 +43,11 @@ class RobotConfig:
     min_angular_vel: float = 0.1
     max_angular_vel: float = 0.75
     obstacle: ObstacleConfig = field(default_factory=ObstacleConfig)
-    # Arm gesture map_node plays on POI arrival before advancing to the next POI
-    # (see unitree_sdk2py's g1_arm_action_client action_map for valid names).
-    # None means no arrival action for this robot.
-    arrival_action: str | None = None
+    # Gestures selectable per-POI (see poi["action"]) that map_node plays on arrival
+    # before advancing to the next POI. Names are dispatched as "play <name>" on
+    # /service/command; unitree_control.py maps them to SDK calls per robot model.
+    # Empty for robots with no arrival-gesture support.
+    available_actions: list[str] = field(default_factory=list)
     arrival_action_hold_s: float = 5.0
 
     @property
@@ -66,6 +67,10 @@ class RobotConfig:
         return float(hl - self.control_x), float(hl + self.control_x), float(hw)
 
 
+# go2/go2w share the vendored SDK's go2 SportClient (see unitree_control.py), so
+# both get the same "fun move" gesture vocabulary.
+_GO2_ACTIONS = ['Hello', 'Stretch', 'Heart']
+
 GO2_CONFIG = RobotConfig(
     name='go2', shape='square',
     length=0.4, width=0.3,
@@ -73,6 +78,7 @@ GO2_CONFIG = RobotConfig(
     control_x=0.0, control_y=0.0,
     safety_radius=0.2,
     obstacle=ObstacleConfig(robot_z_bottom=-0.4, robot_z_top=0.4),
+    available_actions=_GO2_ACTIONS,
 )
 
 GO2W_CONFIG = RobotConfig(
@@ -82,6 +88,7 @@ GO2W_CONFIG = RobotConfig(
     control_x=0.0, control_y=0.0,
     safety_radius=0.2,
     obstacle=ObstacleConfig(robot_z_bottom=-0.4, robot_z_top=0.4),
+    available_actions=_GO2_ACTIONS,
 )
 
 B2_CONFIG = RobotConfig(
@@ -102,6 +109,14 @@ B2W_CONFIG = RobotConfig(
     obstacle=ObstacleConfig(robot_z_bottom=-0.6, robot_z_top=0.6),
 )
 
+# Named gestures from unitree_sdk2py's g1_arm_action_client.action_map, minus
+# "release arm" (id 0) which is a reset/neutral pose, not an arrival gesture.
+_G1_ACTIONS = [
+    'shake hand', 'high five', 'hug', 'high wave', 'clap', 'face wave',
+    'left kiss', 'heart', 'right heart', 'hands up', 'x-ray', 'right hand up',
+    'reject', 'right kiss', 'two-hand kiss',
+]
+
 G1_CONFIG = RobotConfig(
     name='g1', shape='square',
     length=0.3, width=0.5,
@@ -110,7 +125,7 @@ G1_CONFIG = RobotConfig(
     safety_radius=0.15,
     min_linear_vel=0.2, min_angular_vel=0.3,
     obstacle=ObstacleConfig(robot_z_bottom=-0.8, robot_z_top=0.6),
-    arrival_action='high wave',
+    available_actions=_G1_ACTIONS,
 )
 
 ROBOT_TYPE = os.environ.get("ROBOT_TYPE", "go2").strip().lower()

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -147,7 +147,7 @@ class Ros2UnitreeManagerNode(Node):
                         f"Arm action {action_key!r} got FSM_UNAVAILABLE "
                         f"(attempt {attempt + 1}/{5}), retrying"
                     )
-                    time.sleep(0.15)
+                    time.sleep(0.2)
                 self.logger.info(f"Arm action {action_key!r}: code={code}, data={data!r}")
             elif self.is_quadruped and action_key in ROBOT_CONFIG.available_actions:
                 code = getattr(self.sport_client, action_key)()

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import rclpy
 from rclpy.node import Node
@@ -136,8 +137,18 @@ class Ros2UnitreeManagerNode(Node):
                     self.logger.info(f"Standing: Damp code={code1}, Squat2StandUp code={code2}")
                 self._robot_status = RobotStatus.STANDUP
             elif self.arm_action_client is not None and action_key in self.arm_action_map:
-                code = self.arm_action_client.ExecuteAction(self.arm_action_map[action_key])
-                self.logger.info(f"Arm action {action_key!r}: code={code}")
+                from unitree_sdk2py.g1.arm.g1_arm_action_api import ROBOT_API_ID_ARM_ACTION_EXECUTE_ACTION
+                parameter = json.dumps({"data": self.arm_action_map[action_key]})
+                for attempt in range(5):
+                    code, data = self.arm_action_client._Call(ROBOT_API_ID_ARM_ACTION_EXECUTE_ACTION, parameter)
+                    if code != 7404 or attempt == 4:
+                        break
+                    self.logger.info(
+                        f"Arm action {action_key!r} got FSM_UNAVAILABLE "
+                        f"(attempt {attempt + 1}/{5}), retrying"
+                    )
+                    time.sleep(0.15)
+                self.logger.info(f"Arm action {action_key!r}: code={code}, data={data!r}")
             elif self.is_quadruped and action_key in ROBOT_CONFIG.available_actions:
                 code = getattr(self.sport_client, action_key)()
                 self.logger.info(f"Sport action {action_key!r}: code={code}")

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -35,6 +35,18 @@ def _build_sport_client(robot_model: str):
     raise ValueError(f"Unsupported robot model: {robot_model}")
 
 
+def _build_arm_action_client(robot_model: str):
+    """g1 only: humanoid arm gestures (wave/shake hand/etc.), separate from
+    the LocoClient's stand/sit FSM. Returns (client, action_map) or (None, None)."""
+    if robot_model != 'g1':
+        return None, None
+    from unitree_sdk2py.g1.arm.g1_arm_action_client import G1ArmActionClient, action_map
+    client = G1ArmActionClient()
+    client.SetTimeout(10.0)
+    client.Init()
+    return client, action_map
+
+
 def _lowstate_type_and_topic(robot_model: str):
     if robot_model in _QUADRUPED_ROBOT_MODELS:
         from unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_
@@ -60,6 +72,7 @@ class Ros2UnitreeManagerNode(Node):
         self.sport_client = _build_sport_client(robot_model)
         self.sport_client.SetTimeout(10.0)
         self.sport_client.Init()
+        self.arm_action_client, self.arm_action_map = _build_arm_action_client(robot_model)
         if self.is_quadruped:
             self.sport_client.ClassicWalk(True)
         self._robot_status = RobotStatus.SITTING
@@ -99,8 +112,9 @@ class Ros2UnitreeManagerNode(Node):
 
     def ActionMessageHandler(self, msg: String_):
         self.logger.info(f"ActionMessageHandler received: {msg.data!r}")
-        if msg.data.split(" ")[0] == "play":
-            action_key = msg.data.split(" ")[1]
+        parts = msg.data.split(" ", 1)
+        if parts[0] == "play" and len(parts) > 1:
+            action_key = parts[1]
             if action_key == "sit":
                 if self.is_quadruped:
                     code = self.sport_client.StandDown()
@@ -120,6 +134,11 @@ class Ros2UnitreeManagerNode(Node):
                     code2 = self.sport_client.Squat2StandUp()
                     self.logger.info(f"Standing: Damp code={code1}, Squat2StandUp code={code2}")
                 self._robot_status = RobotStatus.STANDUP
+            elif self.arm_action_client is not None and action_key in self.arm_action_map:
+                code = self.arm_action_client.ExecuteAction(self.arm_action_map[action_key])
+                self.logger.info(f"Arm action {action_key!r}: code={code}")
+            else:
+                self.logger.warning(f"Unknown or unsupported action: {action_key!r}")
 
     def _publish_robot_status(self):
         msg = String()

--- a/tinynav/platforms/unitree_control.py
+++ b/tinynav/platforms/unitree_control.py
@@ -8,6 +8,7 @@ from unitree_sdk2py.idl.std_msgs.msg.dds_ import String_
 from std_msgs.msg import Float32, String
 from enum import Enum
 import time
+from tinynav.core.robot_specs import ROBOT_CONFIG
 
 # go2/b2 are quadrupeds sharing the same SportClient gait API (Move/StandUp/
 # StandDown/BalanceStand/ClassicWalk). go2w/b2w are the wheeled variants of the
@@ -137,6 +138,9 @@ class Ros2UnitreeManagerNode(Node):
             elif self.arm_action_client is not None and action_key in self.arm_action_map:
                 code = self.arm_action_client.ExecuteAction(self.arm_action_map[action_key])
                 self.logger.info(f"Arm action {action_key!r}: code={code}")
+            elif self.is_quadruped and action_key in ROBOT_CONFIG.available_actions:
+                code = getattr(self.sport_client, action_key)()
+                self.logger.info(f"Sport action {action_key!r}: code={code}")
             else:
                 self.logger.warning(f"Unknown or unsupported action: {action_key!r}")
 


### PR DESCRIPTION
## Summary
- Make POI arrival actions per-POI and configurable instead of fixed per-robot
- Play a g1 arm gesture on POI arrival and hold nav until it completes
- unitree_control: call the g1 arm action API directly and retry on FSM_UNAVAILABLE
  (code 7404) instead of failing outright, since the arm FSM can be briefly busy
  right after another action; backoff tuned to 0.2s between attempts
- robot_specs: shrink g1 footprint (length 0.3->0.2, width 0.5->0.3) to match the
  physical robot more closely, widen safety_radius (0.15->0.15, net unchanged from
  start) to compensate with a bigger planning margin

## Test plan
- [x] Verify g1 arm gesture plays and releases correctly on POI arrival
- [x] Verify robot no longer stalls short of nearby waypoints while decelerating
