### PR TITLE
fix(planning): add hysteresis to reverse gate, raise reverse speed to 0.3

### DIFF
--- a/tinynav/core/planning_node.py
+++ b/tinynav/core/planning_node.py
@@ -182,8 +182,8 @@ def generate_predefined_trajectory_vocabularies(
     params = []
 
     # constant reverse trajectory
-    # vx = -0.2 m/s, omega = 0
-    reverse_speed = 0.2
+    # vx = -0.3 m/s, omega = 0
+    reverse_speed = 0.3
     p = init_p.copy()
     q = quat_to_matrix(init_q)
     traj = np.empty((num_steps, 7), dtype=np.float64)
@@ -351,6 +351,14 @@ class PlanningNode(Node):
         self.current_pose = None  # Store the latest pose from odometry
 
         self.smoothed_velocity = 0.0
+
+        # Reverse gate hysteresis: engage reverse at reverse_enter_threshold, stay
+        # engaged until front_clearance climbs past the higher reverse_exit_threshold.
+        # A single threshold flip-flopped forward/backward every cycle when
+        # front_clearance jittered near the boundary.
+        self.reverse_enter_threshold = 0.30
+        self.reverse_exit_threshold = 0.45
+        self.reverse_engaged = False
 
         self.create_subscription(Odometry, '/control/target_pose', self.target_pose_callback, 10)
         self.target_pose = None
@@ -529,10 +537,9 @@ class PlanningNode(Node):
         self.occupancy_grid += new_occ
         self.occupancy_grid = np.clip(self.occupancy_grid, -0.2, 0.2)
 
-    def trajectory_cost(self, traj, param, score, target_pose, front_clearance, enter_threshold):
+    def trajectory_cost(self, traj, param, score, target_pose, should_reverse):
         # predefined backward trajectory penalty
         is_backward_traj = param[0] < 0.0
-        should_reverse = front_clearance <= enter_threshold
         reverse_gate_penalty = 0.0
         if should_reverse and not is_backward_traj:
                 reverse_gate_penalty = 1e9
@@ -620,10 +627,12 @@ class PlanningNode(Node):
 
         with Timer(name='pub', text="[{name}] Elapsed time: {milliseconds:.0f} ms"):
             front_clearance = self._front_obstacle_dist(T, obstacle_mask)
-            enter_threshold = 0.30
+            threshold = self.reverse_exit_threshold if self.reverse_engaged else self.reverse_enter_threshold
+            should_reverse = front_clearance <= threshold
+            self.reverse_engaged = should_reverse
 
             top_k = 1
-            top_indices = np.argsort(np.array([self.trajectory_cost(trajectories[i], params[i], scores[i], self.target_pose, front_clearance, enter_threshold) for i in range(len(trajectories))]), kind='stable')[:top_k]
+            top_indices = np.argsort(np.array([self.trajectory_cost(trajectories[i], params[i], scores[i], self.target_pose, should_reverse) for i in range(len(trajectories))]), kind='stable')[:top_k]
             self.last_param = params[top_indices[0]]
 
             if self.target_pose is None:

--- a/tinynav/platforms/cmd_vel_control.py
+++ b/tinynav/platforms/cmd_vel_control.py
@@ -54,7 +54,7 @@ class CmdVelControlNode(Node):
         self.min_effective_linear_speed = self.robot.min_linear_vel
         self.min_effective_angular_speed = self.robot.min_angular_vel
         self.linear_engage_threshold = 0.04
-        self.fixed_reverse_speed = 0.2
+        self.fixed_reverse_speed = 0.3
         # Hack: if path first segment points far away from robot heading,
         # rotate in place instead of publishing near-zero cmd_vel.
         self.force_turn_heading_threshold = np.deg2rad(80.0)


### PR DESCRIPTION
## Summary
- The reverse gate used a single 0.30m front-clearance threshold, causing forward/reverse trajectories to flip-flop every cycle when clearance jittered near the boundary. Added a higher 0.45m exit threshold so reverse mode only disengages once clearance genuinely improves (same enter/exit hysteresis pattern as `fix/cmdvel-deadzone-hysteresis`).
- Raised reverse speed from 0.2 to 0.3 m/s in both the planned reverse trajectory (`planning_node.py`) and the actually-commanded reverse speed (`cmd_vel_control.py`), so the ESDF safety check's assumed reverse distance matches what the robot actually executes.

## Test plan
- [x] `tests/test_planning_node.py` — 8/8 passed
- [x] On-robot test of reverse behavior 

## Test

https://github.com/user-attachments/assets/31f697bb-2a28-42c6-987b-e3cf79ee77ae

