### PR TITLE
feat(sim): geometric footprint collision for web planning lab

### DIFF
--- a/tests/test_sim_collision.py
+++ b/tests/test_sim_collision.py
@@ -1,0 +1,27 @@
+from tool.simulator.planning_scene import SimObject, robot_hits_objects
+
+
+def test_free_at_origin_in_l_corridor_entry():
+    robot = {"shape": "square", "length": 0.4, "width": 0.3, "control_x": 0.0}
+    wall = SimObject("wall", "box", (1.8, -0.85, 0.65), (5.6, 0.3, 1.3))
+    assert not robot_hits_objects([0.0, 0.0], 0.0, robot, [wall])
+
+
+def test_overlap_when_center_inside_box():
+    robot = {"shape": "square", "length": 0.4, "width": 0.3, "control_x": 0.0}
+    box = SimObject("block", "box", (0.0, 0.0, 0.65), (1.0, 1.0, 1.3))
+    assert robot_hits_objects([0.0, 0.0], 0.0, robot, [box])
+
+
+def test_side_graze_is_a_hit():
+    robot = {"shape": "square", "length": 0.4, "width": 0.3, "control_x": 0.0}
+    # wall along y, robot at x just overlapping the +x face
+    wall = SimObject("wall", "box", (0.25, 0.0, 0.65), (0.2, 2.0, 1.3))
+    assert robot_hits_objects([0.0, 0.0], 0.0, robot, [wall])
+
+
+if __name__ == "__main__":
+    test_free_at_origin_in_l_corridor_entry()
+    test_overlap_when_center_inside_box()
+    test_side_graze_is_a_hit()
+    print("ok")

--- a/tool/simulator/offline_planning_web/app.js
+++ b/tool/simulator/offline_planning_web/app.js
@@ -554,10 +554,10 @@ function drawPath(points, color, width, alpha = 1, targetCtx = ctx, targetCanvas
   targetCtx.restore();
 }
 
-function drawFootprint(footprint) {
+function drawFootprint(footprint, colorFill = "rgba(0, 169, 201, 0.24)", colorStroke = "#00a9c9") {
   if (!footprint?.length) return;
-  ctx.fillStyle = "rgba(0, 169, 201, 0.24)";
-  ctx.strokeStyle = "#007d95";
+  ctx.fillStyle = colorFill;
+  ctx.strokeStyle = colorStroke;
   ctx.lineWidth = 3;
   ctx.beginPath();
   footprint.forEach(([x, y], i) => {
@@ -603,14 +603,21 @@ function drawRealtimeOverlay() {
   }
   drawPath(realtimePath, "#0f766e", 4);
   drawPath(currentFrame.selected_trajectory_xy, "#00a9c9", 3, 0.95);
-  drawFootprint(currentFrame.robot_footprint_xy || []);
+  const hit = Boolean(currentFrame.collision);
+  drawFootprint(
+    currentFrame.robot_footprint_xy || [],
+    hit ? "rgba(218, 30, 40, 0.35)" : "rgba(0, 169, 201, 0.24)",
+    hit ? "#da1e28" : "#00a9c9",
+  );
   drawHeadingArrow(currentFrame.robot_xy, currentFrame.robot_yaw_deg, "#003f4a");
   if (currentFrame.robot_xy) drawMarker(currentFrame.robot_xy, "", "#003f4a", 5);
 
-  drawHudPanel([
+  const hud = [
     `realtime tick ${Math.max(0, realtimePath.length - 1)}`,
     `cmd [${(currentFrame.selected_param || []).map((v) => Number(v).toFixed(2)).join(", ")}]`,
-  ]);
+  ];
+  if (currentFrame.collision) hud.unshift("COLLISION (geometry) — reset to continue");
+  drawHudPanel(hud);
 }
 
 function drawScene() {

--- a/tool/simulator/planning_scene.py
+++ b/tool/simulator/planning_scene.py
@@ -120,6 +120,58 @@ def render_depth(
     return depth.reshape((height, width))
 
 
+def footprint_polygon_xy(control_xy, yaw_rad, robot: dict[str, Any]) -> np.ndarray:
+    """Control-frame rectangle in world XY, matching planning_node footprint_from_control."""
+    xy = np.asarray(control_xy, dtype=np.float64)[:2]
+    yaw = float(yaw_rad)
+    fwd = np.array([np.cos(yaw), np.sin(yaw)], dtype=np.float64)
+    left = np.array([-np.sin(yaw), np.cos(yaw)], dtype=np.float64)
+    length = float(robot.get("length", 0.4))
+    width = float(robot.get("width", 0.3))
+    cx = float(robot.get("control_x", 0.0))
+    hl, hw = 0.5 * length, 0.5 * width
+    front, rear = hl - cx, hl + cx
+    return np.stack([
+        xy + fwd * front + left * hw,
+        xy + fwd * front - left * hw,
+        xy - fwd * rear - left * hw,
+        xy - fwd * rear + left * hw,
+    ])
+
+
+def _project_xy(points: np.ndarray, axis: np.ndarray) -> tuple[float, float]:
+    dots = points @ axis
+    return float(dots.min()), float(dots.max())
+
+
+def _obb_hits_aabb(poly: np.ndarray, aabb_min: np.ndarray, aabb_max: np.ndarray) -> bool:
+    half = 0.5 * (aabb_max - aabb_min)
+    mid = 0.5 * (aabb_max + aabb_min)
+    e0 = poly[1] - poly[0]
+    e1 = poly[3] - poly[0]
+    axes = (np.array([1.0, 0.0]), np.array([0.0, 1.0]),
+            e0 / (np.linalg.norm(e0) + 1e-12), e1 / (np.linalg.norm(e1) + 1e-12))
+    for axis in axes:
+        a0, a1 = _project_xy(poly, axis)
+        c = float(mid @ axis)
+        r = abs(axis[0]) * half[0] + abs(axis[1]) * half[1]
+        if a1 < c - r or c + r < a0:
+            return False
+    return True
+
+
+def robot_hits_objects(control_xy, yaw_deg, robot: dict[str, Any], objects: list[SimObject]) -> bool:
+    """XY footprint vs scene boxes. Ignores map voxels and occupancy/ESDF."""
+    poly = footprint_polygon_xy(control_xy, np.deg2rad(float(yaw_deg)), robot)
+    for obj in objects:
+        if obj.kind != "box":
+            continue
+        lo, hi = obj.bounds
+        if _obb_hits_aabb(poly, lo[:2], hi[:2]):
+            return True
+    return False
+
+
 def image_u8_payload(image: np.ndarray, vmin: float, vmax: float) -> dict[str, Any]:
     u8 = np.clip((image.astype(np.float32) - vmin) / max(vmax - vmin, 1e-6), 0.0, 1.0)
     u8 = np.round(u8 * 255.0).astype(np.uint8)

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -42,9 +42,11 @@ from tool.simulator.map_volume import MapVolume
 from tool.simulator.planning_scene import (
     SimObject,
     cam_size,
+    footprint_polygon_xy,
     image_u8_payload,
     make_camera_pose_from_config,
     render_depth,
+    robot_hits_objects,
 )
 
 ROOT = Path(__file__).resolve().parent
@@ -231,6 +233,8 @@ class RosPlanningSimNode(Node):
         self.last_footprint: list[list[float]] = []
         self.last_obstacle_mask: dict[str, Any] | None = None
         self.last_esdf_grid: dict[str, Any] | None = None
+        self.collision = False
+        self.geom_footprint: list[list[float]] = []
         self.running = True
 
         self.depth_pub = self.create_publisher(Image, "/slam/depth", 10)
@@ -290,6 +294,8 @@ class RosPlanningSimNode(Node):
                 self.last_footprint = []
                 self.last_obstacle_mask = None
                 self.last_esdf_grid = None
+                self.collision = False
+                self.geom_footprint = []
 
     def cmd_callback(self, msg: Twist) -> None:
         with self.lock:
@@ -343,6 +349,9 @@ class RosPlanningSimNode(Node):
         self.target_pub.publish(msg)
 
     def integrate_cmd(self, dt: float) -> None:
+        if self.collision:
+            self.last_cmd = Twist()
+            return
         yaw = math.radians(self.yaw_deg)
         self.control_xy[0] += math.cos(yaw) * self.last_cmd.linear.x * dt
         self.control_xy[1] += math.sin(yaw) * self.last_cmd.linear.x * dt
@@ -355,14 +364,24 @@ class RosPlanningSimNode(Node):
             now = time.monotonic()
             dt = max(1e-3, min(0.2, now - self.last_update))
             self.last_update = now
+            prev_xy = [float(self.control_xy[0]), float(self.control_xy[1])]
+            prev_yaw = float(self.yaw_deg)
             self.integrate_cmd(dt)
             config = copy.deepcopy(self.config)
+            robot = config.get("robot") or _robot_dict()
+            objects = [SimObject(**obj) for obj in config.get("objects", [])]
+            if robot_hits_objects(self.control_xy, self.yaw_deg, robot, objects):
+                self.collision = True
+                self.control_xy = prev_xy
+                self.yaw_deg = prev_yaw
+                self.last_cmd = Twist()
             config.setdefault("start", {})["xy"] = [float(self.control_xy[0]), float(self.control_xy[1])]
             config["start"]["yaw_deg"] = float(self.yaw_deg)
             yaw_deg = float(self.yaw_deg)
             map_volume = self.map_volume
+            geom = footprint_polygon_xy(self.control_xy, math.radians(yaw_deg), robot)
+            self.geom_footprint = geom.tolist() + [geom[0].tolist()]
 
-        objects = [SimObject(**obj) for obj in config.get("objects", [])]
         T_cam = make_camera_pose_from_config(config["start"]["xy"], yaw_deg, config["robot"], config["camera"])
         depth = render_depth(objects, T_cam, config["camera"], map_volume=map_volume)
         with self.lock:
@@ -384,12 +403,14 @@ class RosPlanningSimNode(Node):
     def frame(self) -> dict[str, Any]:
         with self.lock:
             xy = [float(self.control_xy[0]), float(self.control_xy[1])]
+            footprint = copy.deepcopy(self.geom_footprint) or copy.deepcopy(self.last_footprint)
             return {
                 "robot_xy": xy,
                 "robot_yaw_deg": float(self.yaw_deg),
-                "robot_footprint_xy": copy.deepcopy(self.last_footprint),
+                "robot_footprint_xy": footprint,
                 "selected_trajectory_xy": copy.deepcopy(self.last_path),
                 "selected_param": [float(self.last_cmd.linear.x), float(self.last_cmd.angular.z)],
+                "collision": bool(self.collision),
                 "depth_u8": image_u8_payload(self.last_depth, 0.0, float(self.config["camera"]["max_range"])),
                 "obstacle_u8": self.last_obstacle_mask,
                 "esdf_u8": self.last_esdf_grid,


### PR DESCRIPTION
## Summary
- Add SAT collision between the control-frame robot rectangle and scene boxes (independent of ESDF/occupancy).
- On hit, freeze integration, expose `collision` on the sim frame, and show a red footprint in the web HUD until reset.
- Fail on true geometry, not raycast occupancy holes.

## Test plan
- [x] `PYTHONPATH=. python tests/test_sim_collision.py`
- [x] Websim Realtime: drive into an L-corridor wall, confirm freeze + COLLISION HUD
- [x] Reset / re-run Realtime clears collision and motion resumes
- [x] Open-space motion unchanged when not touching boxes


https://github.com/user-attachments/assets/32e647f5-5cee-4644-b624-261807ed2402

