### PR TITLE
refactor: name the steps of relocalization, fusion, map loading and planning

### DIFF
--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -231,6 +231,24 @@ class MapNode(Node):
 
         os.makedirs(f"{tinynav_db_path}/nav_temp", exist_ok=True)
         self.nav_temp_db = TinyNavDB(f"{tinynav_db_path}/nav_temp", is_scratch=True)
+        self.load_map(tinynav_map_path)
+        self.reset_map_state()
+
+        self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
+        self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
+        self.nav_done_pub = self.create_publisher(Bool, '/mapping/nav_done', 10)
+        self.nav_progress_pub = self.create_publisher(String, '/mapping/nav_progress', 10)
+
+        self.current_pose_pub = self.create_publisher(Odometry, "/mapping/current_pose", 10)
+        self.global_plan_pub = self.create_publisher(Path, '/mapping/global_plan', 10)
+        self.target_pose_pub = self.create_publisher(Odometry, "/control/target_pose", 10)
+
+        self.tf_broadcaster = TransformBroadcaster(self)
+
+        self._save_completed = False
+        self.nav_target_timer = self.create_timer(0.5, self.nav_target_timer_callback)
+
+    def load_map(self, tinynav_map_path: str) -> None:
         self.map_poses = np.load(f"{tinynav_map_path}/poses.npy", allow_pickle=True).item()
         self.map_K = np.load(f"{tinynav_map_path}/intrinsics.npy")
         self.db = TinyNavDB(tinynav_map_path, is_scratch=False)
@@ -260,6 +278,7 @@ class MapNode(Node):
         print(f"sdf_map.shape: {self.sdf_map.shape}")
         print(f"occupancy_map.shape: {self.occupancy_map.shape}")
 
+    def reset_map_state(self) -> None:
         self.relocalization_poses = {}
         self.relocalization_pose_weights = {}
         self.failed_relocalizations = []
@@ -274,20 +293,6 @@ class MapNode(Node):
         self._speed_estimate: float | None = None
         self.cached_nav_path_in_map = None
         self.cached_nav_path_poi_index = -1
-
-        self.poi_pub = self.create_publisher(Odometry, "/mapping/poi", 10)
-        self.poi_change_pub = self.create_publisher(Odometry, "/mapping/poi_change", 10)
-        self.nav_done_pub = self.create_publisher(Bool, '/mapping/nav_done', 10)
-        self.nav_progress_pub = self.create_publisher(String, '/mapping/nav_progress', 10)
-
-        self.current_pose_pub = self.create_publisher(Odometry, "/mapping/current_pose", 10)
-        self.global_plan_pub = self.create_publisher(Path, '/mapping/global_plan', 10)
-        self.target_pose_pub = self.create_publisher(Odometry, "/control/target_pose", 10)
-
-        self.tf_broadcaster = TransformBroadcaster(self)
-
-        self._save_completed = False
-        self.nav_target_timer = self.create_timer(0.5, self.nav_target_timer_callback)
 
     def pois_callback(self, msg: String):
         self.get_logger().info("Received POIs from planner: " + msg.data)
@@ -462,27 +467,34 @@ class MapNode(Node):
             path_msg.poses.append(pose)
         self.pose_graph_trajectory_pub.publish(path_msg)
 
+    def select_relocalization_candidates(self, query_vlad: np.ndarray) -> list[tuple[int, float]]:
+        return [
+            (int(self.vlad_timestamps[idx_in_map]), float(similarity))
+            for idx_in_map, similarity in find_loop(
+                query_vlad,
+                self.map_vlad_descriptors,
+                -1.0,
+                self.relocalization_loop_top_k,
+            )
+        ]
+
+    def rank_relocalization_candidates(self, pnp_candidates: list, candidate_timestamps: list[int]) -> tuple[bool, np.ndarray, float]:
+        success, best_pose_in_camera, pose_cov_weight, _, _, _ = rerank_by_pnp_inliers(pnp_candidates, self.map_K)
+        return success, best_pose_in_camera, pose_cov_weight
+
     def relocalize_with_depth(self, keyframe: np.ndarray, keyframe_features: dict, K: np.ndarray | None) -> tuple[bool, np.ndarray, float]:
         if K is None:
             return False, np.eye(4), -np.inf
 
         query_vlad = self.get_vlad_descriptor(keyframe)
-        idx_and_similarity_array = find_loop(
-            query_vlad,
-            self.map_vlad_descriptors,
-            -1.0,
-            self.relocalization_loop_top_k,
-        )
-        if len(idx_and_similarity_array) == 0:
+        candidates = self.select_relocalization_candidates(query_vlad)
+        if len(candidates) == 0:
             print("VLAD: no relocalization candidates")
             return False, np.eye(4), -np.inf
-        candidate_timestamps = [
-            int(self.vlad_timestamps[idx_in_map])
-            for idx_in_map, _similarity in idx_and_similarity_array
-        ]
 
         pnp_candidates = []
-        for timestamp_in_map in candidate_timestamps:
+        pnp_timestamps = []
+        for timestamp_in_map, _similarity in candidates:
             reference_keyframe_pose = self.map_poses[timestamp_in_map]
             reference_depth, _, reference_features, _, _ = self.db.get_depth_embedding_features_images(timestamp_in_map)
             reference_matched_keypoints, keyframe_matched_keypoints, matches = self.match_keypoints(reference_features, keyframe_features)
@@ -498,8 +510,9 @@ class MapNode(Node):
                 print(f"not enough landmarks to relocalize, {point_count}")
                 continue
             pnp_candidates.append((point_3d_in_world_list, point_2d_in_keyframe_list))
+            pnp_timestamps.append(timestamp_in_map)
 
-        success, best_pose_in_camera, pose_cov_weight, _, _, _ = rerank_by_pnp_inliers(pnp_candidates, self.map_K)
+        success, best_pose_in_camera, pose_cov_weight = self.rank_relocalization_candidates(pnp_candidates, pnp_timestamps)
         if success:
             print(f"relocalization pose : {best_pose_in_camera}")
             return True, best_pose_in_camera, pose_cov_weight
@@ -585,6 +598,9 @@ class MapNode(Node):
             pass
 
 
+    def select_fusion_constraints(self, constraints):
+        return constraints[-100:]
+
     def compute_transform_from_map_to_odom(self):
         """
         Solve the optmization problem.
@@ -603,7 +619,7 @@ class MapNode(Node):
                 weight = self.relocalization_pose_weights[timestamp]
 
                 relative_pose_constraint.append((0, 1, observation_T_from_map_to_odom, weight * np.array([10.0, 10.0, 10.0]), weight * np.array([10.0, 10.0, 10.0])))
-        relative_pose_constraint = relative_pose_constraint[-100:]
+        relative_pose_constraint = self.select_fusion_constraints(relative_pose_constraint)
         optimized_parameters = pose_graph_solve(optimized_parameters, relative_pose_constraint, constant_pose_index_dict, max_iteration_num = 1000)
         self.T_from_map_to_odom = optimized_parameters[0]
 
@@ -620,6 +636,47 @@ class MapNode(Node):
             pose.pose.orientation.w = 1.0
             path_msg.poses.append(pose)
         self.global_plan_pub.publish(path_msg)
+
+    def poi_reached(self, poi, pos):
+        return np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0
+
+    def publish_nav_progress(self, percent, path_remaining_m, path_total_m, estimated_remaining_s):
+        self.nav_progress_pub.publish(String(data=json.dumps({
+            "poi_index": self.poi_index,
+            "percent": percent,
+            "path_remaining_m": path_remaining_m,
+            "path_total_m": path_total_m,
+            "estimated_remaining_s": estimated_remaining_s,
+        })))
+
+    def update_leg_progress(self, remaining_length):
+        now = time.time()
+        if self._leg_initial_length is None:
+            self._leg_initial_length = remaining_length
+            self._leg_start_time = now
+
+        covered = self._leg_initial_length - remaining_length
+        elapsed = now - self._leg_start_time
+        if covered > 0.1 and elapsed > 1.0:
+            self._speed_estimate = covered / elapsed
+
+        initial = self._leg_initial_length
+        percent = max(0.0, min(100.0, covered / initial * 100.0)) if initial > 0 else 0.0
+        estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
+        return percent, estimated_remaining_s
+
+    def select_target_position(self, paths, closest_idx, pos):
+        max_speed = 0.5
+        accumulated_distance = 0.0
+        start_point = pos[:3]
+        target_position = paths[-1]
+        for i in range(closest_idx, len(paths) - 1):
+            accumulated_distance += np.linalg.norm(paths[i][:2] - start_point[:2])
+            if accumulated_distance > max_speed * 5:
+                target_position = paths[i]
+                break
+            start_point = paths[i]
+        return target_position
 
     def nav_target_timer_callback(self):
         if (
@@ -642,15 +699,9 @@ class MapNode(Node):
         poi = self.pois[self.poi_index]
         pos = pose_in_map[:3, 3]
 
-        if np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0:
+        if self.poi_reached(poi, pos):
             if self._leg_initial_length is not None:
-                self.nav_progress_pub.publish(String(data=json.dumps({
-                    "poi_index": self.poi_index,
-                    "percent": 100.0,
-                    "path_remaining_m": 0.0,
-                    "path_total_m": round(self._leg_initial_length, 2),
-                    "estimated_remaining_s": 0.0,
-                })))
+                self.publish_nav_progress(100.0, 0.0, round(self._leg_initial_length, 2), 0.0)
             self.poi_index += 1
             self._leg_initial_length = None
             self._leg_start_time = None
@@ -693,38 +744,12 @@ class MapNode(Node):
             for i in range(closest_idx, len(paths) - 1)
         ) if closest_idx < len(paths) - 1 else 0.0
 
-        now = time.time()
-        if self._leg_initial_length is None:
-            self._leg_initial_length = remaining_length
-            self._leg_start_time = now
+        percent, estimated_remaining_s = self.update_leg_progress(remaining_length)
 
-        covered = self._leg_initial_length - remaining_length
-        elapsed = now - self._leg_start_time
-        if covered > 0.1 and elapsed > 1.0:
-            self._speed_estimate = covered / elapsed
+        self.publish_nav_progress(round(percent, 1), round(remaining_length, 2),
+                                  round(self._leg_initial_length, 2), round(estimated_remaining_s, 1))
 
-        initial = self._leg_initial_length
-        percent = max(0.0, min(100.0, covered / initial * 100.0)) if initial > 0 else 0.0
-        estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
-
-        self.nav_progress_pub.publish(String(data=json.dumps({
-            "poi_index": self.poi_index,
-            "percent": round(percent, 1),
-            "path_remaining_m": round(remaining_length, 2),
-            "path_total_m": round(initial, 2),
-            "estimated_remaining_s": round(estimated_remaining_s, 1),
-        })))
-
-        max_speed = 0.5
-        accumulated_distance = 0.0
-        start_point = pos[:3]
-        target_position = paths[-1]
-        for i in range(closest_idx, len(paths) - 1):
-            accumulated_distance += np.linalg.norm(paths[i][:2] - start_point[:2])
-            if accumulated_distance > max_speed * 5:
-                target_position = paths[i]
-                break
-            start_point = paths[i]
+        target_position = self.select_target_position(paths, closest_idx, pos)
 
         T = self.latest_odom_pose @ np.linalg.inv(pose_in_map)
         target_position_in_odom = T[:3, :3] @ target_position + T[:3, 3]

--- a/tinynav/core/map_node.py
+++ b/tinynav/core/map_node.py
@@ -175,6 +175,40 @@ def search_within_sdf_map( start:tuple, goal:tuple, sdf_map:np.ndarray, occupanc
                             parent[neighbor] = current
     return []
 
+def select_relocalization_candidates(query_vlad: np.ndarray, map_vlad_descriptors: np.ndarray, vlad_timestamps: np.ndarray, top_k: int) -> list[tuple[int, float]]:
+    return [
+        (int(vlad_timestamps[idx_in_map]), float(similarity))
+        for idx_in_map, similarity in find_loop(
+            query_vlad,
+            map_vlad_descriptors,
+            -1.0,
+            top_k,
+        )
+    ]
+
+def rank_relocalization_candidates(pnp_candidates: list, map_K: np.ndarray) -> tuple[bool, np.ndarray, float]:
+    success, best_pose_in_camera, pose_cov_weight, _, _, _ = rerank_by_pnp_inliers(pnp_candidates, map_K)
+    return success, best_pose_in_camera, pose_cov_weight
+
+def select_fusion_constraints(constraints):
+    return constraints[-100:]
+
+def poi_reached(poi, pos):
+    return np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0
+
+def select_target_position(paths, closest_idx, pos):
+    max_speed = 0.5
+    accumulated_distance = 0.0
+    start_point = pos[:3]
+    target_position = paths[-1]
+    for i in range(closest_idx, len(paths) - 1):
+        accumulated_distance += np.linalg.norm(paths[i][:2] - start_point[:2])
+        if accumulated_distance > max_speed * 5:
+            target_position = paths[i]
+            break
+        start_point = paths[i]
+    return target_position
+
 class MapNode(Node):
     def __init__(self, tinynav_db_path: str, tinynav_map_path: str, verbose_timer: bool = True):
         """Initialization
@@ -467,33 +501,17 @@ class MapNode(Node):
             path_msg.poses.append(pose)
         self.pose_graph_trajectory_pub.publish(path_msg)
 
-    def select_relocalization_candidates(self, query_vlad: np.ndarray) -> list[tuple[int, float]]:
-        return [
-            (int(self.vlad_timestamps[idx_in_map]), float(similarity))
-            for idx_in_map, similarity in find_loop(
-                query_vlad,
-                self.map_vlad_descriptors,
-                -1.0,
-                self.relocalization_loop_top_k,
-            )
-        ]
-
-    def rank_relocalization_candidates(self, pnp_candidates: list, candidate_timestamps: list[int]) -> tuple[bool, np.ndarray, float]:
-        success, best_pose_in_camera, pose_cov_weight, _, _, _ = rerank_by_pnp_inliers(pnp_candidates, self.map_K)
-        return success, best_pose_in_camera, pose_cov_weight
-
     def relocalize_with_depth(self, keyframe: np.ndarray, keyframe_features: dict, K: np.ndarray | None) -> tuple[bool, np.ndarray, float]:
         if K is None:
             return False, np.eye(4), -np.inf
 
         query_vlad = self.get_vlad_descriptor(keyframe)
-        candidates = self.select_relocalization_candidates(query_vlad)
+        candidates = select_relocalization_candidates(query_vlad, self.map_vlad_descriptors, self.vlad_timestamps, self.relocalization_loop_top_k)
         if len(candidates) == 0:
             print("VLAD: no relocalization candidates")
             return False, np.eye(4), -np.inf
 
         pnp_candidates = []
-        pnp_timestamps = []
         for timestamp_in_map, _similarity in candidates:
             reference_keyframe_pose = self.map_poses[timestamp_in_map]
             reference_depth, _, reference_features, _, _ = self.db.get_depth_embedding_features_images(timestamp_in_map)
@@ -510,9 +528,8 @@ class MapNode(Node):
                 print(f"not enough landmarks to relocalize, {point_count}")
                 continue
             pnp_candidates.append((point_3d_in_world_list, point_2d_in_keyframe_list))
-            pnp_timestamps.append(timestamp_in_map)
 
-        success, best_pose_in_camera, pose_cov_weight = self.rank_relocalization_candidates(pnp_candidates, pnp_timestamps)
+        success, best_pose_in_camera, pose_cov_weight = rank_relocalization_candidates(pnp_candidates, self.map_K)
         if success:
             print(f"relocalization pose : {best_pose_in_camera}")
             return True, best_pose_in_camera, pose_cov_weight
@@ -598,9 +615,6 @@ class MapNode(Node):
             pass
 
 
-    def select_fusion_constraints(self, constraints):
-        return constraints[-100:]
-
     def compute_transform_from_map_to_odom(self):
         """
         Solve the optmization problem.
@@ -619,7 +633,7 @@ class MapNode(Node):
                 weight = self.relocalization_pose_weights[timestamp]
 
                 relative_pose_constraint.append((0, 1, observation_T_from_map_to_odom, weight * np.array([10.0, 10.0, 10.0]), weight * np.array([10.0, 10.0, 10.0])))
-        relative_pose_constraint = self.select_fusion_constraints(relative_pose_constraint)
+        relative_pose_constraint = select_fusion_constraints(relative_pose_constraint)
         optimized_parameters = pose_graph_solve(optimized_parameters, relative_pose_constraint, constant_pose_index_dict, max_iteration_num = 1000)
         self.T_from_map_to_odom = optimized_parameters[0]
 
@@ -636,9 +650,6 @@ class MapNode(Node):
             pose.pose.orientation.w = 1.0
             path_msg.poses.append(pose)
         self.global_plan_pub.publish(path_msg)
-
-    def poi_reached(self, poi, pos):
-        return np.linalg.norm(poi[:2] - pos[:2]) < 0.5 and abs(poi[2] - pos[2]) < 2.0
 
     def publish_nav_progress(self, percent, path_remaining_m, path_total_m, estimated_remaining_s):
         self.nav_progress_pub.publish(String(data=json.dumps({
@@ -665,19 +676,6 @@ class MapNode(Node):
         estimated_remaining_s = remaining_length / self._speed_estimate if self._speed_estimate else -1.0
         return percent, estimated_remaining_s
 
-    def select_target_position(self, paths, closest_idx, pos):
-        max_speed = 0.5
-        accumulated_distance = 0.0
-        start_point = pos[:3]
-        target_position = paths[-1]
-        for i in range(closest_idx, len(paths) - 1):
-            accumulated_distance += np.linalg.norm(paths[i][:2] - start_point[:2])
-            if accumulated_distance > max_speed * 5:
-                target_position = paths[i]
-                break
-            start_point = paths[i]
-        return target_position
-
     def nav_target_timer_callback(self):
         if (
             self.poi_index < 0
@@ -699,7 +697,7 @@ class MapNode(Node):
         poi = self.pois[self.poi_index]
         pos = pose_in_map[:3, 3]
 
-        if self.poi_reached(poi, pos):
+        if poi_reached(poi, pos):
             if self._leg_initial_length is not None:
                 self.publish_nav_progress(100.0, 0.0, round(self._leg_initial_length, 2), 0.0)
             self.poi_index += 1
@@ -749,7 +747,7 @@ class MapNode(Node):
         self.publish_nav_progress(round(percent, 1), round(remaining_length, 2),
                                   round(self._leg_initial_length, 2), round(estimated_remaining_s, 1))
 
-        target_position = self.select_target_position(paths, closest_idx, pos)
+        target_position = select_target_position(paths, closest_idx, pos)
 
         T = self.latest_odom_pose @ np.linalg.inv(pose_in_map)
         target_position_in_odom = T[:3, :3] @ target_position + T[:3, 3]

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -299,6 +299,18 @@ def roll_occupancy_grid(occupancy_grid, old_origin, new_origin, resolution):
     return rolled, updated_origin
 
 
+def generate_trajectories(init_p, init_q):
+    trajectories, params = generate_trajectory_library_3d(
+        init_p=init_p, init_q=init_q,
+        max_linear_vel=ROBOT_CONFIG.max_linear_vel,
+        max_angular_vel=ROBOT_CONFIG.max_angular_vel,
+    )
+    vocab_trajs, vocab_params = generate_predefined_trajectory_vocabularies(init_p=init_p, init_q=init_q)
+    trajectories = np.concatenate([trajectories, vocab_trajs], axis=0)
+    params = np.concatenate([params, vocab_params], axis=0)
+    return trajectories, params
+
+
 # === PlanningNode class ===
 class PlanningNode(Node):
     def __init__(self):
@@ -529,17 +541,6 @@ class PlanningNode(Node):
         self.occupancy_grid += new_occ
         self.occupancy_grid = np.clip(self.occupancy_grid, -0.2, 0.2)
 
-    def generate_trajectories(self, init_p, init_q):
-        trajectories, params = generate_trajectory_library_3d(
-            init_p=init_p, init_q=init_q,
-            max_linear_vel=ROBOT_CONFIG.max_linear_vel,
-            max_angular_vel=ROBOT_CONFIG.max_angular_vel,
-        )
-        vocab_trajs, vocab_params = generate_predefined_trajectory_vocabularies(init_p=init_p, init_q=init_q)
-        trajectories = np.concatenate([trajectories, vocab_trajs], axis=0)
-        params = np.concatenate([params, vocab_params], axis=0)
-        return trajectories, params
-
     def trajectory_cost(self, traj, param, score, target_pose, front_clearance, enter_threshold):
         # predefined backward trajectory penalty
         is_backward_traj = param[0] < 0.0
@@ -617,7 +618,7 @@ class PlanningNode(Node):
         with Timer(name='traj gen', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             init_p = self.camera_to_robot_center(T)
             init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
-            trajectories, params = self.generate_trajectories(init_p, init_q)
+            trajectories, params = generate_trajectories(init_p, init_q)
             self.last_T = T
             self.last_stamp = stamp
 

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -495,6 +495,98 @@ class PlanningNode(Node):
         ]
         self.occupancy_cloud_esdf_pub.publish(pc2.create_cloud(header, fields, points))
 
+    def update_velocity_estimate(self, T, stamp):
+        if self.last_T is None:
+            self.last_T = T.copy()
+            self.smoothed_velocity = 0.0
+            self.last_stamp = 0
+            self.smoothed_velocity = 0.0
+        velocity_estimated = np.linalg.norm(T[:3, 3] - self.last_T[:3, 3]) / (stamp - self.last_stamp)
+        self.smoothed_velocity = 0.9 * self.smoothed_velocity + 0.1 * velocity_estimated
+
+    def build_obstacle_and_esdf(self, T):
+        obstacle_mask = build_obstacle_map(
+            self.occupancy_grid, self.origin, self.resolution,
+            robot_z=T[2, 3], config=self.obstacle_config,
+        )
+        ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
+        return obstacle_mask, ESDF_map
+
+    def score_trajectories(self, trajectories, ESDF_map):
+        front_len, rear_len, half_w = ROBOT_CONFIG.footprint_from_control()
+        return score_trajectories_by_ESDF(trajectories, ESDF_map, self.origin, self.resolution, ROBOT_CONFIG.safety_radius, front_len, rear_len, half_w)
+
+    def update_occupancy_grid(self, depth, T, fx, fy, cx, cy):
+        center = self.origin + np.array(self.grid_shape) * self.resolution / 2
+        robot_pos = T[:3, 3]
+        delta = robot_pos - center
+        if np.linalg.norm(delta) > .1:
+            new_center = robot_pos
+            new_origin = new_center - np.array(self.grid_shape) * self.resolution / 2
+            self.occupancy_grid, self.origin = roll_occupancy_grid(self.occupancy_grid, self.origin, new_origin, self.resolution)
+        new_occ = run_raycasting_loopy(depth, T, self.grid_shape, fx, fy, cx, cy, self.origin, self.step, self.resolution)
+        self.occupancy_grid *= 0.99
+        self.occupancy_grid += new_occ
+        self.occupancy_grid = np.clip(self.occupancy_grid, -0.2, 0.2)
+
+    def generate_trajectories(self, init_p, init_q):
+        trajectories, params = generate_trajectory_library_3d(
+            init_p=init_p, init_q=init_q,
+            max_linear_vel=ROBOT_CONFIG.max_linear_vel,
+            max_angular_vel=ROBOT_CONFIG.max_angular_vel,
+        )
+        vocab_trajs, vocab_params = generate_predefined_trajectory_vocabularies(init_p=init_p, init_q=init_q)
+        trajectories = np.concatenate([trajectories, vocab_trajs], axis=0)
+        params = np.concatenate([params, vocab_params], axis=0)
+        return trajectories, params
+
+    def trajectory_cost(self, traj, param, score, target_pose, front_clearance, enter_threshold):
+        # predefined backward trajectory penalty
+        is_backward_traj = param[0] < 0.0
+        should_reverse = front_clearance <= enter_threshold
+        reverse_gate_penalty = 0.0
+        if should_reverse and not is_backward_traj:
+                reverse_gate_penalty = 1e9
+        elif not should_reverse and is_backward_traj:
+                reverse_gate_penalty = 1e9
+
+        # regular trajectory penalty
+        traj_end = np.array(traj[-1,:3])
+        target_end = target_pose if target_pose is not None else traj_end
+        dist = np.linalg.norm(traj_end - target_end)
+        # heading error weighted like distance (1 rad ~ 1 m) far from the goal, faded out
+        # linearly inside 2 m so bearing noise cannot dominate the distance term on arrival
+        heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / 2.0)
+
+        return (
+            score * 2000
+            + 1000 * dist
+            + 100 * heading
+            + 10 * abs(self.last_param[0] - param[0])
+            + 10 * abs(self.last_param[1] - param[1])
+            + reverse_gate_penalty
+        )
+
+    def publish_selected_path(self, trajectories, top_indices, header):
+        path = Path()
+        path.header = header
+        path.header.frame_id = "world"
+
+        for i in top_indices:
+            for j in range(0, len(trajectories[i]), 10):
+                x,y,z,qx,qy,qz,qw = trajectories[i][j]
+                pose = PoseStamped()
+                pose.header = header
+                pose.pose.position.x = x
+                pose.pose.position.y = y
+                pose.pose.position.z = z
+                pose.pose.orientation.x = qx
+                pose.pose.orientation.y = qy
+                pose.pose.orientation.z = qz
+                pose.pose.orientation.w = qw
+                path.poses.append(pose)
+        self.path_pub.publish(path)
+
     @Timer(name="Planning Loop", text="\n\n[{name}] Elapsed time: {milliseconds:.0f} ms")
     def sync_callback(self, depth_msg, odom_msg):
         if self.K is None:
@@ -503,37 +595,17 @@ class PlanningNode(Node):
             depth = self.bridge.imgmsg_to_cv2(depth_msg, desired_encoding='32FC1')
             stamp = Time.from_msg(odom_msg.header.stamp).nanoseconds / 1e9
             T,_ = msg2np(odom_msg)
-            if self.last_T is None:
-                self.last_T = T.copy()
-                self.smoothed_velocity = 0.0
-                self.last_stamp = 0
-                self.smoothed_velocity = 0.0
-            velocity_estimated = np.linalg.norm(T[:3, 3] - self.last_T[:3, 3]) / (stamp - self.last_stamp)
-            self.smoothed_velocity = 0.9 * self.smoothed_velocity + 0.1 * velocity_estimated
+            self.update_velocity_estimate(T, stamp)
             fx, fy = self.K[0, 0], self.K[1, 1]
             cx, cy = self.K[0, 2], self.K[1, 2]
 
         with Timer(name='raycasting', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            center = self.origin + np.array(self.grid_shape) * self.resolution / 2
-            robot_pos = T[:3, 3]
-            delta = robot_pos - center
-            if np.linalg.norm(delta) > .1:
-                new_center = robot_pos
-                new_origin = new_center - np.array(self.grid_shape) * self.resolution / 2
-                self.occupancy_grid, self.origin = roll_occupancy_grid(self.occupancy_grid, self.origin, new_origin, self.resolution)
-            new_occ = run_raycasting_loopy(depth, T, self.grid_shape, fx, fy, cx, cy, self.origin, self.step, self.resolution)
-            self.occupancy_grid *= 0.99
-            self.occupancy_grid += new_occ
-            self.occupancy_grid = np.clip(self.occupancy_grid, -0.2, 0.2)
+            self.update_occupancy_grid(depth, T, fx, fy, cx, cy)
 
             self.publish_3d_occupancy_cloud(self.occupancy_grid, self.resolution, self.origin)
 
         with Timer(name='obstacle map', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            obstacle_mask = build_obstacle_map(
-                self.occupancy_grid, self.origin, self.resolution,
-                robot_z=T[2, 3], config=self.obstacle_config,
-            )
-            ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
+            obstacle_mask, ESDF_map = self.build_obstacle_and_esdf(T)
 
         with Timer(name='vis', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             self.publish_3d_occupancy_cloud_with_esdf(self.occupancy_grid, ESDF_map, self.resolution, self.origin)
@@ -545,60 +617,20 @@ class PlanningNode(Node):
         with Timer(name='traj gen', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             init_p = self.camera_to_robot_center(T)
             init_q = np.array([odom_msg.pose.pose.orientation.x, odom_msg.pose.pose.orientation.y, odom_msg.pose.pose.orientation.z, odom_msg.pose.pose.orientation.w])
-            trajectories, params = generate_trajectory_library_3d(
-                init_p=init_p, init_q=init_q,
-                max_linear_vel=ROBOT_CONFIG.max_linear_vel,
-                max_angular_vel=ROBOT_CONFIG.max_angular_vel,
-            )
-            vocab_trajs, vocab_params = generate_predefined_trajectory_vocabularies(init_p=init_p, init_q=init_q)
-            trajectories = np.concatenate([trajectories, vocab_trajs], axis=0)
-            params = np.concatenate([params, vocab_params], axis=0)
+            trajectories, params = self.generate_trajectories(init_p, init_q)
             self.last_T = T
             self.last_stamp = stamp
 
         with Timer(name='traj score', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            front_len, rear_len, half_w = ROBOT_CONFIG.footprint_from_control()
-            scores, occ_points = score_trajectories_by_ESDF(trajectories, ESDF_map, self.origin, self.resolution, ROBOT_CONFIG.safety_radius, front_len, rear_len, half_w)
+            scores, occ_points = self.score_trajectories(trajectories, ESDF_map)
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
             enter_threshold = 0.30
 
-            def cost_function(traj, param, score, target_pose):
-                # predefined backward trajectory penalty
-                is_backward_traj = param[0] < 0.0
-                should_reverse = front_clearance <= enter_threshold
-                reverse_gate_penalty = 0.0
-                if should_reverse and not is_backward_traj:
-                        reverse_gate_penalty = 1e9
-                elif not should_reverse and is_backward_traj:
-                        reverse_gate_penalty = 1e9
-
-                # regular trajectory penalty
-                traj_end = np.array(traj[-1,:3])
-                target_end = target_pose if target_pose is not None else traj_end
-                dist = np.linalg.norm(traj_end - target_end)
-                # heading error weighted like distance (1 rad ~ 1 m) far from the goal, faded out
-                # linearly inside 2 m so bearing noise cannot dominate the distance term on arrival
-                heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / 2.0)
-
-                return (
-                    score * 2000
-                    + 1000 * dist
-                    + 100 * heading
-                    + 10 * abs(self.last_param[0] - param[0])
-                    + 10 * abs(self.last_param[1] - param[1])
-                    + reverse_gate_penalty
-                )
-
             top_k = 1
-            top_indices = np.argsort(np.array([cost_function(trajectories[i], params[i], scores[i], self.target_pose) for i in range(len(trajectories))]), kind='stable')[:top_k]
+            top_indices = np.argsort(np.array([self.trajectory_cost(trajectories[i], params[i], scores[i], self.target_pose, front_clearance, enter_threshold) for i in range(len(trajectories))]), kind='stable')[:top_k]
             self.last_param = params[top_indices[0]]
-
-            # path
-            path = Path()
-            path.header = depth_msg.header
-            path.header.frame_id = "world"
 
             if self.target_pose is None:
                 return
@@ -607,20 +639,7 @@ class PlanningNode(Node):
                 self.get_logger().info('All trajectories in collision, stopping path.')
                 return
 
-            for i in top_indices:
-                for j in range(0, len(trajectories[i]), 10):
-                    x,y,z,qx,qy,qz,qw = trajectories[i][j]
-                    pose = PoseStamped()
-                    pose.header = depth_msg.header
-                    pose.pose.position.x = x
-                    pose.pose.position.y = y
-                    pose.pose.position.z = z
-                    pose.pose.orientation.x = qx
-                    pose.pose.orientation.y = qy
-                    pose.pose.orientation.z = qz
-                    pose.pose.orientation.w = qw
-                    path.poses.append(pose)
-            self.path_pub.publish(path)
+            self.publish_selected_path(trajectories, top_indices, depth_msg.header)
 
 def main(args=None):
     rclpy.init(args=args)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -516,18 +516,6 @@ class PlanningNode(Node):
         velocity_estimated = np.linalg.norm(T[:3, 3] - self.last_T[:3, 3]) / (stamp - self.last_stamp)
         self.smoothed_velocity = 0.9 * self.smoothed_velocity + 0.1 * velocity_estimated
 
-    def build_obstacle_and_esdf(self, T):
-        obstacle_mask = build_obstacle_map(
-            self.occupancy_grid, self.origin, self.resolution,
-            robot_z=T[2, 3], config=self.obstacle_config,
-        )
-        ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
-        return obstacle_mask, ESDF_map
-
-    def score_trajectories(self, trajectories, ESDF_map):
-        front_len, rear_len, half_w = ROBOT_CONFIG.footprint_from_control()
-        return score_trajectories_by_ESDF(trajectories, ESDF_map, self.origin, self.resolution, ROBOT_CONFIG.safety_radius, front_len, rear_len, half_w)
-
     def update_occupancy_grid(self, depth, T, fx, fy, cx, cy):
         center = self.origin + np.array(self.grid_shape) * self.resolution / 2
         robot_pos = T[:3, 3]
@@ -606,7 +594,11 @@ class PlanningNode(Node):
             self.publish_3d_occupancy_cloud(self.occupancy_grid, self.resolution, self.origin)
 
         with Timer(name='obstacle map', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            obstacle_mask, ESDF_map = self.build_obstacle_and_esdf(T)
+            obstacle_mask = build_obstacle_map(
+                self.occupancy_grid, self.origin, self.resolution,
+                robot_z=T[2, 3], config=self.obstacle_config,
+            )
+            ESDF_map = distance_transform_edt(~obstacle_mask).astype(np.float32) * self.resolution
 
         with Timer(name='vis', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             self.publish_3d_occupancy_cloud_with_esdf(self.occupancy_grid, ESDF_map, self.resolution, self.origin)
@@ -623,7 +615,8 @@ class PlanningNode(Node):
             self.last_stamp = stamp
 
         with Timer(name='traj score', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
-            scores, occ_points = self.score_trajectories(trajectories, ESDF_map)
+            front_len, rear_len, half_w = ROBOT_CONFIG.footprint_from_control()
+            scores, occ_points = score_trajectories_by_ESDF(trajectories, ESDF_map, self.origin, self.resolution, ROBOT_CONFIG.safety_radius, front_len, rear_len, half_w)
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)


### PR DESCRIPTION
Three commits: the extraction, rebased onto `main`; the follow-up that turns the steps needing no node into functions; and the one that drops two wrappers that were not worth their names.

## 1. Naming the steps

Moves only.

**`map_node.py`**

Out of `relocalize_with_depth`: the VLAD top-k and the `rerank_by_pnp_inliers` call.
Out of `compute_transform_from_map_to_odom`: the `[-100:]` window.
Out of `__init__`: `load_map` and `reset_map_state` — the map-derived half and the map-frame state it initialises.
Out of `nav_target_timer_callback` (111 lines → 79): the arrival test, the progress payload shared by both publish sites, the leg length / speed / ETA, and the lookahead point along the plan.

**`planning_node.py`** — out of `sync_callback` (125 lines → 57): the smoothed velocity, the roll/raycast/decay, the trajectory library, the cost function, and the `Path` built from the winners.

`run_raycasting_loopy`, `generate_trajectory_library_3d` and `score_trajectories_by_ESDF` stay where they are: they are `@njit`, which does not take a method.

## 2. What does not need a node

Counting the `self` attributes each extracted step actually reads:

| step | `self` attrs | what it touches |
| --- | --- | --- |
| `select_fusion_constraints` | 0 | — |
| `poi_reached` | 0 | — |
| `select_target_position` | 0 | — |
| `generate_trajectories` | 0 | — |
| `rank_relocalization_candidates` | 1 | `map_K`, read-only |
| `select_relocalization_candidates` | 3 | three read-only map arrays |
| `update_velocity_estimate` | 3 | read **and write** |
| `update_occupancy_grid` | 5 | grid state |
| `load_map` / `reset_map_state` / `publish_*` | 2-12 | loading, assignment, publishing |

The top six are functions now, at module level, callable and testable without constructing a node:

```
select_relocalization_candidates(query_vlad, map_vlad_descriptors, vlad_timestamps, top_k)
rank_relocalization_candidates(pnp_candidates, map_K)
select_fusion_constraints(constraints)
poi_reached(poi, pos)
select_target_position(paths, closest_idx, pos)
generate_trajectories(init_p, init_q)
```

The rest mutate node state or publish, and stay methods.

## 3. Two wrappers withdrawn

`build_obstacle_and_esdf` and `score_trajectories` each wrapped a single call and its
arguments, and neither had a second caller. They are back inline, byte for byte as
`main` has them. Extraction is worth it where it takes a name off a block of work, not
where it renames one line.

`rank_relocalization_candidates` no longer takes `candidate_timestamps`. An earlier revision added it; nothing in this repo called it, and a parameter with no caller here is not this repo's to carry. The `pnp_timestamps` list that fed it is gone with it.

## Rebase

Rebased onto `main` for #246, which touched the same traj-score section. Both sides of the conflict resolved toward `main`: the dead `top_k = 100` (overwritten by `top_k = 1` two statements later) that #246 deleted stays deleted, and #246's weights — `score * 2000 + 1000 * dist` — carry into the extracted `trajectory_cost`.

## Verified

In `uniflexai/tinynav:latest`: `ruff check` clean on both files, and `pytest tests` gives 13 failed / 27 passed on this branch and the identical 13 by name on `main` — all TensorRT and missing-model-file failures. Three modules fail to collect on both (`uf_find`, `theta_star`, `InputAligner` are absent from the image) and were skipped on both sides. The Planning Loop timer still measures `sync_callback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
