### PR TITLE
fix(planning): reduce ESDF score weight, raise distance weight

### DIFF
--- a/tests/test_planning_node.py
+++ b/tests/test_planning_node.py
@@ -154,7 +154,9 @@ _FACING_X = np.array([[0.0, 0.0, 1.0],
                       [0.0, -1.0, 0.0]])
 
 # mirrors the regular-trajectory term of PlanningNode.cost_function (planning_node.py); keep
-# the weights (100000/100/100/10/10) and heading fade distance (2.0) in sync by hand
+# the weights and heading fade distance (2.0) in sync by hand
+_ESDF_WEIGHT = 2000.0
+_DIST_WEIGHT = 1000.0
 _HEADING_WEIGHT = 100.0
 _HEADING_FADE_DIST = 2.0
 
@@ -162,8 +164,8 @@ def _trajectory_cost(traj, param, score, target_end, last_param, heading_weight=
     dist = np.linalg.norm(np.asarray(traj[-1, :3]) - target_end)
     heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / _HEADING_FADE_DIST)
     return (
-        score * 100000
-        + 100 * dist
+        score * _ESDF_WEIGHT
+        + _DIST_WEIGHT * dist
         + heading_weight * heading
         + 10 * abs(last_param[0] - param[0])
         + 10 * abs(last_param[1] - param[1])
@@ -193,14 +195,17 @@ def test_goal_heading_error():
         got = goal_heading_error(end, np.array(target))
         assert abs(got - expected) < 1e-6, f"target {target}: {got} != {expected}"
 
-def test_goal_behind_turns_in_place():
-    # forward-only samples all recede from a target behind, so distance alone picks vx=0,
-    # and the shared vx=0 endpoint leaves smoothness to pick omega=0 too
+def test_goal_behind_curves_toward_target():
+    # forward-only samples can't reverse, but a tight max-rate turn still shaves a little
+    # off the final distance to a target directly behind; at _DIST_WEIGHT=1000 that small
+    # gain outweighs the smoothness cost of moving, so the pick curves instead of standing
+    # still or rotating in place
     behind = np.array([-5.0, 0.0, 0.0])
-    assert tuple(_pick(behind, heading_weight=0.0)) == (0.0, 0.0)
+    vx0, omega0 = _pick(behind, heading_weight=0.0)
+    assert vx0 > 0.0 and abs(omega0) > 1e-6, f"target behind (no heading term) yields vx={vx0}, omega={omega0}"
 
     vx, omega = _pick(behind)
-    assert abs(omega) > 1e-6, f"target behind still yields omega={omega}"
+    assert vx > 0.0 and abs(omega) > 1e-6, f"target behind still yields vx={vx}, omega={omega}"
 
 def test_goal_ahead_still_drives_straight():
     vx, omega = _pick(np.array([5.0, 0.0, 0.0]))
@@ -233,7 +238,7 @@ def test_heading_fade_is_monotonic_in_distance():
 
     def heading_term(range_m):
         target = np.array([0.0, range_m, 0.0])  # 90 deg off the nose at every range
-        return _trajectory_cost(traj, param, 0.0, target, last_param) - 100 * range_m
+        return _trajectory_cost(traj, param, 0.0, target, last_param) - _DIST_WEIGHT * range_m
 
     terms = [heading_term(r) for r in (0.5, 1.0, 2.0, 4.0)]
     assert terms[0] < terms[1] < terms[2], f"heading penalty not growing with range: {terms}"
@@ -242,7 +247,7 @@ def test_heading_fade_is_monotonic_in_distance():
 
 if __name__ == "__main__":
     test_goal_heading_error()
-    test_goal_behind_turns_in_place()
+    test_goal_behind_curves_toward_target()
     test_goal_ahead_still_drives_straight()
     test_goal_abeam_turns_while_driving()
     test_heading_fades_within_arrival_radius()

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -559,8 +559,6 @@ class PlanningNode(Node):
         with Timer(name='traj score', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_len, rear_len, half_w = ROBOT_CONFIG.footprint_from_control()
             scores, occ_points = score_trajectories_by_ESDF(trajectories, ESDF_map, self.origin, self.resolution, ROBOT_CONFIG.safety_radius, front_len, rear_len, half_w)
-            top_k = 100
-            top_indices = np.argsort(scores, kind='stable')[:top_k]
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)

--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -585,8 +585,8 @@ class PlanningNode(Node):
                 heading = goal_heading_error(traj[-1], target_end) * min(1.0, dist / 2.0)
 
                 return (
-                    score * 100000
-                    + 100 * dist
+                    score * 2000
+                    + 1000 * dist
                     + 100 * heading
                     + 10 * abs(self.last_param[0] - param[0])
                     + 10 * abs(self.last_param[1] - param[1])


### PR DESCRIPTION
## Summary
- Lower the ESDF score's weight in the trajectory cost function (`score * 100000` -> `score * 2000`) so it no longer overwhelms the distance/heading terms far outside the safety margin.
- Raise the goal-distance weight (`100 * dist` -> `1000 * dist`) so the planner is more willing to trade a little clearance/control smoothness to make progress toward the target, instead of the ESDF term dominating and refusing to move.
- Drop an unused `top_indices` computation (`argsort` over the raw ESDF `score`, top 100) in `planning_node.py` — it was immediately overwritten by the `cost_function`-based selection below and never read in between, so it was pure wasted work every frame.

## Test plan
- [x] `tests/test_planning_node.py` cost-function tests pass in the `tinynav-dev` container (only the pre-existing, unrelated raycasting C++/vectorized mismatch fails — confirmed present on `main` too).
- [x] Manually exercised in the web planning sim (`scripts/run_ros_planning_web.sh`, port 8766) across open-space, near-obstacle, and behind-target scenarios.
- [x] Known remaining rough edges (e.g. narrow-corridor squeeze behavior) are expected to be addressed by richer trajectory vocabulary in a follow-up slice, not further weight tuning.


## Comparison
main branch:

https://github.com/user-attachments/assets/baea39b8-8984-4033-931a-ff52e49b4a4f


https://github.com/user-attachments/assets/c06cd132-bf15-4e51-9261-586303e63798


https://github.com/user-attachments/assets/4bc0d060-0ae4-4b41-9441-849e3cbc70cd

this pr:

https://github.com/user-attachments/assets/70d37d54-9484-4d1a-90de-77854bdb0167


https://github.com/user-attachments/assets/62a828a4-8732-483a-a15c-fb8059454530


https://github.com/user-attachments/assets/5bec4f85-407e-4a89-a997-001afab3a3a4