### PR TITLE
fix(sim): use simulator control in web planning lab

### DIFF
--- a/tinynav/platforms/simulator_control.py
+++ b/tinynav/platforms/simulator_control.py
@@ -5,6 +5,7 @@ from geometry_msgs.msg import Twist
 from nav_msgs.msg import Path
 import numpy as np
 from scipy.spatial.transform import Rotation as R
+from tinynav.core.robot_specs import ROBOT_CONFIG
 
 
 class SimulatorControlNode(Node):
@@ -14,33 +15,47 @@ class SimulatorControlNode(Node):
         self.create_subscription(Path, '/planning/trajectory_path', self.path_callback, 10)
 
         self.last_path = None
+        self.T_robot_to_camera = np.array([
+            [0, -1, 0, 0],
+            [0, 0, -1, 0],
+            [1, 0, 0, 0],
+            [0, 0, 0, 1]]
+        )
+        self.planner_dt = 0.1
+        self.path_pose_stride = 10
+        self.lookahead_steps = 1
+        self.max_forward_speed = ROBOT_CONFIG.max_linear_vel
+        self.max_angular_speed = ROBOT_CONFIG.max_angular_vel
 
     def path_callback(self, msg):
         self.last_path = msg
-        # Publish the planned velocity
-        ## calculate diff between current time, and last path time
         if self.last_path is None:
             return
-        dt = 0.1  # Time step from trajectory generation
-        idx = 1
-        if idx < 0 or idx >= len(self.last_path.poses):
+        if len(self.last_path.poses) < 2:
             self.get_logger().warn("Index out of bounds for path poses, cannot publish planned velocity.")
             return
-        # get the velocity from the path.pose[idx] - path.pose[idx]
-        p1 = self.last_path.poses[idx].pose.position
-        p2 = self.last_path.poses[idx + 1].pose.position
-        linear_velocity_vec = np.array([p2.x - p1.x, p2.y - p1.y, p2.z - p1.z]) / dt
-        q1 = self.last_path.poses[idx].pose.orientation
-        q2 = self.last_path.poses[idx + 1].pose.orientation
-        r1 = R.from_quat([q1.x, q1.y, q1.z, q1.w])
-        r2 = R.from_quat([q2.x, q2.y, q2.z, q2.w])
-        angular_velocity_vec = (r2 * r1.inv()).as_rotvec() / dt
-        cmd = Twist()
-        cmd.linear.x = linear_velocity_vec[0] * 0.5  # Max 0.5 m/s
-        cmd.angular.z = angular_velocity_vec[2] * 1.0  # Max 1.0 rad/s
 
-        cmd.linear.x = np.clip(cmd.linear.x, -0.5, 0.5)
-        cmd.angular.z = np.clip(cmd.angular.z, -0.5, 0.5)
+        def msg2np(pose_stamped):
+            T = np.eye(4)
+            position = pose_stamped.pose.position
+            quat = pose_stamped.pose.orientation
+            T[:3, :3] = R.from_quat([quat.x, quat.y, quat.z, quat.w]).as_matrix()
+            T[:3, 3] = np.array([position.x, position.y, position.z]).ravel()
+            return T
+
+        step_idx = int(min(self.lookahead_steps, len(self.last_path.poses) - 1))
+        T1 = msg2np(self.last_path.poses[0]) @ self.T_robot_to_camera
+        T2 = msg2np(self.last_path.poses[step_idx]) @ self.T_robot_to_camera
+        T_robot_2_to_1 = np.linalg.inv(T1) @ T2
+        dt = self.planner_dt * self.path_pose_stride * max(1, step_idx)
+        p = T_robot_2_to_1[:3, 3]
+        linear_velocity_vec = p / dt
+        angular_velocity_vec = R.from_matrix(T_robot_2_to_1[:3, :3]).as_rotvec() / dt
+
+        cmd = Twist()
+        cmd.linear.x = float(np.clip(linear_velocity_vec[0], -self.max_forward_speed, self.max_forward_speed))
+        cmd.angular.z = float(np.clip(angular_velocity_vec[2], -self.max_angular_speed, self.max_angular_speed))
+
         print(f"cmd: {cmd}")
         self.cmd_pub.publish(cmd)
 
@@ -59,4 +74,3 @@ def main(args=None):
 
 if __name__ == '__main__':
     main()
-

--- a/tool/simulator/ros_planning_web.py
+++ b/tool/simulator/ros_planning_web.py
@@ -3,7 +3,7 @@
 
 Web UI edits the scene. This process publishes synthetic /slam/depth,
 /slam/odometry(_visual), /control/target_pose, then mirrors outputs from the
-real planning_node + cmd_vel_control loop.
+real planning_node + simulator_control loop.
 """
 
 from __future__ import annotations
@@ -437,7 +437,7 @@ EXECUTOR: MultiThreadedExecutor | None = None
 PROCS: list[subprocess.Popen] = []
 CHILD_SCRIPTS = (
     "tinynav/core/planning_node.py",
-    "tinynav/platforms/cmd_vel_control.py",
+    "tinynav/platforms/simulator_control.py",
 )
 _LAST_PLANNING_RESET = 0.0
 _PLANNING_RESET_COOLDOWN_S = 1.0
@@ -614,7 +614,7 @@ def update_config(request: RunRequest) -> dict[str, Any]:
     node.set_config(copy.deepcopy(request.config), reset=reset)
     robot_changed = prev_robot != node.config.get("robot", {}).get("name")
     if robot_changed:
-        _stop_script("tinynav/platforms/cmd_vel_control.py")
+        _stop_script("tinynav/platforms/simulator_control.py")
     if reset or robot_changed:
         ensure_ros_loop(reset_planning=True, force=robot_changed)
     return {"ok": True, "robot_changed": robot_changed}


### PR DESCRIPTION
## Summary

The web planning lab is meant to validate planner behavior in a lightweight simulator loop, but it was launching the production `cmd_vel_control.py` node. That made simulated motion depend on real-robot safety behavior such as nav active state, stale-path slowdown, acceleration limiting, minimum executable velocity, and rotate-first gates. In practice this could make the web sim look artificially slow even when the planner path itself implied a much higher forward speed.

This PR switches the web lab back to simulator-specific control and fixes that simulator control path so the published `/cmd_vel` better reflects the planner trajectory:

- run the web planning lab with `simulator_control.py` instead of the real `cmd_vel_control.py`
- compute simulator cmd velocity in the robot frame from the published planning path
- use the path publish stride when deriving velocity, and clamp against `ROBOT_CONFIG` limits

## Test

- `python3 -m py_compile tinynav/platforms/simulator_control.py tool/simulator/ros_planning_web.py`
