### PR TITLE
Reduce planning grid resolution

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -326,7 +326,7 @@ class PlanningNode(Node):
         self.camerainfo_sub = self.create_subscription(CameraInfo, '/camera/camera/infra2/camera_info', self.info_callback, 10)
 
         self.grid_shape = (100, 100, 10)
-        self.resolution = 0.1
+        self.resolution = 0.05
         self.origin = np.array(self.grid_shape) * self.resolution / -2.
         self.step = 10
         self.occupancy_grid = np.zeros(self.grid_shape)


### PR DESCRIPTION
## Summary
- Reduce the planning node grid resolution from 0.1 m to 0.05 m.
- With the resolution cut in half, perception is more precise and narrow-path traversal is more accurate.
- The planning output frequency did not decrease in testing, and the measured behavior looks good.

## Comparison
- in go2w, default specs, it could pass 80cm hallway in 0.05m res, but fail in 0.1m
- blue line is resolution 0.1m
- orange line is resolution 0.05m
- the downing sparks of /planning/trajectory_path is caused by switching map
<img width="1397" height="928" alt="img_v3_02154_469438e8-a9a6-4209-bd15-07b2c4d62fhu" src="https://github.com/user-attachments/assets/2770513c-717c-4b3b-83a0-5446eeb93cc4" />
